### PR TITLE
Wip 9191 add common module

### DIFF
--- a/src/Imlight.Common/Imlight.Common.csproj
+++ b/src/Imlight.Common/Imlight.Common.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Imlight.Common/Logger/LocalFileWriter.cs
+++ b/src/Imlight.Common/Logger/LocalFileWriter.cs
@@ -15,6 +15,7 @@ namespace Imlight.Common.Logger
 
         internal static ObservableQueue<string> WriteQueue = new ObservableQueue<string>();
 
+        private static StreamWriter writer = new StreamWriter($"{Directory.GetCurrentDirectory()}/{Log.LogFileName}.txt");
         private static bool attemptedSubscription = false;
         private static readonly object _lock = new object();
 
@@ -62,14 +63,12 @@ namespace Imlight.Common.Logger
                 var n = new object();
                 using (new TimeoutLock(n, TimeSpan.FromSeconds(Log.LogToFileTimeout)))
                 {
-                    using (StreamWriter writer = new StreamWriter($"{Directory.GetCurrentDirectory()}/{Log.LogFileName}.txt", true))
-                    {
-                        for (int i = 0; i < messages.Length; i++)
-                            writer.WriteLine(messages[i]);
-                        writer.Close();
-                    }
+                    // The log line itself carries a newline character.
+                    for (int i = 0; i < messages.Length; i++)
+                        writer.Write(messages[i]);
 
                     WriteQueue.Dequeue();
+                    writer.Flush();
                 }
             }
             catch (Exception ex)
@@ -90,14 +89,12 @@ namespace Imlight.Common.Logger
             {
                 lock (_lock)
                 {
-                    using (StreamWriter writer = new StreamWriter($"{Directory.GetCurrentDirectory()}/{Log.LogFileName}.txt", true))
-                    {
-                        for (int i = 0; i < messages.Length; i++)
-                            writer.WriteLine(messages[i]);
-                        writer.Close();
-                    }
+                    // The log line itself carries a newline character.
+                    for (int i = 0; i < messages.Length; i++)
+                        writer.WriteLine(messages[i]);
 
                     WriteQueue.Dequeue();
+                    writer.Flush();
                 }
             }
             catch (Exception ex)

--- a/src/Imlight.Common/Logger/LocalFileWriter.cs
+++ b/src/Imlight.Common/Logger/LocalFileWriter.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.IO;
+using System.Diagnostics;
+
+namespace Imlight.Common.Logger
+{
+    internal static class LocalFileWriter
+    {
+
+        internal static ObservableQueue<string> WriteQueue = new ObservableQueue<string>();
+
+        private static bool attemptedSubscription = false;
+        private static readonly object _lock = new object();
+
+        /// <summary>
+        /// Writes a message to the local log file.
+        /// </summary>
+        /// <param name="fullMessage">The full message content.</param>
+        internal static void WriteToLogFile(string fullMessage)
+        {
+            // Subscribe to WriteQueue if not already
+            if (!attemptedSubscription) SetWriteQueueSubscriptions();
+
+            // This is all that needs to be done. The event handler will do the work from here.
+            WriteQueue.Enqueue(fullMessage);
+        }
+
+        private static void SetWriteQueueSubscriptions()
+        {
+            WriteQueue.CollectionChanged += WriteQueue_CollectionChanged;
+
+            attemptedSubscription = true;
+        }
+
+        private static void WriteQueue_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (WriteQueue.Count == 0) return;
+            else if (e.Action != NotifyCollectionChangedAction.Add) return;
+
+            string[] s = e.NewItems.Cast<string>().ToArray();
+            TimeoutLockWriteToFile(s);
+            LockWriteToFile(s);
+        }
+
+        /// <summary>
+        /// Writes messages to the local file. This is for debug build, and utilizies a diagnostic lock that will throw an exception
+        /// upon reaching a hang time of x seconds.
+        /// </summary>
+        /// <param name="messages">The array of messages to write.</param>
+        [Conditional("DEBUG")]
+        private static void TimeoutLockWriteToFile(string[] messages)
+        {
+            // Lock thread using TimeoutLock. TimeoutLock will throw an exception if it takes more than x seconds.
+            try
+            {
+                var n = new object();
+                using (new TimeoutLock(n, TimeSpan.FromSeconds(Log.LogToFileTimeout)))
+                {
+                    using (StreamWriter writer = new StreamWriter($"{Directory.GetCurrentDirectory()}/{Log.LogFileName}.txt", true))
+                    {
+                        for (int i = 0; i < messages.Length; i++)
+                            writer.WriteLine(messages[i]);
+                        writer.Close();
+                    }
+
+                    WriteQueue.Dequeue();
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Writes messages to the local file. This is for release build, and utilitizes C#'s built in lock functionality.
+        /// </summary>
+        /// <param name="messages">The array of messages to write.</param>
+        [Conditional("RELEASE")]
+        private static void LockWriteToFile(string[] messages)
+        {
+            // Use a normal lock for release builds.
+            try
+            {
+                lock (_lock)
+                {
+                    using (StreamWriter writer = new StreamWriter($"{Directory.GetCurrentDirectory()}/{Log.LogFileName}.txt", true))
+                    {
+                        for (int i = 0; i < messages.Length; i++)
+                            writer.WriteLine(messages[i]);
+                        writer.Close();
+                    }
+
+                    WriteQueue.Dequeue();
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.ToString());
+            }
+        }
+    }
+}

--- a/src/Imlight.Common/Logger/LocalFileWriter.cs
+++ b/src/Imlight.Common/Logger/LocalFileWriter.cs
@@ -14,6 +14,7 @@ namespace Imlight.Common.Logger
     {
 
         internal static ObservableQueue<string> WriteQueue = new ObservableQueue<string>();
+        internal static float writeDiagnosticLockTimeout { get; private set; } = 1.0f;
 
         private static StreamWriter writer = new StreamWriter($"{Directory.GetCurrentDirectory()}/{Log.LogFileName}.txt");
         private static bool attemptedSubscription = false;
@@ -61,19 +62,21 @@ namespace Imlight.Common.Logger
             try
             {
                 var n = new object();
-                using (new TimeoutLock(n, TimeSpan.FromSeconds(Log.LogToFileTimeout)))
+                using (new TimeoutLock(n, TimeSpan.FromSeconds(writeDiagnosticLockTimeout)))
                 {
                     // The log line itself carries a newline character.
                     for (int i = 0; i < messages.Length; i++)
                         writer.Write(messages[i]);
-
-                    WriteQueue.Dequeue();
-                    writer.Flush();
                 }
             }
             catch (Exception ex)
             {
                 Log.Error(ex.ToString());
+            }
+            finally
+            {
+                WriteQueue.Dequeue();
+                writer.Flush();
             }
         }
 
@@ -92,14 +95,16 @@ namespace Imlight.Common.Logger
                     // The log line itself carries a newline character.
                     for (int i = 0; i < messages.Length; i++)
                         writer.WriteLine(messages[i]);
-
-                    WriteQueue.Dequeue();
-                    writer.Flush();
                 }
             }
             catch (Exception ex)
             {
                 Log.Error(ex.ToString());
+            }
+            finally
+            {
+                WriteQueue.Dequeue();
+                writer.Flush();
             }
         }
     }

--- a/src/Imlight.Common/Logger/Log.cs
+++ b/src/Imlight.Common/Logger/Log.cs
@@ -167,10 +167,10 @@ namespace Imlight.Common.Logger
             switch (level)
             {
                 case LogLevel.Verbose:
-                    sb.Append($"VERB]: {message}\n");
+                    sb.Append($"VERB]: {message}{Environment.NewLine}");
                     break;
                 case LogLevel.Debug:
-                    sb.Append($"DEBG]: {message}\n");
+                    sb.Append($"DEBG]: {message}{Environment.NewLine}");
                     break;
                 default:
                     throw new LogUnsupportedInternalException($"Log level of \"{level}\" is unsupported with this method!" +
@@ -221,7 +221,7 @@ namespace Imlight.Common.Logger
             }
 
             // Write message+
-            Console.Write($"]: {message}\n");
+            Console.Write($"]: {message}{Environment.NewLine}");
 
             // Log to local file
             if (LogToFile)

--- a/src/Imlight.Common/Logger/Log.cs
+++ b/src/Imlight.Common/Logger/Log.cs
@@ -1,0 +1,261 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+/*
+Common
+Common is not a node. It's instead a series of utilities of common functionalities
+useful for all nodes.
+
+For better elaboration, see the Common diagram:
+https://app.diagrams.net/#G17utqstWzrlxPp8cVjTZX4e_Hhy8ThKSn
+*/
+
+namespace Imlight.Common.Logger
+{
+    public enum LogLevel
+    {
+        Verbose,
+        Debug,
+        Information,
+        Warning,
+        Error,
+        Fatal
+    }
+
+    /// <summary>
+    /// A static class to print messages to a console.
+    /// </summary>
+    public static class Log
+    {
+
+        //@todo: Move this to a configuration file.
+        public static bool LogToFile { get; set; } = true;
+        public static string LogFileName { get; set; } = "debug-log";
+        public static float LogToFileTimeout { get; set; } = 5.0f;
+        public static LogLevel MinimumLogLevel { get; set; } = LogLevel.Verbose;
+
+        /// <summary>
+        /// Prints a verbose log to the console.
+        /// </summary>
+        /// <param name="message">The message content.</param>
+        /// <param name="callerName">The original calling class.</param>
+        /// <param name="lineNumber">The line message this method was called from.</param>
+        /// <exception cref="ArgumentException">The message content cannot be null nor empty.</exception>
+        /// <exception cref="ArgumentNullException">The callerName cannot be null nor empty.</exception>
+        public static void Verbose(string message, [CallerMemberName] string callerName = "", [CallerLineNumber] int lineNumber = 0)
+        {
+            if (string.IsNullOrEmpty(message)) throw new ArgumentException($"'{nameof(message)}' cannot be null or empty.", nameof(message));
+            if (callerName is null)            throw new ArgumentNullException(nameof(callerName));
+
+            IrrelevantLog(LogLevel.Verbose, message, $"{callerName}:L{lineNumber}");
+        }
+
+        /// <summary>
+        /// Prints a debug log to the console.
+        /// </summary>
+        /// <param name="message">The message content.</param>
+        /// <param name="callerName">The original calling class.</param>
+        /// <param name="lineNumber">The line message this method was called from.</param>
+        /// <exception cref="ArgumentException">The message content cannot be null nor empty.</exception>
+        /// <exception cref="ArgumentNullException">The callerName cannot be null nor empty.</exception>
+        public static void Debug(string message, [CallerMemberName] string callerName = "", [CallerLineNumber] int lineNumber = 0)
+        {
+            if (string.IsNullOrEmpty(message)) throw new ArgumentException($"'{nameof(message)}' cannot be null or empty.", nameof(message));
+            if (callerName is null)            throw new ArgumentNullException(nameof(callerName));
+
+            IrrelevantLog(LogLevel.Debug, message, $"{callerName}:L{lineNumber}");
+        }
+
+        /// <summary>
+        /// Prints an information log to the console.
+        /// </summary>
+        /// <param name="message">The message content.</param>
+        /// <param name="callerName">The original calling class.</param>
+        /// <param name="lineNumber">The line message this method was called from.</param>
+        /// <exception cref="ArgumentException">The message content cannot be null nor empty.</exception>
+        /// <exception cref="ArgumentNullException">The callerName cannot be null nor empty.</exception>
+        public static void Info(string message, [CallerMemberName] string callerName = "", [CallerLineNumber] int lineNumber = 0)
+        {
+            if (string.IsNullOrEmpty(message)) throw new ArgumentException($"'{nameof(message)}' cannot be null or empty.", nameof(message));
+            if (callerName is null)            throw new ArgumentNullException(nameof(callerName));
+
+            GenericLog(LogLevel.Information, message, $"{callerName}:L{lineNumber}");
+        }
+
+        /// <summary>
+        /// Prints a warning to the console.
+        /// </summary>
+        /// <param name="message">The message content.</param>
+        /// <param name="callerName">The original calling class.</param>
+        /// <param name="lineNumber">The line message this method was called from.</param>
+        /// <exception cref="ArgumentException">The message content cannot be null nor empty.</exception>
+        /// <exception cref="ArgumentNullException">The callerName cannot be null nor empty.</exception>
+        public static void Warn(string message, [CallerMemberName] string callerName = "", [CallerLineNumber] int lineNumber = 0)
+        {
+            if (string.IsNullOrEmpty(message)) throw new ArgumentException($"'{nameof(message)}' cannot be null or empty.", nameof(message));
+            if (callerName is null)            throw new ArgumentNullException(nameof(callerName));
+
+            GenericLog(LogLevel.Warning, message, $"{callerName}:L{lineNumber}");
+        }
+
+        /// <summary>
+        /// Prints an error to the console.
+        /// </summary>
+        /// <param name="message">The message content.</param>
+        /// <param name="callerName">The original calling class.</param>
+        /// <param name="lineNumber">The line message this method was called from.</param>
+        /// <exception cref="ArgumentException">The message content cannot be null nor empty.</exception>
+        /// <exception cref="ArgumentNullException">The callerName cannot be null nor empty.</exception>
+        public static void Error(string message, [CallerMemberName] string callerName = "", [CallerLineNumber] int lineNumber = 0)
+        {
+            if (string.IsNullOrEmpty(message)) throw new ArgumentException($"'{nameof(message)}' cannot be null or empty.", nameof(message));
+            if (callerName is null)            throw new ArgumentNullException(nameof(callerName));
+
+            GenericLog(LogLevel.Error, message, $"{callerName}:L{lineNumber}");
+        }
+
+        /// <summary>
+        /// Prints a fatal error to the console.
+        /// </summary>
+        /// <param name="message">The message content.</param>
+        /// <param name="callerName">The original calling class.</param>
+        /// <param name="lineNumber">The line message this method was called from.</param>
+        /// <exception cref="ArgumentException">The message content cannot be null nor empty.</exception>
+        /// <exception cref="ArgumentNullException">The callerName cannot be null nor empty.</exception>
+        public static void Fatal(string message, [CallerMemberName] string callerName = "", [CallerLineNumber] int lineNumber = 0)
+        {
+            if (string.IsNullOrEmpty(message)) throw new ArgumentException($"'{nameof(message)}' cannot be null or empty.", nameof(message));
+            if (callerName is null)            throw new ArgumentNullException(nameof(callerName));
+
+            GenericLog(LogLevel.Fatal, message, $"{callerName}:L{lineNumber}");
+        }
+
+        /// <summary>
+        /// Prints a test log in all log levels. 
+        /// </summary>
+        public static void TestLogLevels()
+        {
+            Verbose("This is what verbose looks like!");
+            Debug("This is what debug looks like!");
+            Info("This is what info looks like!");
+            Warn("This is what warn looks like!");
+            Error("This is what error looks like!");
+            Fatal("This is what fatal looks like!");
+        }
+
+        /// <summary>
+        /// Writes an "irrelevant" log for verbose or debug logs. Logs printed using this method will be entirely in a dark gray color.
+        /// </summary>
+        /// <param name="level">The log level of this message.</param>
+        /// <param name="message">The message content.</param>
+        /// <param name="callerFormat">The format of the calling method information.</param>
+        /// <exception cref="LogUnsupportedInternalException"></exception>
+        private static void IrrelevantLog(LogLevel level, string message, string callerFormat)
+        {
+            // Build log
+            StringBuilder sb = new StringBuilder();
+
+            // Add time and caller name
+            string _timeFormatted = DateTime.Now.ToString("s");
+            sb.Append($"[{_timeFormatted}][{callerFormat}][");
+
+            // Write log prefix
+            switch (level)
+            {
+                case LogLevel.Verbose:
+                    sb.Append($"VERB]: {message}\n");
+                    break;
+                case LogLevel.Debug:
+                    sb.Append($"DEBG]: {message}\n");
+                    break;
+                default:
+                    throw new LogUnsupportedInternalException($"Log level of \"{level}\" is unsupported with this method!" +
+                        $"Use GenericLog() instead.");
+            }
+
+            WriteColored(sb.ToString(), ConsoleColor.DarkGray);
+        }
+
+        /// <summary>
+        /// Writes a generic log. Does not support verbose or debug logs. Use IrrelevantLog() instead.
+        /// </summary>
+        /// <param name="level">The log level of this message.</param>
+        /// <param name="message">The message content.</param>
+        /// <param name="callerFormat">The format of the calling method information.</param>
+        /// <exception cref="LogUnsupportedInternalException">This does not support verbose or debug logs. Use IrrelevantLog() instead.</exception>
+        private static void GenericLog(LogLevel level, string message, string callerFormat)
+        {
+            // Build log
+            // $"[${DateTime.Now}][{callerName}][VERBO]: {message}";
+
+            // Write time and caller name
+            string _timeFormatted = DateTime.Now.ToString("s");
+            Console.Write($"[{_timeFormatted}][{callerFormat}][");
+
+            // Write colored log prefix
+            switch (level)
+            {
+                case LogLevel.Verbose:
+                case LogLevel.Debug:
+                    Error($"LogLevel {level} is not supported by the GenericLog function. Please use LogIrrelevant.");
+                    return;
+                case LogLevel.Information:
+                    WriteColored("INFO", ConsoleColor.White);
+                    break;
+                case LogLevel.Warning:
+                    WriteColored("WARN", ConsoleColor.DarkYellow);
+                    break;
+                case LogLevel.Error:
+                    WriteColored("ERRO", ConsoleColor.Red);
+                    break;
+                case LogLevel.Fatal:
+                    WriteColored("FATL", ConsoleColor.White, ConsoleColor.Red);
+                    break;
+                default:
+                    throw new LogUnsupportedInternalException($"Log level of \"{level}\" is unsupported with this method!" +
+                        $"Use IrrelevantLog() instead.");
+            }
+
+            // Write message+
+            Console.Write($"]: {message}\n");
+
+            // Log to local file
+            if (LogToFile)
+            {
+                // Rebuild message
+                string fullMessage = $"[{_timeFormatted}][{callerFormat}][{level}]: {message}\n";
+                LocalFileWriter.WriteToLogFile(fullMessage);
+            }
+        }
+
+        /// <summary>
+        /// Writes a statement to the log in a given color.
+        /// </summary>
+        /// <param name="message">The message content.</param>
+        /// <param name="color">The foreground color of the log.</param>
+        /// <param name="bgColor">The background color of the log.</param>
+        /// <exception cref="ArgumentException">The message content cannot be null nor empty.</exception>
+        private static void WriteColored(string message, ConsoleColor color, ConsoleColor bgColor = ConsoleColor.Black)
+        {
+            if (string.IsNullOrEmpty(message)) throw new ArgumentException($"'{nameof(message)}' cannot be null or empty.", nameof(message));
+
+            ConsoleColor _defaultFg = Console.ForegroundColor;
+            ConsoleColor _defaultBg = Console.BackgroundColor;
+
+            // Set colors
+            Console.ForegroundColor = color;
+            Console.BackgroundColor = bgColor;
+
+            Console.Write(message);
+
+            // Set colors back to default
+            Console.ForegroundColor = _defaultFg;
+            Console.BackgroundColor = _defaultBg;
+        }
+
+    }
+}

--- a/src/Imlight.Common/Logger/Log.cs
+++ b/src/Imlight.Common/Logger/Log.cs
@@ -35,7 +35,6 @@ namespace Imlight.Common.Logger
         //@todo: Move this to a configuration file.
         public static bool LogToFile { get; set; } = true;
         public static string LogFileName { get; set; } = "debug-log";
-        public static float LogToFileTimeout { get; set; } = 5.0f;
         public static LogLevel MinimumLogLevel { get; set; } = LogLevel.Verbose;
 
         /// <summary>

--- a/src/Imlight.Common/Logger/Log.cs
+++ b/src/Imlight.Common/Logger/Log.cs
@@ -37,6 +37,8 @@ namespace Imlight.Common.Logger
         public static string LogFileName { get; set; } = "debug-log";
         public static LogLevel MinimumLogLevel { get; set; } = LogLevel.Verbose;
 
+        public static event EventHandler<LogCreatedEventArgs> LogCreated;
+
         /// <summary>
         /// Prints a verbose log to the console.
         /// </summary>
@@ -177,6 +179,10 @@ namespace Imlight.Common.Logger
             }
 
             WriteColored(sb.ToString(), ConsoleColor.DarkGray);
+
+            // Invoke event
+            LogCreatedEventArgs eventData = new LogCreatedEventArgs(level, _timeFormatted, callerFormat, message);
+            LogCreated?.Invoke(null, eventData);
         }
 
         /// <summary>
@@ -229,6 +235,10 @@ namespace Imlight.Common.Logger
                 string fullMessage = $"[{_timeFormatted}][{callerFormat}][{level}]: {message}\n";
                 LocalFileWriter.WriteToLogFile(fullMessage);
             }
+
+            // Invoke event
+            LogCreatedEventArgs eventData = new LogCreatedEventArgs(level, _timeFormatted, callerFormat, message);
+            LogCreated?.Invoke(null, eventData);
         }
 
         /// <summary>

--- a/src/Imlight.Common/Logger/LogCreatedEventArgs.cs
+++ b/src/Imlight.Common/Logger/LogCreatedEventArgs.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Imlight.Common.Logger
+{
+    public class LogCreatedEventArgs : EventArgs
+    {
+
+        public LogLevel Level { get; set; }
+        public string Time { get; set; }
+        public string Source { get; set; }
+        public string Message { get; set; }
+
+        // ctor
+        public LogCreatedEventArgs(LogLevel level, string time, string source, string message)
+        {
+            Level = level;
+            Time = time;
+            Source = source;
+            Message = message;
+        }
+
+    }
+}

--- a/src/Imlight.Common/Logger/LogUnsupportedInternalException.cs
+++ b/src/Imlight.Common/Logger/LogUnsupportedInternalException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Imlight.Common.Logger
+{
+    internal class LogUnsupportedInternalException : Exception
+    {
+
+        public LogUnsupportedInternalException(string message) : base(message) { }
+
+    }
+}

--- a/src/Imlight.Common/ObservableQueue.cs
+++ b/src/Imlight.Common/ObservableQueue.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Imlight.Common
+{
+    public class ObservableQueue<T> : Queue<T>, INotifyCollectionChanged, IDisposable
+    {
+
+        public event NotifyCollectionChangedEventHandler CollectionChanged;
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public ObservableQueue()
+        {
+        }
+
+        public ObservableQueue(IEnumerable<T> collection) : base(collection)
+        {
+            for (int i = 0; i < collection.Count(); i++)
+                base.Enqueue(collection.ElementAt(i));
+        }
+
+        public ObservableQueue(List<T> collection) : base(collection)
+        {
+            for (int i = 0; i < collection.Count(); i++)
+                base.Enqueue(collection.ElementAt(i));
+        }
+
+        public ObservableQueue(int capacity) : base(capacity)
+        {
+        }
+
+        public new virtual void Clear()
+        {
+            base.Clear();
+            this.CollectionChanged(
+                this,
+                new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        }
+
+        public new virtual void Enqueue(T item)
+        {
+            base.Enqueue(item);
+            this.CollectionChanged(
+                this,
+                new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item));
+        }
+
+        public new virtual void Dequeue()
+        {
+            var lastItem = base.Dequeue();
+            this.CollectionChanged(
+                this,
+                new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, lastItem));
+        }
+
+        ~ObservableQueue()
+        {
+            base.Clear();
+        }
+
+        public void Dispose()
+        {
+            base.Clear();
+        }
+    }
+}

--- a/src/Imlight.Common/TimeoutLock.cs
+++ b/src/Imlight.Common/TimeoutLock.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Imlight.Common
+{
+    /// <summary>
+    /// Shares the same functionality as the 'lock' keyword. However, this class will throw a TimeoutException if
+    /// the thread remains locked for longer than the given ctor timespan.
+    /// </summary>
+    public class TimeoutLock : IDisposable
+    {
+
+        private object lockObj = new object();
+
+        // ctor
+        public TimeoutLock(object lockObj, TimeSpan timeout)
+        {
+            this.lockObj = lockObj;
+            if (!System.Threading.Monitor.TryEnter(this.lockObj, timeout))
+                throw new TimeoutException();
+        }
+
+        public void Dispose()
+        {
+            System.Threading.Monitor.Exit(this.lockObj);
+        }
+    }
+}

--- a/src/Imlight.sln
+++ b/src/Imlight.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Imlight.Storage", "Storage\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Imlight.Storage.Backup", "StorageBackup\Imlight.Storage.Backup.csproj", "{59A8BA84-33F0-442D-B282-9A8E50B64197}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Imlight.Common", "Imlight.Common\Imlight.Common.csproj", "{314D6BF8-787D-4A08-AD12-E0BC073E6CC8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{59A8BA84-33F0-442D-B282-9A8E50B64197}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{59A8BA84-33F0-442D-B282-9A8E50B64197}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{59A8BA84-33F0-442D-B282-9A8E50B64197}.Release|Any CPU.Build.0 = Release|Any CPU
+		{314D6BF8-787D-4A08-AD12-E0BC073E6CC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{314D6BF8-787D-4A08-AD12-E0BC073E6CC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{314D6BF8-787D-4A08-AD12-E0BC073E6CC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{314D6BF8-787D-4A08-AD12-E0BC073E6CC8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Realm/Imlight.Realm.csproj
+++ b/src/Realm/Imlight.Realm.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Imlight.Common\Imlight.Common.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Realm/Realm.cs
+++ b/src/Realm/Realm.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using System;
 using System.Net.Sockets;
+using Imlight.Common.Logger;
 
 /*
 Realm
@@ -25,9 +26,7 @@ namespace Imlight.Realm
         public Realm(string name, bool autoStart = true)
         {
             this.Name = name;
-            this.Server = new TcpServer();
-
-            if (autoStart) StartServer();
+            this.Server = new TcpServer(TcpServer.DEFAULT_PORT, autoStart);
         }
 
         /// <summary>
@@ -35,13 +34,14 @@ namespace Imlight.Realm
         /// </summary>
         public void StartServer()
         {
+            // Check if the server is already listening.
             if (this.Server.Listening())
             {
-                // Log error here
+                Log.Warn($"Attempted to start already listening realm \"{this.Name}\".");
                 return;
             }
 
-            Task.Run(async () => this.Server.StartAsync());
+            this.Server.Start();
         }
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace Imlight.Realm
         {
             if (!this.Server.Listening())
             {
-                // Log error here
+                Log.Warn($"Attempted to stop non-running realm \"{this.Name}\".");
                 return;
             }
 

--- a/src/Realm/RealmManager.cs
+++ b/src/Realm/RealmManager.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System;
 using System.Collections.Generic;
+using Imlight.Common.Logger;
 
 /*
 Realm
@@ -31,6 +32,13 @@ namespace Imlight.Realm
             {
                 Realm newRealm = new Realm(name, true);
                 this.Realms.Add(newRealm);
+
+                Log.Info($"New realm \"{name}\" created.");
+            }
+            else
+            {
+                Log.Error($"Attempted to create realm by name \"{name}\", but a realm by that name already exists!");
+                return;
             }
         }
 
@@ -44,10 +52,13 @@ namespace Imlight.Realm
             {
                 Realm realm = Realms.FirstOrDefault(x => x.Name == name);
                 this.Realms.Remove(realm);
+
+                Log.Info($"Realm \"{name}\" removed.");
             }
             else
             {
-                //@TODO: Log error here
+                Log.Error($"Attempted to remove realm by name \"{name}\", but a realm by that name was not found!");
+                return;
             }
         }
 
@@ -56,6 +67,8 @@ namespace Imlight.Realm
         /// </summary>
         public void StopAllRealms()
         {
+            Log.Info("Stopping all realms..");
+
             // Stopping a realm simply stops the server. The realm isn't destroyed.
             for (int i = 0; i < Realms.Count; i++)
             {
@@ -69,6 +82,8 @@ namespace Imlight.Realm
         /// </summary>
         public void DisposeAllRealms()
         {
+            Log.Warn("Disposing all realms..");
+
             // The be-all-end-all. Servers are stopped and deleted with this method.
             for (int i = 0; i < Realms.Count; i++)
             {
@@ -86,8 +101,15 @@ namespace Imlight.Realm
         /// <returns>True, if a realm is found by that name. Flase otherwise.</returns>
         private bool doesRealmExist(string name)
         {
-            Realm r = this.Realms.First(realm => realm.Name == name);
-            return !(r != null);
+            try 
+            {
+                Realm r = this.Realms.First(realm => realm.Name == name);
+                return !(r != null);
+            }
+            catch (Exception ex)
+            {
+                return false;
+            }
         }
 
     }

--- a/src/Realm/TcpServer.cs
+++ b/src/Realm/TcpServer.cs
@@ -42,23 +42,23 @@ namespace Imlight.Realm
             this.tokenSource = CancellationTokenSource.CreateLinkedTokenSource(new CancellationToken());
             this.Sockets = new List<TcpClient>();
 
-            if (doAutoStart) Task.Run(async () => await StartAsync());
+            if (doAutoStart) Start();
         }
 
         internal bool Listening() => this.listening;
 
         /// <summary>
-        /// Asyncronously start the TCP server.
+        /// Starts the TCP server.
         /// </summary>
         /// <returns></returns>
-        internal async Task StartAsync()
+        internal void Start()
         {
+            this.listener.Start();
             this.token = this.tokenSource.Token;
-            listener.Start();
             this.listening = true;
 
             // Begin listen on subtask
-            await Task.Run(async () => ListenAsync(this.token));
+            Task.Run(async () => ListenAsync(this.token));
         }
 
         /// <summary>
@@ -81,8 +81,7 @@ namespace Imlight.Realm
                 }
                 catch (Exception ex)
                 {
-                    // Log error here
-                    int i = 0;
+                    Imlight.Common.Logger.Log.Error($"REALM LISTEN ERROR: {ex.ToString()}");
                 }
                 finally
                 {


### PR DESCRIPTION
9191 Adds the common node as seen on the Imlight web graph (found [here](https://app.diagrams.net/#G17utqstWzrlxPp8cVjTZX4e_Hhy8ThKSn)).

The primary feature of this current module is the logger. Using this static class, we can create logs of varying levels.
```csharp
Log.Verbose("This is what verbose looks like!");
Log.Debug("This is what debug looks like!");
Log.Info("This is what info looks like!");
Log.Warn("This is what warn looks like!");
Log.Error("This is what error looks like!");
Log.Fatal("This is what fatal looks like!");
```

With this see a nicely formatted log happening in our console. Note that levels `Verbose` and `Debug` remain in dark gray. These are called irrelevant logs, and have less priority over other logs.
![unknown](https://user-images.githubusercontent.com/21114359/193245633-e6c638ed-2cdd-4d01-adcc-555b2c578af0.png)

Upon this come two further additions:

1. ObservableQueue.cs
2. TimeoutLock.cs

_ObservableQueue_ stands as an [ObservableCollection](https://learn.microsoft.com/en-us/dotnet/api/system.collections.objectmodel.observablecollection-1?view=net-7.0) from Microsofts' ObjectModel, with the functionalities of a queue.

_TimeoutLock_ functions as the [lock](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/lock) keyword does. It's difference lies in the diagnostic definition of "timeout". This lock will throw an exception if the main thread is locked for a given ctor timespan.
