### PR TITLE
`fix/mounts` --> `quality-assurance`

### DIFF
--- a/src/Common/Configuration/IniSerializer.cs
+++ b/src/Common/Configuration/IniSerializer.cs
@@ -87,6 +87,11 @@ public static class IniSerializer {
 
         foreach (var property in type.GetProperties()) {
             propertyValues.TryGetValue(property.Name, out var value);
+
+            if (value == null) {
+                continue;
+            }
+
             property.SetValue(obj, Convert.ChangeType(value, property.PropertyType));
         }
 

--- a/src/Common/Configuration/ServerSettings.cs
+++ b/src/Common/Configuration/ServerSettings.cs
@@ -94,6 +94,12 @@ public sealed class ServerSettings {
     [DefaultValue(Byte.MaxValue)]
     public byte MaxLevel { get; set; }
 
+    [DefaultValue(75)]
+    public int MaxInventoryItems { get; set; }
+
+    [DefaultValue(100)]
+    public int MaxJewelsAllowed { get; set;}
+
     #endregion
 
     #region Patch Server

--- a/src/CoreLib/AntiAmbrose/AuthorityRequester.cs
+++ b/src/CoreLib/AntiAmbrose/AuthorityRequester.cs
@@ -4,6 +4,7 @@
  */
 
 using Imlight.Common;
+using Imlight.CoreLib.WizardData.Models.Misc;
 using Imlight.CoreLib.WizardData.Models.Player;
 
 namespace Imlight.CoreLib.AntiAmbrose;

--- a/src/CoreLib/AntiAmbrose/UserAuthenticator.cs
+++ b/src/CoreLib/AntiAmbrose/UserAuthenticator.cs
@@ -9,6 +9,7 @@ using Imlight.Common.IO;
 using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.WizardData.Collections;
 using Imlight.CoreLib.WizardData.Implementations;
+using Imlight.CoreLib.WizardData.Models.Misc;
 using Imlight.CoreLib.WizardData.Models.Player;
 using System;
 using static Imlight.Common.Caches.LOGIN_7_PROTOCOL;

--- a/src/CoreLib/AntiAmbrose/UserValidator.cs
+++ b/src/CoreLib/AntiAmbrose/UserValidator.cs
@@ -7,6 +7,7 @@ using Imlight.Common.Cryptography;
 using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.WizardData.Collections;
 using Imlight.CoreLib.WizardData.Implementations;
+using Imlight.CoreLib.WizardData.Models.Misc;
 using Imlight.CoreLib.WizardData.Models.Player;
 using System;
 using static Imlight.Common.Caches.LOGIN_7_PROTOCOL;

--- a/src/CoreLib/Game/Commands/CommandDispatcher.cs
+++ b/src/CoreLib/Game/Commands/CommandDispatcher.cs
@@ -13,6 +13,7 @@ using Imlight.Common.Caches;
 using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.Shared.Packets;
 using Imlight.CoreLib.WizardData.Collections;
+using Imlight.CoreLib.WizardData.Models.Misc;
 using Imlight.CoreLib.WizardData.Models.Player;
 
 namespace Imlight.CoreLib.Game.Commands;

--- a/src/CoreLib/Game/Commands/Protocols/CommandAccountProtocol.cs
+++ b/src/CoreLib/Game/Commands/Protocols/CommandAccountProtocol.cs
@@ -6,6 +6,7 @@
 using Imlight.CoreLib.AntiAmbrose;
 using Imlight.CoreLib.WizardData;
 using Imlight.CoreLib.WizardData.Implementations;
+using Imlight.CoreLib.WizardData.Models.Misc;
 using Imlight.CoreLib.WizardData.Models.Player;
 using System;
 using System.Text;

--- a/src/CoreLib/Game/Commands/Protocols/CommandBanProtocol.cs
+++ b/src/CoreLib/Game/Commands/Protocols/CommandBanProtocol.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Imlight.CoreLib.Shared.Packets;
 using Imlight.CoreLib.WizardData.Collections;
 using Imlight.CoreLib.WizardData.Implementations;
+using Imlight.CoreLib.WizardData.Models.Misc;
 using Imlight.CoreLib.WizardData.Models.Player;
 
 namespace Imlight.CoreLib.Game.Commands.Protocols;

--- a/src/CoreLib/Game/Commands/Protocols/CommandModifyProtocol.cs
+++ b/src/CoreLib/Game/Commands/Protocols/CommandModifyProtocol.cs
@@ -28,14 +28,14 @@ internal class CommandModifyProtocol : CommandProtocol {
     [Alias("lvlup")]
     private void LevelUpCommand() {
         // Check to see if the new level would be above the max level.
-        var isOverMax = (Context.Character.Level + 1) > ConfigurationManager.Settings.MaxLevel;
+        var isOverMax = (Context.Character.MagicSchoolBehavior.Level + 1) > ConfigurationManager.Settings.MaxLevel;
         if (isOverMax) {
             InformSenderClient("You cannot level up any further.");
             return;
         }
 
         var msg = new CHARACTER_103_PROTOCOL.MSG_LEVELUP() {
-            NewLevel = (byte) (Context.Character.Level + 1)
+            NewLevel = (byte) (Context.Character.MagicSchoolBehavior.Level + 1)
         };
         Context.SessionActor.Tell(msg, null);
     }

--- a/src/CoreLib/Game/Commands/Protocols/CommandModifyProtocol.cs
+++ b/src/CoreLib/Game/Commands/Protocols/CommandModifyProtocol.cs
@@ -99,7 +99,7 @@ internal class CommandModifyProtocol : CommandProtocol {
         }
 
         var coreObject = (WizClientObjectItem)CoreObjectFactory.FinalizeCoreObject(templateIdLong);
-        var addedItemSuccess = Context.Character.InventoryAddItem(coreObject);
+        var addedItemSuccess = Context.Character.InventoryBehavior.AddItem(coreObject);
 
         if (!addedItemSuccess) {
             InformSenderClient("Could not add item to inventory.");

--- a/src/CoreLib/Game/Commands/Protocols/CommandPunishmentProtocol.cs
+++ b/src/CoreLib/Game/Commands/Protocols/CommandPunishmentProtocol.cs
@@ -4,6 +4,7 @@
  */
 
 using Imlight.CoreLib.Shared.Packets;
+using Imlight.CoreLib.WizardData.Models.Misc;
 using Imlight.CoreLib.WizardData.Models.Player;
 using System;
 using System.Text;

--- a/src/CoreLib/Game/Services/AttachService.cs
+++ b/src/CoreLib/Game/Services/AttachService.cs
@@ -112,7 +112,7 @@ internal class AttachService : MessageService {
             TestServer = 0
         };
 
-        var actualWizardName = WizardNameBank.GetEnglishName(wizard.NameIndices, wizard.WizardAvatar.m_eGender);
+        var actualWizardName = WizardNameBank.GetEnglishName(wizard.PlayerNameBehavior.NameIndices, wizard.WizardAvatar.m_eGender);
         AddPlayerToZone(charGameObject, actualWizardName);
 
         SendToSocket(loginCompleteMsg);

--- a/src/CoreLib/Game/Services/ChatService.cs
+++ b/src/CoreLib/Game/Services/ChatService.cs
@@ -52,7 +52,7 @@ public class ChatService : MessageService {
         }
 
         // Craft the wizard name.
-        var nameIndices = wizard.NameIndices;
+        var nameIndices = wizard.PlayerNameBehavior.NameIndices;
         var gender = wizard.WizardAvatar.m_eGender;
         var sourceName = CraftSourceNameFromIndices(nameIndices, gender);
 
@@ -64,8 +64,7 @@ public class ChatService : MessageService {
             return;
         }
 
-        var actualCharacterName = WizardNameBank.GetEnglishName(wizard.NameIndices, wizard.WizardAvatar.m_eGender);
-        Logger.Information("{0} says in chat: {1}", Logger.Args(actualCharacterName, cleanedMessage));
+        Logger.Information("{0} says in chat: {1}", Logger.Args(wizard.PlayerNameBehavior.GetWizardName(), cleanedMessage));
 
         // Add the chat log to the database.
         var chatLog = new ChatLog() {
@@ -97,7 +96,7 @@ public class ChatService : MessageService {
 
         var globalId = GetActiveGameObject().m_globalID;
         var character = GetActiveWizard();
-        var nameIndices = character.NameIndices;
+        var nameIndices = character.PlayerNameBehavior.NameIndices;
         var gender = character.WizardAvatar.m_eGender;
         var src = CraftSourceNameFromIndices(nameIndices, gender);
 

--- a/src/CoreLib/Game/Services/ChatService.cs
+++ b/src/CoreLib/Game/Services/ChatService.cs
@@ -17,6 +17,7 @@ using Imlight.CoreLib.Shared.Packets;
 using Imlight.CoreLib.Shared.Resources;
 using Imlight.CoreLib.WizardData.Collections;
 using Imlight.CoreLib.WizardData.Implementations;
+using Imlight.CoreLib.WizardData.Models.Misc;
 using Imlight.CoreLib.WizardData.Models.Player;
 
 namespace Imlight.CoreLib.Game.Services;

--- a/src/CoreLib/Game/Services/EquipmentService.cs
+++ b/src/CoreLib/Game/Services/EquipmentService.cs
@@ -9,6 +9,7 @@ using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.Shared.Packets;
 using Imlight.CoreLib.Shared.Resources;
 using Imlight.CoreLib.WizardData.Implementations;
+using Imlight.CoreLib.WizardData.Models.Misc;
 using Imlight.CoreLib.WizardData.Models.Player;
 using System;
 using System.Collections.Generic;

--- a/src/CoreLib/Game/Services/EquipmentService.cs
+++ b/src/CoreLib/Game/Services/EquipmentService.cs
@@ -95,13 +95,19 @@ public class EquipmentService : MessageService {
             SendUnequipItem(message.SlotName, index, equippedItemId);
         }
 
-        if (!wizard.InventoryToEquipmentTransfer(itemId, out var effects)) {
+        if (!wizard.InventoryToEquipmentTransfer(itemId, out var effects, out var removedEffects)) {
             Logger.Warning("Equip failed on item {0}", Logger.Args(itemId));
             return;
         }
 
         SendEquipItem(item, message.SlotName);
         SendAddEffects(effects);
+
+        // If removedEffects is not null, the Wizard replaced an item with another item that has different effects.
+        // We need to remove the old effects from the client.
+        if (removedEffects is not null) {
+            SendRemoveEffects(removedEffects);
+        }
     }
 
     private void UnEquipItem(GAME_5_PROTOCOL.MSG_EQUIPITEM message) {

--- a/src/CoreLib/Game/Services/EquipmentService.cs
+++ b/src/CoreLib/Game/Services/EquipmentService.cs
@@ -95,7 +95,7 @@ public class EquipmentService : MessageService {
             SendUnequipItem(message.SlotName, index, equippedItemId);
         }
 
-        if (!wizard.EquipmentToInventoryTransfer(itemId, out var effects)) {
+        if (!wizard.InventoryToEquipmentTransfer(itemId, out var effects)) {
             Logger.Warning("Equip failed on item {0}", Logger.Args(itemId));
             return;
         }

--- a/src/CoreLib/Game/Services/EquipmentService.cs
+++ b/src/CoreLib/Game/Services/EquipmentService.cs
@@ -86,9 +86,8 @@ public class EquipmentService : MessageService {
         // We don't have to remove it here because the EquipItem method will do that for us.
         if (wizard.EquipmentBehavior.SlotInUse(message.SlotName, out var index)) {
             // Debug log.
-            var wizardName = WizardNameBank.GetEnglishName(wizard.NameIndices, wizard.WizardAvatar.m_eGender);
             Logger.Debug("{0} tried to equip item {1} in slot {2} that is already in use. Unequipping from index {3}",
-                Logger.Args(wizardName, itemId, message.SlotName, index));
+                Logger.Args(wizard.PlayerNameBehavior.GetWizardName(), itemId, message.SlotName, index));
 
             // Get the item that is currently equipped in this slot.
             var equippedItemId = wizard.EquipmentBehavior.GetItemInSlot(message.SlotName).m_globalID;

--- a/src/CoreLib/Game/Services/EquipmentService.cs
+++ b/src/CoreLib/Game/Services/EquipmentService.cs
@@ -54,7 +54,7 @@ public class EquipmentService : MessageService {
             // This is the very first step in that process. Start by telling the Wizard to apply
             // all of the effects for the equipment it has equipped.
             var playerCharacter = GetActiveWizard();
-            playerCharacter.ApplyEffectsForAllEquipment();
+            playerCharacter.InitializeGameEffects();
 
             // Now that the effects have been applied, we need to tell the client about them.
             var effects = playerCharacter.GameEffects;
@@ -70,7 +70,7 @@ public class EquipmentService : MessageService {
         var account = GetActiveAccount();
         var itemId = message.ItemID;
 
-        var item = wizard.InventoryGetItem(itemId);
+        var item = wizard.InventoryBehavior.GetItem(itemId);
         if (item is null) {
             var infractionText = $"Player tried to equip item {itemId} that they do not have in their inventory!";
             account.AddInfraction(InfractionType.SuspiciousBehavior, infractionText);
@@ -82,39 +82,36 @@ public class EquipmentService : MessageService {
             return;
         }
 
-        // Todo: Check if player meets requirements to equip item. If not, log an infraction.
-
         // Check to see if the player already has this item equipped. If they do, broadcast the removal of it.
         // We don't have to remove it here because the EquipItem method will do that for us.
-        if (wizard.EquipmentSlotInUse(message.SlotName, out var index)) {
+        if (wizard.EquipmentBehavior.SlotInUse(message.SlotName, out var index)) {
             // Debug log.
             var wizardName = WizardNameBank.GetEnglishName(wizard.NameIndices, wizard.WizardAvatar.m_eGender);
             Logger.Debug("{0} tried to equip item {1} in slot {2} that is already in use. Unequipping from index {3}",
                 Logger.Args(wizardName, itemId, message.SlotName, index));
 
             // Get the item that is currently equipped in this slot.
-            var equippedItemId = wizard.EquipmentGetItem(index);
+            var equippedItemId = wizard.EquipmentBehavior.GetItemInSlot(message.SlotName).m_globalID;
             SendUnequipItem(message.SlotName, index, equippedItemId);
         }
 
-        var addedEffects = wizard.EquipmentEquipItem(itemId);
-        if (addedEffects is null) {
+        if (!wizard.EquipmentToInventoryTransfer(itemId, out var effects)) {
             Logger.Warning("Equip failed on item {0}", Logger.Args(itemId));
             return;
         }
 
         SendEquipItem(item, message.SlotName);
-        SendAddEffects(addedEffects);
+        SendAddEffects(effects);
     }
 
     private void UnEquipItem(GAME_5_PROTOCOL.MSG_EQUIPITEM message) {
-        var playerCharacter = GetActiveWizard();
+        var wizard = GetActiveWizard();
+        var wizEquipmentBehavior = wizard.EquipmentBehavior;
         var account = GetActiveAccount();
         var itemId = message.ItemID;
 
         // Check to see if the player has this item equipped. If they don't, log an infraction.
-        var item = playerCharacter.InventoryGetItem(itemId);
-        if (item is null) {
+        if (!wizEquipmentBehavior.HasItemEquipped(itemId)) {
             var infractionText = $"Player tried to unequip item {itemId} that they do not have in their inventory!";
             account.AddInfraction(InfractionType.SuspiciousBehavior, infractionText);
 
@@ -126,10 +123,9 @@ public class EquipmentService : MessageService {
         }
 
         // This needs to be done before we unequip the item, because we need to know what slot it was in.
-        var slot = playerCharacter.EquipmentGetItemSlotIndex(itemId);
+        var slot = wizEquipmentBehavior.GetSlotOfItem(itemId);
 
-        var removedEffects = playerCharacter.EquipmentUnequipItem(itemId);
-        if (removedEffects is null) {
+        if (!wizard.EquipmentToInventoryTransfer(itemId, out var removedEffects)) {
             // If this fails, there is perhaps desync between the server and the client.
             // Send a message to the client to assure them that the server does not have the item equipped.
             SendUnequipItem(message.SlotName, slot, itemId);

--- a/src/CoreLib/Game/Services/WizardService.cs
+++ b/src/CoreLib/Game/Services/WizardService.cs
@@ -56,7 +56,7 @@ public class WizardService : MessageService {
 
         var levelUpMessage = new WIZARD_12_PROTOCOL.MSG_LEVELUP {
             GlobalID = _activeWizard.CharId,
-            NewLevel = _activeWizard.Level,
+            NewLevel = _activeWizard.MagicSchoolBehavior.Level,
             Data = "0000000000"
         };
         ZoneBroadcast(levelUpMessage, false);

--- a/src/CoreLib/Game/WizardObjectLoader.cs
+++ b/src/CoreLib/Game/WizardObjectLoader.cs
@@ -17,7 +17,7 @@ namespace Imlight.CoreLib.Game;
 public static class WizardObjectLoader {
     public static WizClientObject GetPlayerGameObject(ref Wizard character) {
         var clientObject = CoreObjectFactory.InitializeCoreObjectBehaviors(new WizClientObject(), 1);
-        CharacterHelper.ResetStats(character.GameStats, character.Level, character.WizardSchool);
+        CharacterHelper.ResetStats(character.GameStats, (byte) character.MagicSchoolBehavior.Level, character.MagicSchoolBehavior.MagicSchool);
 
         // Set the stats on the new object.
         clientObject.m_templateID = 1;
@@ -97,11 +97,8 @@ public static class WizardObjectLoader {
 
     public static void SetMagicSchoolBehavior(WizClientObject clientObject, ref Wizard character) {
         if (CoreObjectFactory.FindBehaviorInstance<ClientMagicSchoolBehavior>(clientObject, out var schoolBehavior)) {
-            schoolBehavior.m_equippedTeleportEffect = character.GameStats.m_equippedTeleportEffect;
-            schoolBehavior.m_experiencePoints = character.XpToNextLevel;
-            schoolBehavior.m_level = character.Level;
-            schoolBehavior.m_trainingPoints = character.TrainingPoints;
-            schoolBehavior.m_schoolOfFocus = (uint) character.WizardSchool;
+            var idx = clientObject.m_inactiveBehaviors.IndexOf(schoolBehavior);
+            clientObject.m_inactiveBehaviors[idx] = character.MagicSchoolBehavior.GetClientBehaviorInstance();
         }
         else {
             throw new Exception("Behavior ClientMagicSchoolBehavior not found!");
@@ -110,7 +107,8 @@ public static class WizardObjectLoader {
 
     public static void SetSpellbookBehavior(WizClientObject clientObject, ref Wizard character) {
         if (CoreObjectFactory.FindBehaviorInstance<ClientSpellbookBehavior>(clientObject, out var spellbookBehavior)) {
-            spellbookBehavior.m_spellIDList = new List<SpellIDTracker>();
+            var idx = clientObject.m_inactiveBehaviors.IndexOf(spellbookBehavior);
+            clientObject.m_inactiveBehaviors[idx] = character.SpellbookBehavior.GetClientBehaviorInstance();
         }
         else {
             throw new Exception("Behavior ClientSpellbookBehavior not found!");

--- a/src/CoreLib/Game/WizardObjectLoader.cs
+++ b/src/CoreLib/Game/WizardObjectLoader.cs
@@ -117,7 +117,8 @@ public static class WizardObjectLoader {
 
     public static void SetMountOwnerBehavior(WizClientObject clientObject, ref Wizard character) {
         if (CoreObjectFactory.FindBehaviorInstance<ClientMountOwnerBehavior>(clientObject, out var mountOwnerBehavior)) {
-            mountOwnerBehavior.m_race = (eRace) 1283940943;
+            var idx = clientObject.m_inactiveBehaviors.IndexOf(mountOwnerBehavior);
+            clientObject.m_inactiveBehaviors[idx] = character.MountOwnerBehavior.GetClientBehaviorInstance();
         }
         else {
             throw new Exception("Behavior ClientMountOwnerBehavior not found!");

--- a/src/CoreLib/Game/WizardObjectLoader.cs
+++ b/src/CoreLib/Game/WizardObjectLoader.cs
@@ -87,12 +87,8 @@ public static class WizardObjectLoader {
 
     public static void SetPlayerNameBehavior(WizClientObject clientObject, ref Wizard character) {
         if (CoreObjectFactory.FindBehaviorInstance<ClientWizPlayerNameBehavior>(clientObject, out var nameBehavior)) {
-            nameBehavior.m_eGender = character.WizardAvatar.m_eGender;
-            nameBehavior.m_eRace = character.WizardAvatar.m_eRace;
-            nameBehavior.m_nameKeys = character.NameIndices;
-            nameBehavior.m_wsNameOverride = character.NameOverride;
-            nameBehavior.m_chatPermissions = 2; // todo: set this to the correct value.
-            nameBehavior.m_friendlyPlayer = character.GameStats.m_friendlyPlayer;
+            var idx = clientObject.m_inactiveBehaviors.IndexOf(nameBehavior);
+            clientObject.m_inactiveBehaviors[idx] = character.PlayerNameBehavior.GetClientBehaviorInstance();
         }
         else {
             throw new Exception("Behavior ClientWizPlayerNameBehavior not found!");

--- a/src/CoreLib/Game/WizardObjectLoader.cs
+++ b/src/CoreLib/Game/WizardObjectLoader.cs
@@ -37,6 +37,7 @@ public static class WizardObjectLoader {
         SetInventoryBehavior(clientObject, ref character);
         SetMagicSchoolBehavior(clientObject, ref character);
         SetSpellbookBehavior(clientObject, ref character);
+        SetMountOwnerBehavior(clientObject, ref character);
 
         return clientObject;
     }
@@ -53,15 +54,8 @@ public static class WizardObjectLoader {
 
     public static void SetInventoryBehavior(WizClientObject clientObject, ref Wizard character) {
         if (CoreObjectFactory.FindBehaviorInstance<ClientWizInventoryBehavior>(clientObject, out var inventoryBehavior)) {
-            // Create a local copy of the inventory items.
-            var equipmentCopy = character.EquippedItems.ToList();
-
-            inventoryBehavior.m_numItemsAllowed = 75;
-            inventoryBehavior.m_numJewelsAllowed = 100;
-            inventoryBehavior.m_itemList = character.InventoryItems
-                .Where(x => !equipmentCopy.Any(y => y is not null && y.m_itemID == x.m_globalID))
-                .ToList()
-                .ConvertAll(item => (CoreObject) item);
+            var idx = clientObject.m_inactiveBehaviors.IndexOf(inventoryBehavior);
+            clientObject.m_inactiveBehaviors[idx] = character.InventoryBehavior.GetClientBehaviorInstance();
         }
         else {
             throw new Exception("Behavior ClientWizInventoryBehavior not found!");
@@ -70,17 +64,8 @@ public static class WizardObjectLoader {
 
     public static void SetEquipmentBehavior(WizClientObject clientObject, Wizard character) {
         if (CoreObjectFactory.FindBehaviorInstance<ClientWizEquipmentBehavior>(clientObject, out var equipmentBehavior)) {
-            // Create a local copy of the inventory items.
-            var equipmentCopy = character.EquippedItems.ToList();
-            var slotList = equipmentCopy.Where(x => x.m_itemID != 0).ToList();
-
-            equipmentBehavior.m_equipmentSets = new List<EquipmentSet>();
-            equipmentBehavior.m_publicItemList = CharacterHelper.GetEquipmentList(character).m_infoList;
-            equipmentBehavior.m_slotList = slotList;
-            equipmentBehavior.m_itemList = character.InventoryItems
-                .Where(x => equipmentCopy.Any(y => y is not null && y.m_itemID == x.m_globalID))
-                .ToList()
-                .ConvertAll(item => (CoreObject) item);
+            var idx = clientObject.m_inactiveBehaviors.IndexOf(equipmentBehavior);
+            clientObject.m_inactiveBehaviors[idx] = character.EquipmentBehavior.GetClientBehaviorInstance();
         }
         else {
             throw new Exception("Behavior ClientWizEquipmentBehavior not found!");
@@ -133,6 +118,15 @@ public static class WizardObjectLoader {
         }
         else {
             throw new Exception("Behavior ClientSpellbookBehavior not found!");
+        }
+    }
+
+    public static void SetMountOwnerBehavior(WizClientObject clientObject, ref Wizard character) {
+        if (CoreObjectFactory.FindBehaviorInstance<ClientMountOwnerBehavior>(clientObject, out var mountOwnerBehavior)) {
+            mountOwnerBehavior.m_race = (eRace) 1283940943;
+        }
+        else {
+            throw new Exception("Behavior ClientMountOwnerBehavior not found!");
         }
     }
 }

--- a/src/CoreLib/WizardData/Collections/AccountCollection.cs
+++ b/src/CoreLib/WizardData/Collections/AccountCollection.cs
@@ -102,7 +102,8 @@ public static class AccountCollection {
             var inventory = session.Query<WizClientObjectItem>(collectionName: WizardItemCollection.CollectionName)
                 .Where(i => i.m_characterId == character.CharId)
                 .ToList();
-            character.InventoryItems = inventory.ToList();
+            character.Account = account;
+            character.InventoryBehavior.InventoryItems = inventory.ToList();
         }
 
         // Load infractions. The constructor will load the action history.
@@ -142,7 +143,8 @@ public static class AccountCollection {
             var inventory = session.Query<WizClientObjectItem>(collectionName: WizardItemCollection.CollectionName)
                 .Where(i => i.m_characterId == character.CharId)
                 .ToList();
-            character.InventoryItems = inventory.ToList();
+            character.Account = account;
+            character.InventoryBehavior.InventoryItems = inventory.ToList();
         }
 
         // Load infractions. The constructor will load the action history.

--- a/src/CoreLib/WizardData/Collections/AccountCollection.cs
+++ b/src/CoreLib/WizardData/Collections/AccountCollection.cs
@@ -98,12 +98,19 @@ public static class AccountCollection {
             .ToList();
         account.Characters = characters;
         foreach (var character in account.Characters) {
+            character.Account = account;
+
             // Load the character's inventory.
             var inventory = session.Query<WizClientObjectItem>(collectionName: WizardItemCollection.CollectionName)
                 .Where(i => i.m_characterId == character.CharId)
                 .ToList();
-            character.Account = account;
-            character.InventoryBehavior.InventoryItems = inventory.ToList();
+            character.InventoryBehavior.Items = inventory.ToList();
+
+            // Load the character's equipment.
+            // The equipped items are stored as global IDs in the character's EquipmentBehavior.
+            // Find any items in the inventory that match the equipped item IDs.
+            character.EquipmentBehavior.EquippedItems = inventory
+                .Where(i => character.EquipmentBehavior.EquippedItemIds.Any(e => i.m_globalID == e)).ToList();
         }
 
         // Load infractions. The constructor will load the action history.
@@ -139,12 +146,19 @@ public static class AccountCollection {
             .ToList();
         account.Characters = characters;
         foreach (var character in account.Characters) {
+            character.Account = account;
+
             // Load the character's inventory.
             var inventory = session.Query<WizClientObjectItem>(collectionName: WizardItemCollection.CollectionName)
                 .Where(i => i.m_characterId == character.CharId)
                 .ToList();
-            character.Account = account;
-            character.InventoryBehavior.InventoryItems = inventory.ToList();
+            character.InventoryBehavior.Items = inventory.ToList();
+
+            // Load the character's equipment.
+            // The equipped items are stored as global IDs in the character's EquipmentBehavior.
+            // Find any items in the inventory that match the equipped item IDs.
+            character.EquipmentBehavior.EquippedItems = inventory
+                .Where(i => character.EquipmentBehavior.EquippedItemIds.Any(e => i.m_globalID == e)).ToList();
         }
 
         // Load infractions. The constructor will load the action history.
@@ -330,4 +344,5 @@ public static class AccountCollection {
         existingAccount.InfractionIds.Remove(infractionIndex);
         session.SaveChanges();
     }
+
 }

--- a/src/CoreLib/WizardData/Collections/AccountCollection.cs
+++ b/src/CoreLib/WizardData/Collections/AccountCollection.cs
@@ -6,6 +6,7 @@
 using System.Linq;
 using Imlight.CoreLib.WizardData.Collections;
 using Imlight.CoreLib.WizardData.Databases;
+using Imlight.CoreLib.WizardData.Models.Misc;
 using Imlight.CoreLib.WizardData.Models.Player;
 using Raven.Client.Documents;
 using static Imlight.Common.Caches.TypeCache;

--- a/src/CoreLib/WizardData/Collections/AccountCollection.cs
+++ b/src/CoreLib/WizardData/Collections/AccountCollection.cs
@@ -104,7 +104,8 @@ public static class AccountCollection {
             var inventory = session.Query<WizClientObjectItem>(collectionName: WizardItemCollection.CollectionName)
                 .Where(i => i.m_characterId == character.CharId)
                 .ToList();
-            character.InventoryBehavior.Items = inventory.ToList();
+            character.InventoryBehavior.Items = inventory
+                .Where(i => character.InventoryBehavior.InventoryItemIds.Contains(i.m_globalID)).ToList();
 
             // Load the character's equipment.
             // The equipped items are stored as global IDs in the character's EquipmentBehavior.
@@ -152,7 +153,8 @@ public static class AccountCollection {
             var inventory = session.Query<WizClientObjectItem>(collectionName: WizardItemCollection.CollectionName)
                 .Where(i => i.m_characterId == character.CharId)
                 .ToList();
-            character.InventoryBehavior.Items = inventory.ToList();
+            character.InventoryBehavior.Items = inventory
+                .Where(i => character.InventoryBehavior.InventoryItemIds.Contains(i.m_globalID)).ToList();
 
             // Load the character's equipment.
             // The equipped items are stored as global IDs in the character's EquipmentBehavior.

--- a/src/CoreLib/WizardData/Collections/ChatLogCollection.cs
+++ b/src/CoreLib/WizardData/Collections/ChatLogCollection.cs
@@ -4,7 +4,7 @@
  */
 
 using Imlight.CoreLib.WizardData.Databases;
-using Imlight.CoreLib.WizardData.Models.Player;
+using Imlight.CoreLib.WizardData.Models.Misc;
 using Raven.Client.Documents;
 
 namespace Imlight.CoreLib.WizardData.Collections;

--- a/src/CoreLib/WizardData/Collections/CommandLogCollection.cs
+++ b/src/CoreLib/WizardData/Collections/CommandLogCollection.cs
@@ -4,7 +4,7 @@
  */
 
 using Imlight.CoreLib.WizardData.Databases;
-using Imlight.CoreLib.WizardData.Models.Player;
+using Imlight.CoreLib.WizardData.Models.Misc;
 using Raven.Client.Documents;
 
 namespace Imlight.CoreLib.WizardData.Collections;

--- a/src/CoreLib/WizardData/Collections/InfractionCollection.cs
+++ b/src/CoreLib/WizardData/Collections/InfractionCollection.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Linq;
 using Imlight.CoreLib.WizardData.Databases;
-using Imlight.CoreLib.WizardData.Models.Player;
+using Imlight.CoreLib.WizardData.Models.Misc;
 using Raven.Client.Documents;
 
 namespace Imlight.CoreLib.WizardData.Collections;

--- a/src/CoreLib/WizardData/Collections/WizardCollection.cs
+++ b/src/CoreLib/WizardData/Collections/WizardCollection.cs
@@ -77,7 +77,7 @@ public static class WizardCollection {
             var items = session.Query<WizClientObjectItem>(collectionName: WizardItemCollection.CollectionName)
                 .Where(x => x.m_characterId == id)
                 .ToList();
-            character.InventoryBehavior.InventoryItems = items.ToList();
+            character.InventoryBehavior.Items = items.ToList();
         }
 
         return character;

--- a/src/CoreLib/WizardData/Collections/WizardCollection.cs
+++ b/src/CoreLib/WizardData/Collections/WizardCollection.cs
@@ -154,7 +154,7 @@ public static class WizardCollection {
             return;
         }
 
-        existingCharacter.Level = wizard.Level;
+        existingCharacter.MagicSchoolBehavior.Level = wizard.MagicSchoolBehavior.Level;
         session.SaveChanges();
     }
 }

--- a/src/CoreLib/WizardData/Collections/WizardCollection.cs
+++ b/src/CoreLib/WizardData/Collections/WizardCollection.cs
@@ -69,7 +69,7 @@ public static class WizardCollection {
         using var session = s_store.OpenSession();
 
         var character = session.Query<Wizard>(collectionName: CollectionName)
-            .Include(i => i.InventoryItemIds)
+            .Include(i => i.InventoryBehavior.InventoryItemIds)
             .FirstOrDefault(x => x.CharId == id);
 
         // Get each of the items for this character.
@@ -77,7 +77,7 @@ public static class WizardCollection {
             var items = session.Query<WizClientObjectItem>(collectionName: WizardItemCollection.CollectionName)
                 .Where(x => x.m_characterId == id)
                 .ToList();
-            character.InventoryItems = items.ToList();
+            character.InventoryBehavior.InventoryItems = items.ToList();
         }
 
         return character;
@@ -127,7 +127,7 @@ public static class WizardCollection {
     /// Updates the equipment of a character in the wizard collection.
     /// </summary>
     /// <param name="wizard">The wizard object containing the updated equipment.</param>
-    public static void UpdateCharacterEquipment(Wizard wizard) {
+    public static void UpdateCharacterItems(Wizard wizard) {
         using var session = s_store.OpenSession();
 
         var existingCharacter = session.Query<Wizard>(collectionName: CollectionName)
@@ -136,7 +136,8 @@ public static class WizardCollection {
             return;
         }
 
-        existingCharacter.EquippedItems = wizard.EquippedItems;
+        existingCharacter.InventoryBehavior = wizard.InventoryBehavior;
+        existingCharacter.EquipmentBehavior = wizard.EquipmentBehavior;
         session.SaveChanges();
     }
 

--- a/src/CoreLib/WizardData/Collections/WizardCollection.cs
+++ b/src/CoreLib/WizardData/Collections/WizardCollection.cs
@@ -157,4 +157,21 @@ public static class WizardCollection {
         existingCharacter.MagicSchoolBehavior.Level = wizard.MagicSchoolBehavior.Level;
         session.SaveChanges();
     }
+
+    /// <summary>
+    /// Updates the character mount for a wizard.
+    /// </summary>
+    /// <param name="wizard">The wizard whose character mount is being updated.</param>
+    public static void UpdateCharacterMount(Wizard wizard) {
+        using var session = s_store.OpenSession();
+
+        var existingCharacter = session.Query<Wizard>(collectionName: CollectionName)
+            .FirstOrDefault(x => x.CharId == wizard.CharId);
+        if (existingCharacter is null) {
+            return;
+        }
+
+        existingCharacter.MountOwnerBehavior = wizard.MountOwnerBehavior;
+        session.SaveChanges();
+    }
 }

--- a/src/CoreLib/WizardData/Collections/WizardItemCollection.cs
+++ b/src/CoreLib/WizardData/Collections/WizardItemCollection.cs
@@ -49,7 +49,7 @@ public static class WizardItemCollection {
         // Instead, we're going to use a patch request to add the item id to the character's item list.
         var patchRequest = new PatchByQueryOperation(
             $"from Characters where CharId = '{item.m_characterId}'" +
-            $"update {{ this.{nameof(Wizard.InventoryItemIds)}.Add('{item.m_globalID}'); }}");
+            $"update {{ this.{nameof(Wizard.InventoryBehavior.InventoryItemIds)}.Add('{item.m_globalID}'); }}");
         s_store.Operations.Send(patchRequest);
 
         session.SaveChanges();
@@ -117,7 +117,7 @@ public static class WizardItemCollection {
         // Instead, we're going to use a patch request to add the item id to the character's item list.
         var patchRequest = new PatchByQueryOperation(
             $"from Characters where CharId = '{item.m_characterId}'" +
-            $"update {{ this.{nameof(Wizard.InventoryItemIds)}.Remove('{item.m_globalID}'); }}");
+            $"update {{ this.{nameof(Wizard.InventoryBehavior.InventoryItemIds)}.Remove('{item.m_globalID}'); }}");
 
         session.SaveChanges();
 
@@ -150,7 +150,7 @@ public static class WizardItemCollection {
         // Instead, we're going to use a patch request to add the item id to the character's item list.
         var patchRequest = new PatchByQueryOperation(
             $"from Characters where CharId = '{charId}'" +
-            $"update {{ this.{nameof(Wizard.InventoryItemIds)}.Remove('{itemId}'); }}");
+            $"update {{ this.{nameof(Wizard.InventoryBehavior.InventoryItemIds)}.Remove('{itemId}'); }}");
 
         session.SaveChanges();
         return true;

--- a/src/CoreLib/WizardData/Implementations/CharacterHelper.cs
+++ b/src/CoreLib/WizardData/Implementations/CharacterHelper.cs
@@ -65,16 +65,12 @@ internal static class CharacterHelper {
     /// <param name="character">The Wizard in question.</param>
     /// <returns>The EquippedItemInfoList that was crafted.</returns>
     /// <exception cref="Exception"></exception>
-    internal static EquippedItemInfoList GetEquipmentList(Wizard character) {
+    internal static EquippedItemInfoList GetEquipmentList(ServerWizEquipmentBehavior behavior) {
         var equipmentList = new EquippedItemInfoList {
             m_infoList = new List<EquippedItemInfo>(),
         };
-        foreach (var equippedItem in character.EquippedItems.Where(x => x.m_itemID != 0)) {
-            // The equipped items are stored as a list of ItemID's. We need to get the actual item
-            // from the inventory and then convert it to a public item.
-            var itemId = equippedItem.m_itemID;
-            var actualItem = character.InventoryGetItem(itemId);
-            var publicItem = ItemHelper.GetPublicItem(actualItem);
+        foreach (var equippedItem in behavior.EquippedItems) {
+            var publicItem = ItemHelper.GetPublicItem(equippedItem);
 
             equipmentList.m_infoList.Add(publicItem);
         }

--- a/src/CoreLib/WizardData/Implementations/CharacterHelper.cs
+++ b/src/CoreLib/WizardData/Implementations/CharacterHelper.cs
@@ -53,7 +53,7 @@ internal static class CharacterHelper {
             m_globalID = (GID) character.CharId,
             m_templateID = 1,
             m_userID = (GID) character.AccountId,
-            m_equipmentInfoList = GetEquipmentList(character),
+            m_equipmentInfoList = GetEquipmentList(character.EquipmentBehavior),
         };
         return creationInfo;
     }

--- a/src/CoreLib/WizardData/Implementations/CharacterHelper.cs
+++ b/src/CoreLib/WizardData/Implementations/CharacterHelper.cs
@@ -66,16 +66,26 @@ internal static class CharacterHelper {
     /// <returns>The EquippedItemInfoList that was crafted.</returns>
     /// <exception cref="Exception"></exception>
     internal static EquippedItemInfoList GetEquipmentList(ServerWizEquipmentBehavior behavior) {
-        var equipmentList = new EquippedItemInfoList {
+        var sortedList = new EquippedItemInfoList {
             m_infoList = new List<EquippedItemInfo>(),
         };
-        foreach (var equippedItem in behavior.EquippedItems) {
-            var publicItem = ItemHelper.GetPublicItem(equippedItem);
 
-            equipmentList.m_infoList.Add(publicItem);
+        foreach (var slot in behavior.SlotList) {
+            var equippedItem = behavior.EquippedItems.FirstOrDefault(item => item.m_globalID == slot.ItemId);
+            if (equippedItem != null) {
+                var publicItem = ItemHelper.GetPublicItem(equippedItem);
+                sortedList.m_infoList.Add(publicItem);
+            }
         }
 
-        return equipmentList;
+        // Sorting the list based on the order in which they appear in the SlotList
+        sortedList.m_infoList.Sort((item1, item2) => {
+            var index1 = behavior.SlotList.FindIndex(slot => slot.ItemId == item1.m_itemID);
+            var index2 = behavior.SlotList.FindIndex(slot => slot.ItemId == item2.m_itemID);
+            return index1.CompareTo(index2);
+        });
+
+        return sortedList;
     }
 
     /// <summary>

--- a/src/CoreLib/WizardData/Implementations/CharacterHelper.cs
+++ b/src/CoreLib/WizardData/Implementations/CharacterHelper.cs
@@ -31,7 +31,7 @@ internal static class CharacterHelper {
         var character = new Wizard(school, wizardAvatar, nameIndices);
 
         // Create the game stats and calculate the base stats.
-        var gameStats = GetNewCharacterGameStats(character.Level, character.WizardSchool);
+        var gameStats = GetNewCharacterGameStats((byte) character.MagicSchoolBehavior.Level, character.MagicSchoolBehavior.MagicSchool);
         character.GameStats = gameStats;
 
         return character;
@@ -45,10 +45,10 @@ internal static class CharacterHelper {
     internal static WizardCharacterCreationInfo GetLoginScreenInfo(Wizard character) {
         var creationInfo = new WizardCharacterCreationInfo {
             m_avatarBehavior = character.WizardAvatar,
-            m_nameIndices = character.NameIndices,
-            m_schoolOfFocus = (uint) character.WizardSchool,
-            m_level = character.Level,
-            m_name = character.NameOverride,
+            m_nameIndices = character.PlayerNameBehavior.NameIndices,
+            m_schoolOfFocus = (uint) character.MagicSchoolBehavior.MagicSchool,
+            m_level = character.MagicSchoolBehavior.Level,
+            m_name = character.PlayerNameBehavior.NameOverride,
             m_location = character.ZoneDisplayName,
             m_globalID = (GID) character.CharId,
             m_templateID = 1,

--- a/src/CoreLib/WizardData/Implementations/IClientBehaviorProvider.cs
+++ b/src/CoreLib/WizardData/Implementations/IClientBehaviorProvider.cs
@@ -1,0 +1,12 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+using static Imlight.Common.Caches.TypeCache;
+
+namespace Imlight.CoreLib.WizardData.Implementations;
+
+public interface IClientBehaviorProvider<T> where T : BehaviorInstance {
+    internal T GetClientBehaviorInstance();
+}

--- a/src/CoreLib/WizardData/Implementations/IClientTypeProvider.cs
+++ b/src/CoreLib/WizardData/Implementations/IClientTypeProvider.cs
@@ -1,0 +1,12 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+using Imlight.Common.ObjectProperty.PropertyReflection;
+
+namespace Imlight.CoreLib.WizardData.Implementations;
+
+public interface IClientTypeProvider<T> where T : PropertyClass {
+    public T GetClientTypeAlternative();
+}

--- a/src/CoreLib/WizardData/Implementations/ItemHelper.cs
+++ b/src/CoreLib/WizardData/Implementations/ItemHelper.cs
@@ -2,6 +2,7 @@ using Imlight.Common;
 using Imlight.Common.Cryptography;
 using Imlight.Common.ObjectProperty.PropertyReflection;
 using Imlight.CoreLib.Shared.Resources;
+using Imlight.CoreLib.WizardData.Models.Player;
 using System;
 using System.Linq;
 using static Imlight.Common.Caches.TypeCache;
@@ -9,10 +10,6 @@ using static Imlight.Common.Caches.TypeCache;
 namespace Imlight.CoreLib.WizardData.Implementations;
 
 internal static class ItemHelper {
-    private static readonly string[] s_slotNames = {
-        "Hat", "Robe", "Shoes", "Weapon", "Athame", "Amulet", "Ring", "Mount", "Deck",
-    };
-
     /// <summary>
     /// Gets the <see cref="EquippedItemInfoList"/> for a <see cref="Wizard"/>. This is a lightweight version of the
     /// actual equipment that is used to publicly display the character's equipment.
@@ -41,28 +38,23 @@ internal static class ItemHelper {
     }
 
     /// <summary>
-    /// Gets the slot hash of a WizClientObjectItem.
+    /// Gets the slot of a WizClientObjectItem from the template adjectives.
     /// </summary>
-    /// <param name="item">The WizClientObjectItem to get the slot hash from.</param>
-    /// <returns>The slot hash of the item, or 0 if the item template is null or the adjective list count is less than 2.</returns>
-    internal static uint GetItemSlotHash(WizClientObjectItem item) {
-        var template = GetItemTemplate(item);
-        if (template == null) {
-            return 0;
-        }
+    /// <param name="itemTemplate"></param>
+    /// <returns>The EquipmentSlot of the item; null if a matching adjective is not found.</returns>
+    internal static EquipmentSlot GetItemSlot(WizItemTemplate itemTemplate) {
+        // Iterate through the EquipmentSlot enum and return the first slot that matches the item's slot.
+        foreach (var slot in Enum.GetValues(typeof(EquipmentSlot)).Cast<EquipmentSlot>()) {
+            // Sanitize the slot name.
+            var slotName = slot.ToString().Split('.')[^1];
 
-        // Iterate through the slot names and return the hash of the first slot name that matches the item's slot.
-        foreach (var slotName in s_slotNames) {
-            if (template.m_adjectiveList.Any(adj => string.Equals(adj, slotName, StringComparison.OrdinalIgnoreCase))) {
-                return StringHash.Compute(slotName);
+            // Check if any of the items adjectives match the slot name.
+            if (itemTemplate.m_adjectiveList.Any(adj => string.Equals(adj, slotName, StringComparison.OrdinalIgnoreCase))) {
+                return slot;
             }
         }
 
-        // Log that we couldn't find the slot name, and print all the adjectives.
-        Logger.Error($"Couldn't find slot name for item {0} with adjectives: {1}",
-            Logger.Args(item.m_templateID, string.Join(", ", template.m_adjectiveList)));
-
-        return 0;
+        return null;
     }
 
     /// <summary>
@@ -71,18 +63,8 @@ internal static class ItemHelper {
     /// <param name="template">The item template.</param>
     /// <returns>The hash value of the item slot.</returns>
     internal static uint GetItemSlotHash(WizItemTemplate template) {
-        if (template == null) {
-            return 0;
-        }
-
-        // Get the slot hash from the item template.
-        if (template.m_adjectiveList.Count < 2) {
-            return 0;
-        }
-        else {
-            // The second adjective is the slot name.
-            var slotName = template.m_adjectiveList[1];
-            return StringHash.Compute(slotName);
-        }
+        var slot = GetItemSlot(template);
+        var slotName = slot?.ToString().Split('.')[^1];
+        return slot is null ? 0 : StringHash.ComputeHash(slotName);
     }
 }

--- a/src/CoreLib/WizardData/Implementations/ItemHelper.cs
+++ b/src/CoreLib/WizardData/Implementations/ItemHelper.cs
@@ -43,14 +43,20 @@ internal static class ItemHelper {
     /// <param name="itemTemplate"></param>
     /// <returns>The EquipmentSlot of the item; null if a matching adjective is not found.</returns>
     internal static EquipmentSlot GetItemSlot(WizItemTemplate itemTemplate) {
+        if (itemTemplate?.m_adjectiveList is null) {
+            throw new InvalidOperationException("Item template does not have an adjective list.");
+        }
+
         // Iterate through the EquipmentSlot enum and return the first slot that matches the item's slot.
-        foreach (var slot in Enum.GetValues(typeof(EquipmentSlot)).Cast<EquipmentSlot>()) {
+        foreach (var slot in Enum.GetValues(typeof(EquipmentSlotType)).Cast<EquipmentSlotType>()) {
             // Sanitize the slot name.
             var slotName = slot.ToString().Split('.')[^1];
 
             // Check if any of the items adjectives match the slot name.
             if (itemTemplate.m_adjectiveList.Any(adj => string.Equals(adj, slotName, StringComparison.OrdinalIgnoreCase))) {
-                return slot;
+                return new EquipmentSlot {
+                    SlotType = slot,
+                };
             }
         }
 

--- a/src/CoreLib/WizardData/Implementations/ItemHelper.cs
+++ b/src/CoreLib/WizardData/Implementations/ItemHelper.cs
@@ -69,8 +69,8 @@ internal static class ItemHelper {
     /// <param name="template">The item template.</param>
     /// <returns>The hash value of the item slot.</returns>
     internal static uint GetItemSlotHash(WizItemTemplate template) {
-        var slot = GetItemSlot(template);
-        var slotName = slot?.ToString().Split('.')[^1];
-        return slot is null ? 0 : StringHash.Compute(slotName);
+        var slotType = GetItemSlot(template).SlotType;
+        var slotName = slotType.ToString().Split('.')[^1];
+        return StringHash.Compute(slotName);
     }
 }

--- a/src/CoreLib/WizardData/Implementations/ItemHelper.cs
+++ b/src/CoreLib/WizardData/Implementations/ItemHelper.cs
@@ -65,6 +65,6 @@ internal static class ItemHelper {
     internal static uint GetItemSlotHash(WizItemTemplate template) {
         var slot = GetItemSlot(template);
         var slotName = slot?.ToString().Split('.')[^1];
-        return slot is null ? 0 : StringHash.ComputeHash(slotName);
+        return slot is null ? 0 : StringHash.Compute(slotName);
     }
 }

--- a/src/CoreLib/WizardData/Models/Misc/ChatLog.cs
+++ b/src/CoreLib/WizardData/Models/Misc/ChatLog.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace Imlight.CoreLib.WizardData.Models.Player;
+namespace Imlight.CoreLib.WizardData.Models.Misc;
 
 public class ChatLog {
     public DateTime TimeStamp { get; set; }

--- a/src/CoreLib/WizardData/Models/Misc/InfractionModels.cs
+++ b/src/CoreLib/WizardData/Models/Misc/InfractionModels.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Imlight.CoreLib.WizardData.Models.Player;
+namespace Imlight.CoreLib.WizardData.Models.Misc;
 
 public enum InfractionType {
     SuspiciousBehavior,

--- a/src/CoreLib/WizardData/Models/Player/Account.cs
+++ b/src/CoreLib/WizardData/Models/Player/Account.cs
@@ -12,6 +12,7 @@ using Imlight.Common.Configuration;
 using Imlight.CoreLib.WizardData.Implementations;
 using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.WizardData.Collections;
+using Imlight.CoreLib.WizardData.Models.Misc;
 
 namespace Imlight.CoreLib.WizardData.Models.Player;
 

--- a/src/CoreLib/WizardData/Models/Player/EquipmentSlot.cs
+++ b/src/CoreLib/WizardData/Models/Player/EquipmentSlot.cs
@@ -31,6 +31,7 @@ public enum EquipmentSlotType {
 [Serializable]
 public class EquipmentSlot : IClientTypeProvider<EquippedSlotInfo> {
     public EquipmentSlotType SlotType { get; set; }
+    public string ItemName { get; set; }
     public GID ItemId { get; set; }
     public DateTime EquippedSince { get; set; }
 

--- a/src/CoreLib/WizardData/Models/Player/EquipmentSlot.cs
+++ b/src/CoreLib/WizardData/Models/Player/EquipmentSlot.cs
@@ -3,9 +3,15 @@
  * Proprietary and confidential.
  */
 
+using Imlight.Common.Cryptography;
+using Imlight.Common.ObjectProperty.PropertyReflection;
+using Imlight.CoreLib.WizardData.Implementations;
+using System;
+using static Imlight.Common.Caches.TypeCache;
+
 namespace Imlight.CoreLib.WizardData.Models.Player;
 
-public enum EquipmentSlot {
+public enum EquipmentSlotType {
     Hat,
     Robe,
     Shoes,
@@ -16,4 +22,24 @@ public enum EquipmentSlot {
     Pet,
     Mount,
     Deck
+}
+
+/// <summary>
+/// Represents a slot in the player's equipment. This is an abstraction on top of Wizard101's
+/// type to make it easier to work with.
+/// </summary>
+[Serializable]
+public class EquipmentSlot : IClientTypeProvider<EquippedSlotInfo> {
+    public EquipmentSlotType SlotType { get; set; }
+    public GID ItemId { get; set; }
+    public DateTime EquippedSince { get; set; }
+
+    public EquippedSlotInfo GetClientTypeAlternative() {
+        // Remove the prefix from the slot type.
+        var slotType = SlotType.ToString().Split('.')[^1];
+        return new EquippedSlotInfo {
+            m_itemID = ItemId,
+            m_itemSlotNameID = StringHash.Compute(slotType),
+        };
+    }
 }

--- a/src/CoreLib/WizardData/Models/Player/ServerMagicSchoolBehavior.cs
+++ b/src/CoreLib/WizardData/Models/Player/ServerMagicSchoolBehavior.cs
@@ -1,0 +1,58 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+using Imlight.Common;
+using Imlight.Common.Configuration;
+using Imlight.Common.IO;
+using Imlight.CoreLib.Shared.Resources;
+using Imlight.CoreLib.WizardData.Implementations;
+using System;
+using System.Text.Json.Serialization;
+using static Imlight.Common.Caches.TypeCache;
+
+namespace Imlight.CoreLib.WizardData.Models.Player;
+
+public enum MagicSchool {
+    Ice = 72777,
+    Life = 2330892,
+    Fire = 2343174,
+    Myth = 2448141,
+    Death = 78318724,
+    Storm = 83375795,
+    Balance = 1027491821,
+}
+
+[Serializable]
+public class ServerMagicSchoolBehavior : BehaviorInstance, IClientBehaviorProvider<ClientMagicSchoolBehavior> {
+    public MagicSchool MagicSchool;
+    public int ExperiencePoints;
+    public int Level;
+    public int TrainingPoints;
+    public int OverflowXp;
+    public int LevelIsLocked;
+    public uint EquippedTeleportEffect;
+
+    public bool SetLevel(byte level) {
+        if (level > ConfigurationManager.Settings.MaxLevel) {
+            return false;
+        }
+
+        Level = level;
+
+        return true;
+    }
+
+    public ClientMagicSchoolBehavior GetClientBehaviorInstance() {
+        return new ClientMagicSchoolBehavior {
+            m_schoolOfFocus = (uint)MagicSchool,
+            m_experiencePoints = ExperiencePoints,
+            m_level = Level,
+            m_trainingPoints = TrainingPoints,
+            m_overflowXP = OverflowXp,
+            m_levelLocked = LevelIsLocked,
+            m_equippedTeleportEffect = EquippedTeleportEffect
+        };
+    }
+}

--- a/src/CoreLib/WizardData/Models/Player/ServerMountOwnerBehavior.cs
+++ b/src/CoreLib/WizardData/Models/Player/ServerMountOwnerBehavior.cs
@@ -1,0 +1,73 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+using Imlight.Common.ObjectProperty.PropertyReflection;
+using Imlight.CoreLib.Shared.Resources;
+using Imlight.CoreLib.WizardData.Implementations;
+using System;
+using System.Linq;
+using System.Text.Json.Serialization;
+using static Imlight.Common.Caches.TypeCache;
+
+namespace Imlight.CoreLib.WizardData.Models.Player;
+
+[Serializable]
+public class ServerMountOwnerBehavior : BehaviorInstance, IClientBehaviorProvider<ClientMountOwnerBehavior> {
+    public eGender MountGender;
+    public eRace MountRace;
+    public int MountPrimaryColor;
+    public int MountSecondaryColor;
+    public int MountPatternColor;
+
+    [JsonIgnore] public GID LastMountId;
+    [JsonIgnore] public eMountType MountType;
+    [JsonIgnore] public bool MountHasAdjustableAnimationRate;
+    [JsonIgnore] public int MountGeometryOption;
+
+    public bool EquipMount(WizItemTemplate mountTemplate, WizClientObjectItem item) {
+        if (mountTemplate == null) {
+            return false;
+        }
+
+        // MountItemBehaviorTemplate
+        if (mountTemplate.m_behaviors.Any(x => x is MountItemBehaviorTemplate)) {
+            var mountBehavior = mountTemplate.m_behaviors.First(x => x is MountItemBehaviorTemplate) as MountItemBehaviorTemplate;
+
+            MountRace = mountBehavior.m_eRace;
+            MountGender = mountBehavior.m_eGender;
+            MountType = mountBehavior.m_eMountType;
+            MountHasAdjustableAnimationRate = mountBehavior.m_adjustableAnimationRate;
+            MountGeometryOption = mountBehavior.m_geometryOption;
+            MountPrimaryColor = item.m_primaryColor;
+            MountSecondaryColor = item.m_secondaryColor;
+            MountPatternColor = item.m_pattern;
+        }
+
+        return true;
+    }
+
+    public void UnequipMount() {
+        MountRace = 0;
+        MountHasAdjustableAnimationRate = false;
+        MountGeometryOption = 0;
+        MountPrimaryColor = 0;
+        MountSecondaryColor = 0;
+        MountPatternColor = 0;
+    }
+
+    public ClientMountOwnerBehavior GetClientBehaviorInstance() {
+        return new ClientMountOwnerBehavior {
+            m_gender = MountGender,
+            m_race = MountRace,
+            m_eMountType = MountType,
+            m_primaryColor = MountPrimaryColor,
+            m_secondaryColor = MountSecondaryColor,
+            m_patternColor = MountPatternColor,
+            m_adjustableAnimationRate = MountHasAdjustableAnimationRate,
+            m_geometryOption = MountGeometryOption,
+            m_lastMountID = LastMountId
+        };
+    }
+}

--- a/src/CoreLib/WizardData/Models/Player/ServerSpellbookBehavior.cs
+++ b/src/CoreLib/WizardData/Models/Player/ServerSpellbookBehavior.cs
@@ -1,0 +1,22 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+using Imlight.CoreLib.WizardData.Implementations;
+using System;
+using System.Collections.Generic;
+using static Imlight.Common.Caches.TypeCache;
+
+namespace Imlight.CoreLib.WizardData.Models.Player;
+
+[Serializable]
+public class ServerSpellbookBehavior : BehaviorInstance, IClientBehaviorProvider<ClientSpellbookBehavior> {
+    public List<SpellIDTracker> SpellIdList;
+
+    public ClientSpellbookBehavior GetClientBehaviorInstance() {
+        return new ClientSpellbookBehavior {
+            m_spellIDList = SpellIdList
+        };
+    }
+}

--- a/src/CoreLib/WizardData/Models/Player/ServerWizEquipmentBehavior.cs
+++ b/src/CoreLib/WizardData/Models/Player/ServerWizEquipmentBehavior.cs
@@ -20,20 +20,17 @@ namespace Imlight.CoreLib.WizardData.Models.Player;
 [Serializable]
 public class ServerWizEquipmentBehavior : BehaviorInstance, IClientBehaviorProvider<ClientWizEquipmentBehavior> {
     public List<EquipmentSlot> SlotList;
-    public List<WizClientObjectItem> EquippedItems;
+    public List<ulong> EquippedItemIds;
 
-    public bool EquipItem(ulong itemId, out WizItemTemplate template) {
+    [JsonIgnore] public List<WizClientObjectItem> EquippedItems;
+
+    public bool EquipItem(WizClientObjectItem item, out WizItemTemplate template, out WizItemTemplate removedTemplate) {
         template = default;
+        removedTemplate = default;
+        var itemId = item.m_globalID;
 
         // Prerequisite checks.
         if (HasItemEquipped(itemId)) {
-            return false;
-        }
-
-        // Get the actual item from this ID.
-        var item = EquippedItems.FirstOrDefault(item => item.m_globalID == itemId);
-        if (item == null) {
-            Logger.Warning("Tried to equip item with global id {0} that does not exist.", Logger.Args(itemId));
             return false;
         }
 
@@ -51,8 +48,17 @@ public class ServerWizEquipmentBehavior : BehaviorInstance, IClientBehaviorProvi
             return false;
         }
 
+        var existingItem = GetItemInSlot(slot.SlotType);
+        if (existingItem is not null) {
+            EquippedItemIds.Remove(existingItem.m_globalID);
+            EquippedItems.Remove(existingItem);
+            removedTemplate = ItemHelper.GetItemTemplate(existingItem);
+        }
+
         // Finally, update the slot.
-        UpdateEquipmentSlot(slot, itemId);
+        UpdateEquipmentSlot(slot, item.m_debugName, itemId);
+        EquippedItemIds.Add(itemId);
+        EquippedItems.Add(item);
         return true;
     }
 
@@ -87,6 +93,8 @@ public class ServerWizEquipmentBehavior : BehaviorInstance, IClientBehaviorProvi
 
         // Finally, update the slot.
         ClearEquipmentSlot(slot);
+        EquippedItemIds.Remove(itemId);
+        EquippedItems.Remove(item);
         return true;
     }
 
@@ -144,13 +152,14 @@ public class ServerWizEquipmentBehavior : BehaviorInstance, IClientBehaviorProvi
         return (byte) slotIndex;
     }
 
-    private void UpdateEquipmentSlot(EquipmentSlot slot, ulong newItemId) {
+    private void UpdateEquipmentSlot(EquipmentSlot slot, string itemName,  ulong newItemId) {
         // Find the slot in the list. If it does, remove it.
         ClearEquipmentSlot(slot);
 
         // Create a new slot and add it to the list.
         var newSlot = new EquipmentSlot {
             SlotType = slot.SlotType,
+            ItemName = itemName,
             ItemId = (GID) newItemId,
             EquippedSince = DateTime.Now,
         };

--- a/src/CoreLib/WizardData/Models/Player/ServerWizEquipmentBehavior.cs
+++ b/src/CoreLib/WizardData/Models/Player/ServerWizEquipmentBehavior.cs
@@ -1,0 +1,124 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+using Imlight.Common;
+using Imlight.Common.Configuration;
+using Imlight.Common.ObjectProperty.PropertyReflection;
+using Imlight.Common.Utilities;
+using Imlight.CoreLib.Game.Effects;
+using Imlight.CoreLib.WizardData.Implementations;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static Imlight.Common.Caches.TypeCache;
+
+namespace Imlight.CoreLib.WizardData.Models.Player;
+
+[Serializable]
+public class ServerWizEquipmentBehavior : BehaviorInstance, IClientBehaviorProvider<ClientWizEquipmentBehavior> {
+    public List<EquipmentSlot> SlotList;
+    public List<WizClientObjectItem> EquippedItems;
+
+    public bool EquipItem(ulong itemId, out WizItemTemplate template) {
+        template = default;
+
+        // Prerequisite checks.
+        if (HasItemEquipped(itemId)) {
+            return false;
+        }
+
+        // Get the actual item from this ID.
+        var item = EquippedItems.FirstOrDefault(item => item.m_globalID == itemId);
+        if (item == null) {
+            Logger.Warning("Tried to equip item with global id {0} that does not exist.", Logger.Args(itemId));
+            return false;
+        }
+
+        // Get the template for this item.
+        template = ItemHelper.GetItemTemplate(item);
+        if (template == null) {
+            Logger.Warning("Tried to equip item with global id {0} that does not have a template.", Logger.Args(itemId));
+            return false;
+        }
+
+        // The slot name is in the adjectives of the item.
+        var slotNameHash = ItemHelper.GetItemSlot(template);
+        if (slotNameHash is null) {
+            Logger.Warning("Tried to equip item with global id {0} that does not have a slot name adjective.", Logger.Args(itemId));
+            return false;
+        }
+
+        // Finally, update the slot.
+        UpdateEquipmentSlot(slotNameHash, itemId);
+        return true;
+    }
+
+    public bool UnequipItem(ulong itemId, out WizItemTemplate template) {
+        template = default;
+
+        // Prerequisite checks.
+        if (!HasItemEquipped(itemId)) {
+            return false;
+        }
+
+        // Get the actual item from this ID.
+        var item = EquippedItems.FirstOrDefault(item => item.m_globalID == itemId);
+        if (item == null) {
+            Logger.Warning("Tried to unequip item with global id {0} that does not exist.", Logger.Args(itemId));
+            return false;
+        }
+
+        // Get the template for this item.
+        template = ItemHelper.GetItemTemplate(item);
+        if (template == null) {
+            Logger.Warning("Tried to unequip item with global id {0} that does not have a template.", Logger.Args(itemId));
+            return false;
+        }
+
+        // The slot name is in the adjectives of the item.
+        var slot = ItemHelper.GetItemSlot(template);
+        if (slot is null) {
+            Logger.Warning("Tried to unequip item with global id {0} that does not have a slot name adjective.", Logger.Args(itemId));
+            return false;
+        }
+
+        // Finally, update the slot.
+        ClearEquipmentSlot(slot);
+        return true;
+    }
+
+    public bool HasItemEquipped(ulong itemId) => EquippedItems.Any(item => item.m_globalID == itemId);
+
+    private void UpdateEquipmentSlot(EquipmentSlot slot, ulong newItemId) {
+        // Find the slot in the list. If it does, remove it.
+        ClearEquipmentSlot(slot);
+
+        // Create a new slot and add it to the list.
+        var newSlot = new EquipmentSlot {
+            SlotType = slot.SlotType,
+            ItemId = (GID) newItemId,
+            EquippedSince = DateTime.Now,
+        };
+        SlotList.Add(newSlot);
+    }
+
+    private void ClearEquipmentSlot(EquipmentSlot slot) {
+        // Find the slot in the list. If it does, remove it.
+        var slotIndex = SlotList.FindIndex(eSlot => eSlot.SlotType == slot.SlotType);
+        if (slotIndex != -1) {
+            SlotList.RemoveAt(slotIndex);
+        }
+    }
+
+    ClientWizEquipmentBehavior IClientBehaviorProvider<ClientWizEquipmentBehavior>.GetClientBehaviorInstance() {
+        return new ClientWizEquipmentBehavior {
+            m_equipmentSets = new List<EquipmentSet>(),
+            m_slotList = SlotList.Select(slot => slot.GetClientTypeAlternative()).ToList(),
+            m_itemList = EquippedItems.ConvertAll(item => item as CoreObject),
+            m_publicItemList = CharacterHelper.GetEquipmentList(this).m_infoList,
+        };
+    }
+}

--- a/src/CoreLib/WizardData/Models/Player/ServerWizEquipmentBehavior.cs
+++ b/src/CoreLib/WizardData/Models/Player/ServerWizEquipmentBehavior.cs
@@ -92,6 +92,58 @@ public class ServerWizEquipmentBehavior : BehaviorInstance, IClientBehaviorProvi
 
     public bool HasItemEquipped(ulong itemId) => EquippedItems.Any(item => item.m_globalID == itemId);
 
+    public bool SlotInUse(string slotName, out byte index) {
+        index = 255;
+
+        // Cast the slot name to an enum value.
+        if (!Enum.TryParse(typeof(EquipmentSlotType), slotName, true, out var slot)) {
+            Logger.Error("Could not parse slot name {0} to an enum value.", Logger.Args(slotName));
+            return false;
+        }
+
+        return SlotInUse((EquipmentSlotType) slot, out index);
+    }
+
+    public bool SlotInUse(EquipmentSlotType slotType, out byte index) {
+        index = 255;
+
+        var slotIndex = SlotList.FindIndex(item => item.SlotType == slotType);
+        if (slotIndex == -1) {
+            return false;
+        }
+
+        index = (byte) slotIndex;
+        return true;
+    }
+
+    public WizClientObjectItem GetItemInSlot(string slotName) {
+        // Cast the slot name to an enum value.
+        if (!Enum.TryParse(typeof(EquipmentSlotType), slotName, true, out var slot)) {
+            Logger.Error("Could not parse slot name {0} to an enum value.", Logger.Args(slotName));
+            return null;
+        }
+
+        return GetItemInSlot((EquipmentSlotType) slot);
+    }
+
+    public WizClientObjectItem GetItemInSlot(EquipmentSlotType slotType) {
+        var slotIndex = SlotList.FindIndex(item => item.SlotType == slotType);
+        if (slotIndex == -1) {
+            return null;
+        }
+
+        return EquippedItems.FirstOrDefault(item => item.m_globalID == SlotList[slotIndex].ItemId);
+    }
+
+    public byte GetSlotOfItem(ulong itemId) {
+        var slotIndex = SlotList.FindIndex(item => item.ItemId == itemId);
+        if (slotIndex == -1) {
+            return 255;
+        }
+
+        return (byte) slotIndex;
+    }
+
     private void UpdateEquipmentSlot(EquipmentSlot slot, ulong newItemId) {
         // Find the slot in the list. If it does, remove it.
         ClearEquipmentSlot(slot);

--- a/src/CoreLib/WizardData/Models/Player/ServerWizEquipmentBehavior.cs
+++ b/src/CoreLib/WizardData/Models/Player/ServerWizEquipmentBehavior.cs
@@ -24,9 +24,7 @@ public class ServerWizEquipmentBehavior : BehaviorInstance, IClientBehaviorProvi
 
     [JsonIgnore] public List<WizClientObjectItem> EquippedItems;
 
-    public bool EquipItem(WizClientObjectItem item, out WizItemTemplate template, out WizItemTemplate removedTemplate) {
-        template = default;
-        removedTemplate = default;
+    public bool EquipItem(WizClientObjectItem item, EquipmentSlotType slotType) {
         var itemId = item.m_globalID;
 
         // Prerequisite checks.
@@ -34,65 +32,30 @@ public class ServerWizEquipmentBehavior : BehaviorInstance, IClientBehaviorProvi
             return false;
         }
 
-        // Get the template for this item.
-        template = ItemHelper.GetItemTemplate(item);
-        if (template == null) {
-            Logger.Warning("Tried to equip item with global id {0} that does not have a template.", Logger.Args(itemId));
-            return false;
-        }
-
-        // The slot name is in the adjectives of the item.
-        var slot = ItemHelper.GetItemSlot(template);
-        if (slot is null) {
-            Logger.Warning("Tried to equip item with global id {0} that does not have a slot name adjective.", Logger.Args(itemId));
-            return false;
-        }
-
-        var existingItem = GetItemInSlot(slot.SlotType);
+        var existingItem = GetItemInSlot(slotType);
         if (existingItem is not null) {
             EquippedItemIds.Remove(existingItem.m_globalID);
             EquippedItems.Remove(existingItem);
-            removedTemplate = ItemHelper.GetItemTemplate(existingItem);
         }
 
         // Finally, update the slot.
-        UpdateEquipmentSlot(slot, item.m_debugName, itemId);
+        UpdateEquipmentSlot(slotType, item.m_debugName, itemId);
         EquippedItemIds.Add(itemId);
         EquippedItems.Add(item);
         return true;
     }
 
-    public bool UnequipItem(ulong itemId, out WizItemTemplate template) {
-        template = default;
-
+    public bool UnequipItem(ulong itemId) {
         // Prerequisite checks.
         if (!HasItemEquipped(itemId)) {
             return false;
         }
 
-        // Get the actual item from this ID.
         var item = EquippedItems.FirstOrDefault(item => item.m_globalID == itemId);
-        if (item == null) {
-            Logger.Warning("Tried to unequip item with global id {0} that does not exist.", Logger.Args(itemId));
-            return false;
-        }
-
-        // Get the template for this item.
-        template = ItemHelper.GetItemTemplate(item);
-        if (template == null) {
-            Logger.Warning("Tried to unequip item with global id {0} that does not have a template.", Logger.Args(itemId));
-            return false;
-        }
-
-        // The slot name is in the adjectives of the item.
-        var slot = ItemHelper.GetItemSlot(template);
-        if (slot is null) {
-            Logger.Warning("Tried to unequip item with global id {0} that does not have a slot name adjective.", Logger.Args(itemId));
-            return false;
-        }
+        var slot = SlotList.Find(eSlot => eSlot.ItemId == itemId);
 
         // Finally, update the slot.
-        ClearEquipmentSlot(slot);
+        ClearEquipmentSlot(slot.SlotType);
         EquippedItemIds.Remove(itemId);
         EquippedItems.Remove(item);
         return true;
@@ -143,6 +106,25 @@ public class ServerWizEquipmentBehavior : BehaviorInstance, IClientBehaviorProvi
         return EquippedItems.FirstOrDefault(item => item.m_globalID == SlotList[slotIndex].ItemId);
     }
 
+    public WizItemTemplate GetTemplateInSlot(string slotName) {
+        // Cast the slot name to an enum value.
+        if (!Enum.TryParse(typeof(EquipmentSlotType), slotName, true, out var slot)) {
+            Logger.Error("Could not parse slot name {0} to an enum value.", Logger.Args(slotName));
+            return null;
+        }
+
+        return GetTemplateInSlot((EquipmentSlotType) slot);
+    }
+
+    public WizItemTemplate GetTemplateInSlot(EquipmentSlotType slotType) {
+        var slotIndex = SlotList.FindIndex(item => item.SlotType == slotType);
+        if (slotIndex == -1) {
+            return null;
+        }
+
+        return ItemHelper.GetItemTemplate(EquippedItems.FirstOrDefault(item => item.m_globalID == SlotList[slotIndex].ItemId));
+    }
+
     public byte GetSlotOfItem(ulong itemId) {
         var slotIndex = SlotList.FindIndex(item => item.ItemId == itemId);
         if (slotIndex == -1) {
@@ -152,13 +134,13 @@ public class ServerWizEquipmentBehavior : BehaviorInstance, IClientBehaviorProvi
         return (byte) slotIndex;
     }
 
-    private void UpdateEquipmentSlot(EquipmentSlot slot, string itemName,  ulong newItemId) {
+    private void UpdateEquipmentSlot(EquipmentSlotType slotType, string itemName,  ulong newItemId) {
         // Find the slot in the list. If it does, remove it.
-        ClearEquipmentSlot(slot);
+        ClearEquipmentSlot(slotType);
 
         // Create a new slot and add it to the list.
         var newSlot = new EquipmentSlot {
-            SlotType = slot.SlotType,
+            SlotType = slotType,
             ItemName = itemName,
             ItemId = (GID) newItemId,
             EquippedSince = DateTime.Now,
@@ -166,9 +148,9 @@ public class ServerWizEquipmentBehavior : BehaviorInstance, IClientBehaviorProvi
         SlotList.Add(newSlot);
     }
 
-    private void ClearEquipmentSlot(EquipmentSlot slot) {
+    private void ClearEquipmentSlot(EquipmentSlotType slotType) {
         // Find the slot in the list. If it does, remove it.
-        var slotIndex = SlotList.FindIndex(eSlot => eSlot.SlotType == slot.SlotType);
+        var slotIndex = SlotList.FindIndex(eSlot => eSlot.SlotType == slotType);
         if (slotIndex != -1) {
             SlotList.RemoveAt(slotIndex);
         }

--- a/src/CoreLib/WizardData/Models/Player/ServerWizEquipmentBehavior.cs
+++ b/src/CoreLib/WizardData/Models/Player/ServerWizEquipmentBehavior.cs
@@ -45,14 +45,14 @@ public class ServerWizEquipmentBehavior : BehaviorInstance, IClientBehaviorProvi
         }
 
         // The slot name is in the adjectives of the item.
-        var slotNameHash = ItemHelper.GetItemSlot(template);
-        if (slotNameHash is null) {
+        var slot = ItemHelper.GetItemSlot(template);
+        if (slot is null) {
             Logger.Warning("Tried to equip item with global id {0} that does not have a slot name adjective.", Logger.Args(itemId));
             return false;
         }
 
         // Finally, update the slot.
-        UpdateEquipmentSlot(slotNameHash, itemId);
+        UpdateEquipmentSlot(slot, itemId);
         return true;
     }
 
@@ -165,7 +165,7 @@ public class ServerWizEquipmentBehavior : BehaviorInstance, IClientBehaviorProvi
         }
     }
 
-    ClientWizEquipmentBehavior IClientBehaviorProvider<ClientWizEquipmentBehavior>.GetClientBehaviorInstance() {
+    public ClientWizEquipmentBehavior GetClientBehaviorInstance() {
         return new ClientWizEquipmentBehavior {
             m_equipmentSets = new List<EquipmentSet>(),
             m_slotList = SlotList.Select(slot => slot.GetClientTypeAlternative()).ToList(),

--- a/src/CoreLib/WizardData/Models/Player/ServerWizInventoryBehavior.cs
+++ b/src/CoreLib/WizardData/Models/Player/ServerWizInventoryBehavior.cs
@@ -41,6 +41,7 @@ public class ServerWizInventoryBehavior : BehaviorInstance, IClientBehaviorProvi
             return false;
         }
 
+        InventoryItemIds.Add(item.m_globalID);
         Items.Add(item);
         return true;
     }

--- a/src/CoreLib/WizardData/Models/Player/ServerWizInventoryBehavior.cs
+++ b/src/CoreLib/WizardData/Models/Player/ServerWizInventoryBehavior.cs
@@ -23,7 +23,7 @@ public class ServerWizInventoryBehavior : BehaviorInstance, IClientBehaviorProvi
 
     public List<ulong> InventoryItemIds { get; set; }
 
-    [JsonIgnore] public List<WizClientObjectItem> InventoryItems { get; set; }
+    [JsonIgnore] public List<WizClientObjectItem> Items { get; set; }
 
     /// <summary>
     /// Adds an item to the player's inventory.
@@ -31,7 +31,7 @@ public class ServerWizInventoryBehavior : BehaviorInstance, IClientBehaviorProvi
     /// <param name="item">The item to be added.</param>
     /// <returns>True if the item was successfully added, false otherwise.</returns>
     public bool AddItem(WizClientObjectItem item) {
-        if (InventoryItems.Count >= s_maxItemsAllowed) {
+        if (Items.Count >= s_maxItemsAllowed) {
             Logger.Debug("Player inventory is full. Cannot add item with global id {0}.", Logger.Args(item.m_globalID));
             return false;
         }
@@ -41,7 +41,7 @@ public class ServerWizInventoryBehavior : BehaviorInstance, IClientBehaviorProvi
             return false;
         }
 
-        InventoryItems.Add(item);
+        Items.Add(item);
         return true;
     }
 
@@ -50,16 +50,18 @@ public class ServerWizInventoryBehavior : BehaviorInstance, IClientBehaviorProvi
     /// </summary>
     /// <param name="itemId">The unique identifier of the item to be removed.</param>
     /// <returns><c>true</c> if the item was successfully removed; otherwise, <c>false</c>.</returns>
-    public bool RemoveItem(ulong itemId) {
+    public bool RemoveItem(ulong itemId, out WizClientObjectItem removedItem) {
+        removedItem = null;
+
         // Get the actual item from the inventory.
-        var item = InventoryItems.Find(i => i.m_globalID == itemId);
-        if (item is null) {
+        removedItem = Items.Find(i => i.m_globalID == itemId);
+        if (removedItem is null) {
             Logger.Debug("Tried to remove item with global id {0} that does not exist in player inventory.",
                 Logger.Args(itemId));
             return false;
         }
 
-        return RemoveItem(item);
+        return RemoveItem(removedItem);
     }
 
     /// <summary>
@@ -71,7 +73,7 @@ public class ServerWizInventoryBehavior : BehaviorInstance, IClientBehaviorProvi
         if (item is null) {
             throw new NullReferenceException("Item cannot be null.");
         }
-        if (!InventoryItems.Remove(item)) {
+        if (!Items.Remove(item)) {
             Logger.Debug("Tried to remove item with global id {0} that does not exist in player inventory.",
                 Logger.Args(item.m_globalID));
             return false;
@@ -83,13 +85,6 @@ public class ServerWizInventoryBehavior : BehaviorInstance, IClientBehaviorProvi
             return false;
         }
 
-        // Persistent save.
-        var persistentSaveSucceeded = WizardItemCollection.RemoveItem(item);
-        if (!persistentSaveSucceeded) {
-            Logger.Error("Could not remove item with global id {0} from database.", Logger.Args(item.m_globalID));
-            return false;
-        }
-
         return true;
     }
 
@@ -98,18 +93,18 @@ public class ServerWizInventoryBehavior : BehaviorInstance, IClientBehaviorProvi
     /// </summary>
     /// <param name="globalId">The global ID of the item to check.</param>
     /// <returns>True if the inventory contains an item with the specified global ID, otherwise false.</returns>
-    public bool HasItem(ulong globalId) => InventoryItems.Any(item => item.m_globalID == globalId);
+    public bool HasItem(ulong globalId) => Items.Any(item => item.m_globalID == globalId);
 
     /// <summary>
     /// Represents an item in the wizard's inventory.
     /// </summary>
-    public WizClientObjectItem GetItem(ulong globalId) => InventoryItems.FirstOrDefault(item => item.m_globalID == globalId);
+    public WizClientObjectItem GetItem(ulong globalId) => Items.FirstOrDefault(item => item.m_globalID == globalId);
 
     public ClientWizInventoryBehavior GetClientBehaviorInstance(){
         return new ClientWizInventoryBehavior {
             m_numItemsAllowed = s_maxItemsAllowed,
             m_numJewelsAllowed = s_maxJewelsAllowed,
-            m_itemList = InventoryItems.ConvertAll(item => (CoreObject) item)
+            m_itemList = Items.ConvertAll(item => (CoreObject) item)
         };
     }
 }

--- a/src/CoreLib/WizardData/Models/Player/ServerWizInventoryBehavior.cs
+++ b/src/CoreLib/WizardData/Models/Player/ServerWizInventoryBehavior.cs
@@ -105,7 +105,7 @@ public class ServerWizInventoryBehavior : BehaviorInstance, IClientBehaviorProvi
     /// </summary>
     public WizClientObjectItem GetItem(ulong globalId) => InventoryItems.FirstOrDefault(item => item.m_globalID == globalId);
 
-    ClientWizInventoryBehavior IClientBehaviorProvider<ClientWizInventoryBehavior>.GetClientBehaviorInstance(){
+    public ClientWizInventoryBehavior GetClientBehaviorInstance(){
         return new ClientWizInventoryBehavior {
             m_numItemsAllowed = s_maxItemsAllowed,
             m_numJewelsAllowed = s_maxJewelsAllowed,

--- a/src/CoreLib/WizardData/Models/Player/ServerWizInventoryBehavior.cs
+++ b/src/CoreLib/WizardData/Models/Player/ServerWizInventoryBehavior.cs
@@ -1,0 +1,115 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+using Imlight.Common;
+using Imlight.Common.Configuration;
+using Imlight.Common.ObjectProperty.PropertyReflection;
+using Imlight.Common.Utilities;
+using Imlight.CoreLib.WizardData.Implementations;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static Imlight.Common.Caches.TypeCache;
+
+namespace Imlight.CoreLib.WizardData.Models.Player;
+
+[Serializable]
+public class ServerWizInventoryBehavior : BehaviorInstance, IClientBehaviorProvider<ClientWizInventoryBehavior> {
+    private static readonly int s_maxItemsAllowed = ConfigurationManager.Settings.MaxInventoryItems;
+    private static readonly int s_maxJewelsAllowed = ConfigurationManager.Settings.MaxJewelsAllowed;
+
+    public List<ulong> InventoryItemIds { get; set; }
+
+    [JsonIgnore] public List<WizClientObjectItem> InventoryItems { get; set; }
+
+    /// <summary>
+    /// Adds an item to the player's inventory.
+    /// </summary>
+    /// <param name="item">The item to be added.</param>
+    /// <returns>True if the item was successfully added, false otherwise.</returns>
+    public bool AddItem(WizClientObjectItem item) {
+        if (InventoryItems.Count >= s_maxItemsAllowed) {
+            Logger.Debug("Player inventory is full. Cannot add item with global id {0}.", Logger.Args(item.m_globalID));
+            return false;
+        }
+
+        if (HasItem(item.m_globalID)) {
+            Logger.Error("Item with same global id {0} already exists in player inventory.", Logger.Args(item.m_globalID));
+            return false;
+        }
+
+        InventoryItems.Add(item);
+        return true;
+    }
+
+    /// <summary>
+    /// Removes an item from the player's inventory based on its unique identifier.
+    /// </summary>
+    /// <param name="itemId">The unique identifier of the item to be removed.</param>
+    /// <returns><c>true</c> if the item was successfully removed; otherwise, <c>false</c>.</returns>
+    public bool RemoveItem(ulong itemId) {
+        // Get the actual item from the inventory.
+        var item = InventoryItems.Find(i => i.m_globalID == itemId);
+        if (item is null) {
+            Logger.Debug("Tried to remove item with global id {0} that does not exist in player inventory.",
+                Logger.Args(itemId));
+            return false;
+        }
+
+        return RemoveItem(item);
+    }
+
+    /// <summary>
+    /// Removes an item from the player's inventory.
+    /// </summary>
+    /// <param name="item">The item to be removed.</param>
+    /// <returns><c>true</c> if the item was successfully removed; otherwise, <c>false</c>.</returns>
+    public bool RemoveItem(WizClientObjectItem item) {
+        if (item is null) {
+            throw new NullReferenceException("Item cannot be null.");
+        }
+        if (!InventoryItems.Remove(item)) {
+            Logger.Debug("Tried to remove item with global id {0} that does not exist in player inventory.",
+                Logger.Args(item.m_globalID));
+            return false;
+        }
+
+        if (!InventoryItemIds.Remove(item.m_globalID)) {
+            Logger.Debug("Tried to remove item with global id {0} that does not exist in player inventory.",
+                Logger.Args(item.m_globalID));
+            return false;
+        }
+
+        // Persistent save.
+        var persistentSaveSucceeded = WizardItemCollection.RemoveItem(item);
+        if (!persistentSaveSucceeded) {
+            Logger.Error("Could not remove item with global id {0} from database.", Logger.Args(item.m_globalID));
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Checks if the inventory contains an item with the specified global ID.
+    /// </summary>
+    /// <param name="globalId">The global ID of the item to check.</param>
+    /// <returns>True if the inventory contains an item with the specified global ID, otherwise false.</returns>
+    public bool HasItem(ulong globalId) => InventoryItems.Any(item => item.m_globalID == globalId);
+
+    /// <summary>
+    /// Represents an item in the wizard's inventory.
+    /// </summary>
+    public WizClientObjectItem GetItem(ulong globalId) => InventoryItems.FirstOrDefault(item => item.m_globalID == globalId);
+
+    ClientWizInventoryBehavior IClientBehaviorProvider<ClientWizInventoryBehavior>.GetClientBehaviorInstance(){
+        return new ClientWizInventoryBehavior {
+            m_numItemsAllowed = s_maxItemsAllowed,
+            m_numJewelsAllowed = s_maxJewelsAllowed,
+            m_itemList = InventoryItems.ConvertAll(item => (CoreObject) item)
+        };
+    }
+}

--- a/src/CoreLib/WizardData/Models/Player/ServerWizPlayerNameBehavior.cs
+++ b/src/CoreLib/WizardData/Models/Player/ServerWizPlayerNameBehavior.cs
@@ -1,0 +1,50 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+using Imlight.Common.IO;
+using Imlight.CoreLib.Shared.Resources;
+using Imlight.CoreLib.WizardData.Implementations;
+using System;
+using static Imlight.Common.Caches.TypeCache;
+
+namespace Imlight.CoreLib.WizardData.Models.Player;
+
+[Serializable]
+public class ServerWizPlayerNameBehavior : BehaviorInstance, IClientBehaviorProvider<ClientWizPlayerNameBehavior> {
+    public uint NameIndices;
+    public bool UseRank;
+    public eGender Gender;
+    public eRace Race;
+    public ByteString BadgeTitle;
+    public uint ChatPermissions;
+    public uint PvpIconId;
+    public uint LocaleId;
+    public bool FriendlyPlayer;
+    public bool Volunteer;
+    public uint GuildName;
+    public WideByteString NameOverride;
+
+    public string GetWizardName() {
+        var actualName = WizardNameBank.GetEnglishName(NameIndices, Gender);
+        return actualName;
+    }
+
+    public ClientWizPlayerNameBehavior GetClientBehaviorInstance() {
+        return new ClientWizPlayerNameBehavior {
+            m_nameKeys = NameIndices,
+            m_useRank = UseRank,
+            m_eGender = Gender,
+            m_eRace = Race,
+            m_badgeTitle = BadgeTitle,
+            m_chatPermissions = ChatPermissions,
+            m_pvpIconID = PvpIconId,
+            m_localeID = LocaleId,
+            m_friendlyPlayer = FriendlyPlayer,
+            m_volunteer = Volunteer,
+            m_guildName = GuildName,
+            m_wsNameOverride = NameOverride
+        };
+    }
+}

--- a/src/CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/CoreLib/WizardData/Models/Player/Wizard.cs
@@ -36,10 +36,8 @@ public enum MagicSchool {
 public class Wizard : IDisposable {
     private const float OrientationCompressionFactor = CharacterHelper.OrientationCompressionFactor;
 
-    public ulong AccountId { get; set; }               // <
-    public ulong CharId { get; set; }                  //  | These values are never subject to change.
-    public uint NameIndices { get; set; }              //  |
-    public WideByteString NameOverride { get; set; }   // <
+    public ulong AccountId { get; set; }
+    public ulong CharId { get; set; }
     public MagicSchool WizardSchool { get; set; }
     public byte Level { get; set; }
     public int TrainingPoints { get; set; }
@@ -71,6 +69,7 @@ public class Wizard : IDisposable {
     }
 
     public WizardCharacterBehavior WizardAvatar { get; set; }
+    public ServerWizPlayerNameBehavior PlayerNameBehavior { get; set; }
     public ServerWizInventoryBehavior InventoryBehavior { get; set; }
     public ServerWizEquipmentBehavior EquipmentBehavior { get; set; }
     public WizGameStats GameStats { get; set; }
@@ -115,7 +114,6 @@ public class Wizard : IDisposable {
     public Wizard(MagicSchool wizardSchoolType, WizardCharacterBehavior avatar, uint nameIndices, byte level = 1) {
         CharId = RandomGen.GenerateGUID();
         WizardSchool = wizardSchoolType;
-        NameIndices = nameIndices;
         Level = level;
         Zone = ConfigurationManager.Settings.StartingZone;
         World = ConfigurationManager.Settings.StartingWorld;
@@ -124,6 +122,7 @@ public class Wizard : IDisposable {
         WizardAvatar = avatar;
         InitializeDefaultInventory();
         InitializeDefaultEquipment();
+        InitializePlayerName(nameIndices);
         GameStats = new WizGameStats();
     }
 
@@ -201,8 +200,7 @@ public class Wizard : IDisposable {
         WizardCollection.UpdateCharacterItems(this);
 
         // Debug log.
-        var actualName = WizardNameBank.GetEnglishName(NameIndices, WizardAvatar.m_eGender);
-        Logger.Debug("{0} equips item {1}", Logger.Args(actualName, itemId));
+        Logger.Debug("{0} equips item {1}", Logger.Args(PlayerNameBehavior.GetWizardName(), itemId));
 
         equipEffects = AddEffectsFromTemplate(template);
         return true;
@@ -233,8 +231,7 @@ public class Wizard : IDisposable {
         WizardCollection.UpdateCharacterItems(this);
 
         // Debug log.
-        var actualName = WizardNameBank.GetEnglishName(NameIndices, WizardAvatar.m_eGender);
-        Logger.Debug("{0} unequips item {1}", Logger.Args(actualName, itemId));
+        Logger.Debug("{0} unequips item {1}", Logger.Args(PlayerNameBehavior.GetWizardName(), itemId));
 
         unequipEffects = RemoveEffectsFromTemplate(template);
         return true;
@@ -242,8 +239,7 @@ public class Wizard : IDisposable {
 
     public void InitializeGameEffects() {
         // Debug log.
-        var actualWizardName = WizardNameBank.GetEnglishName(NameIndices, WizardAvatar.m_eGender);
-        Logger.Debug("{0} is applying effects for all equipment.", Logger.Args(actualWizardName));
+        Logger.Debug("{0} is applying effects for all equipment.", Logger.Args(PlayerNameBehavior.GetWizardName()));
 
         // Get all active effects from what we currently have equipped.
         foreach (var item in EquipmentBehavior.EquippedItems) {
@@ -255,7 +251,7 @@ public class Wizard : IDisposable {
             var activatedEffects = AddEffectsFromTemplate(template);
 
             Logger.Debug("{0} Applied {1} effects for item {2}.",
-                Logger.Args(actualWizardName, activatedEffects.Count, template.m_objectName));
+                Logger.Args(PlayerNameBehavior.GetWizardName(), activatedEffects.Count, template.m_objectName));
         }
     }
 
@@ -334,6 +330,21 @@ public class Wizard : IDisposable {
             SlotList = new List<EquipmentSlot>(),
             EquippedItemIds = new List<ulong>(),
             EquippedItems = new List<WizClientObjectItem>(),
+        };
+    }
+
+    private void InitializePlayerName(uint nameIndices) {
+        PlayerNameBehavior = new ServerWizPlayerNameBehavior {
+            m_nameKeys = nameIndices,
+            m_useRank = false,
+            m_eGender = WizardAvatar.m_eGender,
+            m_eRace = WizardAvatar.m_eRace,
+            m_chatPermissions = 0,
+            m_pvpIconID = 0,
+            m_localeID = 0,
+            m_friendlyPlayer = true,
+            m_volunteer = false,
+            m_guildName = 0,
         };
     }
 

--- a/src/CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/CoreLib/WizardData/Models/Player/Wizard.cs
@@ -69,13 +69,13 @@ public class Wizard : IDisposable {
             }
         }
     }
-    public WizardCharacterBehavior WizardAvatar { get; set; }
-    public WizGameStats GameStats { get; set; }
-    public List<ulong> InventoryItemIds { get; set; }
-    public List<EquippedSlotInfo> EquippedItems { get; set; }
 
-    // Imlight doesn't disassociate the inventory from equipment. An equipped item is still in the inventory.
-    [JsonIgnore] public List<WizClientObjectItem> InventoryItems { get; set; }
+    public WizardCharacterBehavior WizardAvatar { get; set; }
+    public ServerWizInventoryBehavior InventoryBehavior { get; set; }
+    public ServerWizEquipmentBehavior EquipmentBehavior { get; set; }
+    public WizGameStats GameStats { get; set; }
+
+    [JsonIgnore] public Account Account;
     [JsonIgnore] public WizClientObject GameObject;
     [JsonIgnore] public List<GameEffectBase> GameEffects = new();
     [JsonIgnore] public string GameServerIp;
@@ -115,15 +115,16 @@ public class Wizard : IDisposable {
     public Wizard(MagicSchool wizardSchoolType, WizardCharacterBehavior avatar, uint nameIndices, byte level = 1) {
         CharId = RandomGen.GenerateGUID();
         WizardSchool = wizardSchoolType;
-        WizardAvatar = avatar;
         NameIndices = nameIndices;
         Level = level;
         Zone = ConfigurationManager.Settings.StartingZone;
         World = ConfigurationManager.Settings.StartingWorld;
-        GameStats = new WizGameStats();
-        EquippedItems = new List<EquippedSlotInfo>();
 
+        // Do behaviors.
+        WizardAvatar = avatar;
         InitializeDefaultInventory();
+        InitializeDefaultEquipment();
+        GameStats = new WizGameStats();
     }
 
     public void SetCachedLocation(Vector3 loc) => Location = loc;
@@ -166,255 +167,83 @@ public class Wizard : IDisposable {
         return true;
     }
 
-    // todo: Regions are a sign of a class becoming monolithic.
-    #region Inventory
+    public bool InventoryToEquipmentTransfer(ulong itemId, out List<GameEffectBase> equipEffects) {
+        equipEffects = null;
 
-    public bool InventoryAddItem(WizClientObjectItem item) {
-        if (item is null) {
-            throw new NullReferenceException("Item cannot be null.");
-        }
-        if (InventoryHasItem(item.m_globalID)) {
-            Logger.Error("Item with same global id {0} already exists in player inventory.", Logger.Args(item.m_globalID));
+        // Remove the item from the inventory.
+        var invRemoveResult = InventoryBehavior.RemoveItem(itemId);
+        if (!invRemoveResult) {
+            Logger.Warning("Tried to equip item with global id {0} that does not exist in player inventory.", Logger.Args(itemId));
             return false;
         }
 
-        item.m_characterId = (GID) CharId;
-        InventoryItems.Add(item);
-        InventoryItemIds.Add(item.m_globalID);
-
-        // Persistent save.
-        var persistentSaveSucceeded = WizardItemCollection.AddItem(item);
-        if (!persistentSaveSucceeded) {
-            Logger.Error("Could not save item with global id {0} to database.", Logger.Args(item.m_globalID));
-            return false;
-        }
-
-        return true;
-    }
-
-    public bool InventoryRemoveItem(ulong itemId) {
-        // Get the actual item from the inventory.
-        var item = InventoryItems.Find(i => i.m_globalID == itemId);
-        if (item is null) {
-            Logger.Debug("Tried to remove item with global id {0} that does not exist in player inventory.",
-                Logger.Args(itemId));
-            return false;
-        }
-
-        return InventoryRemoveItem(item);
-    }
-
-    public bool InventoryRemoveItem(WizClientObjectItem item) {
-        if (item is null) {
-            throw new NullReferenceException("Item cannot be null.");
-        }
-        if (!InventoryItems.Remove(item)) {
-            Logger.Debug("Tried to remove item with global id {0} that does not exist in player inventory.",
-                Logger.Args(item.m_globalID));
-            return false;
-        }
-
-        if (!InventoryItemIds.Remove(item.m_globalID)) {
-            Logger.Debug("Tried to remove item with global id {0} that does not exist in player inventory.",
-                Logger.Args(item.m_globalID));
-            return false;
-        }
-
-        // Persistent save.
-        var persistentSaveSucceeded = WizardItemCollection.RemoveItem(item);
-        if (!persistentSaveSucceeded) {
-            Logger.Error("Could not remove item with global id {0} from database.", Logger.Args(item.m_globalID));
-            return false;
-        }
-
-        return true;
-    }
-
-    public bool InventoryHasItem(ulong itemId) => InventoryItems.Any(i => i.m_globalID == itemId);
-
-    public WizClientObjectItem InventoryGetItem(ulong itemId) => InventoryItems.Find(i => i.m_globalID == itemId);
-
-    private void InitializeDefaultInventory() {
-        InventoryItems = new List<WizClientObjectItem>();
-        InventoryItemIds = new List<ulong>();
-
-        // Add default items to the inventory.
-        var itemsToAdd = new List<WizClientObjectItem>();
-        _defaultItems.ForEach(templateId => {
-            var coreObject = new WizClientObjectItem {
-                m_globalID = RandomGen.GenerateGUID(),
-                m_templateID = (GID) templateId,
-                m_characterId = (GID) CharId
-            };
-
-            itemsToAdd.Add(coreObject);
-            InventoryItemIds.Add(coreObject.m_globalID);
-        });
-
-        // This is a different method that bulk uploads items to the database.
-        var success = WizardItemCollection.AddDefaultItems(itemsToAdd);
-        if (!success) {
-            Logger.Error("Could not add default items for Wizard {0} to database.", Logger.Args(CharId));
-        }
-    }
-
-    #endregion
-
-    #region Equipment
-
-    public List<GameEffectBase> EquipmentEquipItem(ulong itemId) {
-        // These validations also occur in the EquipmentService, where they are properly dealt with.
-        // They must also happen here, as the Wizard does not keep track of the equipment items, only their IDs.
-        if (EquipmentHasEquippedItem(itemId)) {
+        // Add the item to the equipment.
+        var equipResult = EquipmentBehavior.EquipItem(itemId, out var template);
+        if (!equipResult) {
             Logger.Warning("Tried to equip item with global id {0} that is already equipped.", Logger.Args(itemId));
-            return null;
+            return false;
         }
-
-        // We're still dealing with just an item ID, so we need to get the actual item from the inventory.
-        var item = InventoryGetItem(itemId);
-        if (item is null) {
-            Logger.Warning("Tried to equip item with global id {0} that does not exist in player inventory.", Logger.Args(itemId));
-            return null;
-        }
-
-        // Get the slot name hash of the item.
-        var slotNameHash = ItemHelper.GetItemSlotHash(item);
-        if (slotNameHash == 0) {
-            Logger.Warning("Tried to equip item with global id {0} that does not have a slot name adjective.", Logger.Args(itemId));
-            return null;
-        }
-
-        SetEquipmentSlot(slotNameHash, itemId);
 
         // Persistent save.
-        // The equipped items array is a fairly small binary, so we can just save the whole thing.
-        WizardCollection.UpdateCharacterEquipment(this);
-
-        // Update the actual behavior.
-        WizardObjectLoader.SetEquipmentBehavior(GameObject, this);
-
-        // Apply effects.
-        var template = (WizItemTemplate) CoreObjectFactory.GetCoreTemplate(item.m_templateID);
-        var effects = AddEffectsFromTemplate(template);
+        WizardCollection.UpdateCharacterItems(this);
 
         // Debug log.
         var actualName = WizardNameBank.GetEnglishName(NameIndices, WizardAvatar.m_eGender);
-        Logger.Debug("{0} equips item in slot {1}.", Logger.Args(actualName, slotNameHash));
+        Logger.Debug("{0} equips item {1}", Logger.Args(actualName, itemId));
 
-        return effects;
+        equipEffects = AddEffectsFromTemplate(template);
+        return true;
     }
 
-    public List<GameEffectBase> EquipmentUnequipItem(ulong itemId) {
-        // These validations also occur in the EquipmentService, where they are properly dealt with.
-        // They must also happen here, as the Wizard does not keep track of the equipment items, only their IDs.
-        if (!EquipmentHasEquippedItem(itemId)) {
+    public bool EquipmentToInventoryTransfer(ulong itemId, out List<GameEffectBase> unequipEffects) {
+        unequipEffects = null;
+
+        // Get the actual item.
+        var item = EquipmentBehavior.EquippedItems.FirstOrDefault(i => i.m_globalID == itemId);
+
+        // Remove the item from the equipment.
+        var unequipResult = EquipmentBehavior.UnequipItem(itemId, out var template);
+        if (!unequipResult) {
             Logger.Warning("Tried to unequip item with global id {0} that is not equipped.", Logger.Args(itemId));
-            return null;
+            return false;
         }
 
-        // We're still dealing with just an item ID, so we need to get the actual item from the inventory.
-        var item = InventoryGetItem(itemId);
-        if (item is null) {
-            Logger.Warning("Tried to equip item with global id {0} that does not exist in player inventory.", Logger.Args(itemId));
-            return null;
+        // Add the item to the inventory.
+        var invAddResult = InventoryBehavior.AddItem(item);
+        if (!invAddResult) {
+            Logger.Warning("Tried to add item with global id {0} to inventory, but it already exists.", Logger.Args(itemId));
+            return false;
         }
-
-        // Get the slot name hash of the item.
-        var slotNameHash = ItemHelper.GetItemSlotHash(item);
-        if (slotNameHash == 0) {
-            Logger.Warning("Tried to equip item with global id {0} that does not have a slot name adjective.", Logger.Args(itemId));
-            return null;
-        }
-
-        ClearEquipmentSlot(slotNameHash);
 
         // Persistent save.
-        // The equipped items array is a fairly small binary, so we can just save the whole thing.
-        WizardCollection.UpdateCharacterEquipment(this);
-
-        // Update the actual behavior.
-        WizardObjectLoader.SetEquipmentBehavior(GameObject, this);
-
-        // Remove effects.
-        var template = (WizItemTemplate) CoreObjectFactory.GetCoreTemplate(item.m_templateID);
-        var effects = RemoveEffectsFromTemplate(template);
+        WizardCollection.UpdateCharacterItems(this);
 
         // Debug log.
         var actualName = WizardNameBank.GetEnglishName(NameIndices, WizardAvatar.m_eGender);
-        Logger.Debug("{0} unequips item in slot {1}.", Logger.Args(actualName, slotNameHash));
+        Logger.Debug("{0} unequips item {1}", Logger.Args(actualName, itemId));
 
-        return effects;
+        unequipEffects = RemoveEffectsFromTemplate(template);
+        return true;
     }
 
-    public bool EquipmentHasEquippedItem(ulong itemId) => EquippedItems.Any(i => i.m_itemID == itemId);
-
-    public bool EquipmentSlotInUse(ByteString slotName, out byte index) {
-        var slotHash = StringHash.Compute(slotName);
-        index = (byte) EquippedItems.FindIndex(i => i.m_itemSlotNameID == slotHash);
-        return index != 255;
-    }
-
-    public ulong EquipmentGetItem(byte index) => EquippedItems[index].m_itemID;
-
-    public IEnumerable<(WizClientObjectItem, WizItemTemplate)> EquipmentGetAllItems() {
-        var items = new List<(WizClientObjectItem, WizItemTemplate)>();
-        foreach (var slot in EquippedItems) {
-            if (slot.m_itemID != 0) {
-                var item = InventoryGetItem(slot.m_itemID);
-                if (item is not null) {
-                    var template = (WizItemTemplate) CoreObjectFactory.GetCoreTemplate(item.m_templateID);
-                    items.Add((item, template));
-                }
-            }
-        }
-
-        return items;
-    }
-
-    public byte EquipmentGetItemSlotIndex(ulong itemId) {
-        int index = EquippedItems.FindIndex(i => i.m_itemID == (GID) itemId);
-
-        return (byte) index;
-    }
-
-    public void ApplyEffectsForAllEquipment() {
+    public void InitializeGameEffects() {
+        // Debug log.
         var actualWizardName = WizardNameBank.GetEnglishName(NameIndices, WizardAvatar.m_eGender);
         Logger.Debug("{0} is applying effects for all equipment.", Logger.Args(actualWizardName));
 
-        foreach (var item in EquipmentGetAllItems()) {
-            var template = item.Item2;
+        // Get all active effects from what we currently have equipped.
+        foreach (var item in EquipmentBehavior.EquippedItems) {
+            var template = ItemHelper.GetItemTemplate(item);
+            if (template is null) {
+                continue;
+            }
 
             var activatedEffects = AddEffectsFromTemplate(template);
+
             Logger.Debug("{0} Applied {1} effects for item {2}.",
                 Logger.Args(actualWizardName, activatedEffects.Count, template.m_objectName));
         }
     }
-
-    private void SetEquipmentSlot(uint slotHash, ulong itemId) {
-        // Find if this slot exists already. If so, remove it.
-        var existingSlot = EquippedItems.Find(i => i.m_itemSlotNameID == slotHash);
-        if (existingSlot is not null) {
-            EquippedItems.Remove(existingSlot);
-        }
-
-        // Create the new slot.
-        var newSlot = new EquippedSlotInfo {
-            m_itemSlotNameID = slotHash,
-            m_itemID = (GID) itemId
-        };
-        EquippedItems.Add(newSlot);
-    }
-
-    private void ClearEquipmentSlot(uint slotHash) {
-        var existingSlot = EquippedItems.Find(i => i.m_itemSlotNameID == slotHash);
-        if (existingSlot is not null) {
-            EquippedItems.Remove(existingSlot);
-        }
-    }
-
-    #endregion
-
-    #region Game Effects
 
     private List<GameEffectBase> AddEffectsFromTemplate(WizItemTemplate template) {
         var addedEffects = new List<GameEffectBase>();
@@ -430,8 +259,8 @@ public class Wizard : IDisposable {
                 CharacterEffectHelper.AddGameEffectToStats(this.GameStats, canonicalEffectName, canonicalEffect);
             }
 
-            addedEffects.Add(gameEffect);
             GameEffects.Add(gameEffect);
+            addedEffects.Add(gameEffect);
         }
 
         return addedEffects;
@@ -452,8 +281,6 @@ public class Wizard : IDisposable {
             }
 
             removedEffects.Add(gameEffect);
-
-            // Remove the effect.
             GameEffects.Remove(gameEffect);
 
             if (gameEffect is WizStatisticEffect canonicalEffect) {
@@ -465,7 +292,38 @@ public class Wizard : IDisposable {
         return removedEffects;
     }
 
-    #endregion
+    private void InitializeDefaultInventory() {
+        InventoryBehavior = new ServerWizInventoryBehavior {
+            InventoryItems = new List<WizClientObjectItem>(),
+            InventoryItemIds = new List<ulong>()
+        };
+
+        // Add default items to the inventory.
+        var itemsToAdd = new List<WizClientObjectItem>();
+        _defaultItems.ForEach(templateId => {
+            var coreObject = new WizClientObjectItem {
+                m_globalID = RandomGen.GenerateGUID(),
+                m_templateID = (GID) templateId,
+                m_characterId = (GID) CharId
+            };
+
+            itemsToAdd.Add(coreObject);
+            InventoryBehavior.InventoryItemIds.Add(coreObject.m_globalID);
+        });
+
+        // This is a different method that bulk uploads items to the database.
+        var success = WizardItemCollection.AddDefaultItems(itemsToAdd);
+        if (!success) {
+            Logger.Error("Could not add default items for Wizard {0} to database.", Logger.Args(CharId));
+        }
+    }
+
+    private void InitializeDefaultEquipment() {
+        EquipmentBehavior = new ServerWizEquipmentBehavior {
+            SlotList = new List<EquipmentSlot>(),
+            EquippedItems = new List<WizClientObjectItem>(),
+        };
+    }
 
     public void Dispose() =>
         // If this object is being disposed, the player probably left the server.

--- a/src/CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/CoreLib/WizardData/Models/Player/Wizard.cs
@@ -60,6 +60,7 @@ public class Wizard : IDisposable {
     public ServerWizEquipmentBehavior EquipmentBehavior { get; set; }
     public ServerMagicSchoolBehavior MagicSchoolBehavior { get; set; }
     public ServerSpellbookBehavior SpellbookBehavior { get; set; }
+    public ServerMountOwnerBehavior MountOwnerBehavior { get; set; }
     public WizGameStats GameStats { get; set; }
 
     [JsonIgnore] public Account Account;
@@ -111,6 +112,7 @@ public class Wizard : IDisposable {
         InitializePlayerName(nameIndices);
         InitializeMagicSchoolBehavior(wizardSchoolType, level);
         InitializeSpellbookBehavior();
+        InitializeMountOwnerBehavior();
         GameStats = new WizGameStats();
     }
 
@@ -181,6 +183,18 @@ public class Wizard : IDisposable {
             return false;
         }
 
+        // If this object is a mount, we'll also want to update the mount owner behavior.
+        if (slot.SlotType == EquipmentSlotType.Mount) {
+            var mountEquipSuccess = MountOwnerBehavior.EquipMount(template, inventoryItem);
+            if (!mountEquipSuccess) {
+                Logger.Warning("Could not equip mount {0} to player {1}.", Logger.Args(template.m_objectName, PlayerNameBehavior.GetWizardName()));
+                return false;
+            }
+
+            // Persistent save.
+            WizardCollection.UpdateCharacterMount(this);
+        }
+
         // Persistent save.
         WizardCollection.UpdateCharacterItems(this);
 
@@ -197,6 +211,7 @@ public class Wizard : IDisposable {
         // Get the actual item. We'll also grab the template to remove the effects from the wizard.
         var item = EquipmentBehavior.EquippedItems.FirstOrDefault(i => i.m_globalID == itemId);
         var template = ItemHelper.GetItemTemplate(item);
+        var slot = ItemHelper.GetItemSlot(template);
 
         // Remove the item from the equipment.
         var unequipResult = EquipmentBehavior.UnequipItem(itemId);
@@ -210,6 +225,14 @@ public class Wizard : IDisposable {
         if (!invAddResult) {
             Logger.Warning("Tried to add item with global id {0} to inventory, but it already exists.", Logger.Args(itemId));
             return false;
+        }
+
+        // If this object is a mount, we'll also want to update the mount owner behavior.
+        if (slot.SlotType == EquipmentSlotType.Mount) {
+            MountOwnerBehavior.UnequipMount();
+
+            // Persistent save.
+            WizardCollection.UpdateCharacterMount(this);
         }
 
         // Persistent save.
@@ -349,6 +372,10 @@ public class Wizard : IDisposable {
         SpellbookBehavior = new ServerSpellbookBehavior {
             SpellIdList = new List<SpellIDTracker>()
         };
+    }
+
+    private void InitializeMountOwnerBehavior() {
+        MountOwnerBehavior = new ServerMountOwnerBehavior();
     }
 
     public void Dispose() =>

--- a/src/CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/CoreLib/WizardData/Models/Player/Wizard.cs
@@ -167,18 +167,18 @@ public class Wizard : IDisposable {
         return true;
     }
 
-    public bool InventoryToEquipmentTransfer(ulong itemId, out List<GameEffectBase> equipEffects) {
+    public bool InventoryToEquipmentTransfer(ulong itemId, out List<GameEffectBase> equipEffects, out List<GameEffectBase> unequipEffects) {
         equipEffects = null;
+        unequipEffects = null;
 
         // Remove the item from the inventory.
-        var invRemoveResult = InventoryBehavior.RemoveItem(itemId);
-        if (!invRemoveResult) {
+        if (!InventoryBehavior.RemoveItem(itemId, out var itemRemoved)) {
             Logger.Warning("Tried to equip item with global id {0} that does not exist in player inventory.", Logger.Args(itemId));
             return false;
         }
 
         // Add the item to the equipment.
-        var equipResult = EquipmentBehavior.EquipItem(itemId, out var template);
+        var equipResult = EquipmentBehavior.EquipItem(itemRemoved, out var template, out var removedTemplate);
         if (!equipResult) {
             Logger.Warning("Tried to equip item with global id {0} that is already equipped.", Logger.Args(itemId));
             return false;
@@ -190,6 +190,11 @@ public class Wizard : IDisposable {
         // Debug log.
         var actualName = WizardNameBank.GetEnglishName(NameIndices, WizardAvatar.m_eGender);
         Logger.Debug("{0} equips item {1}", Logger.Args(actualName, itemId));
+
+        // If the equipment behavior removed an item, we need to remove its effects.
+        if (removedTemplate is not null) {
+            unequipEffects = RemoveEffectsFromTemplate(removedTemplate);
+        }
 
         equipEffects = AddEffectsFromTemplate(template);
         return true;
@@ -294,21 +299,18 @@ public class Wizard : IDisposable {
 
     private void InitializeDefaultInventory() {
         InventoryBehavior = new ServerWizInventoryBehavior {
-            InventoryItems = new List<WizClientObjectItem>(),
+            Items = new List<WizClientObjectItem>(),
             InventoryItemIds = new List<ulong>()
         };
 
         // Add default items to the inventory.
         var itemsToAdd = new List<WizClientObjectItem>();
         _defaultItems.ForEach(templateId => {
-            var coreObject = new WizClientObjectItem {
-                m_globalID = RandomGen.GenerateGUID(),
-                m_templateID = (GID) templateId,
-                m_characterId = (GID) CharId
-            };
+            var cObj = (WizClientObjectItem) CoreObjectFactory.FinalizeCoreObject(templateId);
+            cObj.m_characterId = (GID) CharId;
 
-            itemsToAdd.Add(coreObject);
-            InventoryBehavior.InventoryItemIds.Add(coreObject.m_globalID);
+            itemsToAdd.Add(cObj);
+            InventoryBehavior.InventoryItemIds.Add(cObj.m_globalID);
         });
 
         // This is a different method that bulk uploads items to the database.
@@ -321,6 +323,7 @@ public class Wizard : IDisposable {
     private void InitializeDefaultEquipment() {
         EquipmentBehavior = new ServerWizEquipmentBehavior {
             SlotList = new List<EquipmentSlot>(),
+            EquippedItemIds = new List<ulong>(),
             EquippedItems = new List<WizClientObjectItem>(),
         };
     }

--- a/src/CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/CoreLib/WizardData/Models/Player/Wizard.cs
@@ -172,13 +172,26 @@ public class Wizard : IDisposable {
         unequipEffects = null;
 
         // Remove the item from the inventory.
-        if (!InventoryBehavior.RemoveItem(itemId, out var itemRemoved)) {
+        if (!InventoryBehavior.RemoveItem(itemId, out var inventoryItem)) {
             Logger.Warning("Tried to equip item with global id {0} that does not exist in player inventory.", Logger.Args(itemId));
             return false;
         }
 
+        // Get the template for this item. Using this template we can get the slot this object should be on.
+        var template = ItemHelper.GetItemTemplate(inventoryItem);
+        var slot = ItemHelper.GetItemSlot(template);
+
+        // Get the item that is currently in the slot, if there is one. We want to remove its effects.
+        var replacedItem = EquipmentBehavior.GetItemInSlot(slot.SlotType);
+        if (replacedItem != null) {
+            if (!EquipmentToInventoryTransfer(replacedItem.m_globalID, out unequipEffects)) {
+                Logger.Warning("Could not replace item {0} from slot {1}.", Logger.Args(replacedItem.m_globalID, slot.SlotType));
+                return false;
+            }
+        }
+
         // Add the item to the equipment.
-        var equipResult = EquipmentBehavior.EquipItem(itemRemoved, out var template, out var removedTemplate);
+        var equipResult = EquipmentBehavior.EquipItem(inventoryItem, slot.SlotType);
         if (!equipResult) {
             Logger.Warning("Tried to equip item with global id {0} that is already equipped.", Logger.Args(itemId));
             return false;
@@ -191,11 +204,6 @@ public class Wizard : IDisposable {
         var actualName = WizardNameBank.GetEnglishName(NameIndices, WizardAvatar.m_eGender);
         Logger.Debug("{0} equips item {1}", Logger.Args(actualName, itemId));
 
-        // If the equipment behavior removed an item, we need to remove its effects.
-        if (removedTemplate is not null) {
-            unequipEffects = RemoveEffectsFromTemplate(removedTemplate);
-        }
-
         equipEffects = AddEffectsFromTemplate(template);
         return true;
     }
@@ -203,11 +211,12 @@ public class Wizard : IDisposable {
     public bool EquipmentToInventoryTransfer(ulong itemId, out List<GameEffectBase> unequipEffects) {
         unequipEffects = null;
 
-        // Get the actual item.
+        // Get the actual item. We'll also grab the template to remove the effects from the wizard.
         var item = EquipmentBehavior.EquippedItems.FirstOrDefault(i => i.m_globalID == itemId);
+        var template = ItemHelper.GetItemTemplate(item);
 
         // Remove the item from the equipment.
-        var unequipResult = EquipmentBehavior.UnequipItem(itemId, out var template);
+        var unequipResult = EquipmentBehavior.UnequipItem(itemId);
         if (!unequipResult) {
             Logger.Warning("Tried to unequip item with global id {0} that is not equipped.", Logger.Args(itemId));
             return false;

--- a/src/CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/CoreLib/WizardData/Models/Player/Wizard.cs
@@ -22,26 +22,12 @@ using Imlight.CoreLib.Game.Effects;
 
 namespace Imlight.CoreLib.WizardData.Models.Player;
 
-public enum MagicSchool {
-    Ice = 72777,
-    Life = 2330892,
-    Fire = 2343174,
-    Myth = 2448141,
-    Death = 78318724,
-    Storm = 83375795,
-    Balance = 1027491821,
-}
-
 [Serializable]
 public class Wizard : IDisposable {
     private const float OrientationCompressionFactor = CharacterHelper.OrientationCompressionFactor;
 
     public ulong AccountId { get; set; }
     public ulong CharId { get; set; }
-    public MagicSchool WizardSchool { get; set; }
-    public byte Level { get; set; }
-    public int TrainingPoints { get; set; }
-    public int XpToNextLevel { get; set; }
     public string Zone { get; set; }
     public string ZoneDisplayName { get; set; }
     public byte World { get; set; }
@@ -72,6 +58,8 @@ public class Wizard : IDisposable {
     public ServerWizPlayerNameBehavior PlayerNameBehavior { get; set; }
     public ServerWizInventoryBehavior InventoryBehavior { get; set; }
     public ServerWizEquipmentBehavior EquipmentBehavior { get; set; }
+    public ServerMagicSchoolBehavior MagicSchoolBehavior { get; set; }
+    public ServerSpellbookBehavior SpellbookBehavior { get; set; }
     public WizGameStats GameStats { get; set; }
 
     [JsonIgnore] public Account Account;
@@ -113,8 +101,6 @@ public class Wizard : IDisposable {
     // Constructor: Used for character creation.
     public Wizard(MagicSchool wizardSchoolType, WizardCharacterBehavior avatar, uint nameIndices, byte level = 1) {
         CharId = RandomGen.GenerateGUID();
-        WizardSchool = wizardSchoolType;
-        Level = level;
         Zone = ConfigurationManager.Settings.StartingZone;
         World = ConfigurationManager.Settings.StartingWorld;
 
@@ -123,6 +109,8 @@ public class Wizard : IDisposable {
         InitializeDefaultInventory();
         InitializeDefaultEquipment();
         InitializePlayerName(nameIndices);
+        InitializeMagicSchoolBehavior(wizardSchoolType, level);
+        InitializeSpellbookBehavior();
         GameStats = new WizGameStats();
     }
 
@@ -153,12 +141,9 @@ public class Wizard : IDisposable {
     }
 
     public bool SetLevel(byte level) {
-        if (level > ConfigurationManager.Settings.MaxLevel) {
-            Logger.Warning("Tried to set character {0} level to {1}, which is past max level.", Logger.Args(CharId, level));
+        if (!MagicSchoolBehavior.SetLevel(level)) {
             return false;
         }
-
-        Level = level;
 
         // Persistent save.
         WizardCollection.UpdateCharacterLevel(this);
@@ -335,16 +320,34 @@ public class Wizard : IDisposable {
 
     private void InitializePlayerName(uint nameIndices) {
         PlayerNameBehavior = new ServerWizPlayerNameBehavior {
-            m_nameKeys = nameIndices,
-            m_useRank = false,
-            m_eGender = WizardAvatar.m_eGender,
-            m_eRace = WizardAvatar.m_eRace,
-            m_chatPermissions = 0,
-            m_pvpIconID = 0,
-            m_localeID = 0,
-            m_friendlyPlayer = true,
-            m_volunteer = false,
-            m_guildName = 0,
+            NameIndices = nameIndices,
+            UseRank = false,
+            Gender = WizardAvatar.m_eGender,
+            Race = WizardAvatar.m_eRace,
+            ChatPermissions = 0,
+            PvpIconId = 0,
+            LocaleId = 0,
+            FriendlyPlayer = true,
+            Volunteer = false,
+            GuildName = 0,
+        };
+    }
+
+    private void InitializeMagicSchoolBehavior(MagicSchool school, byte level) {
+        MagicSchoolBehavior = new ServerMagicSchoolBehavior {
+            MagicSchool = school,
+            ExperiencePoints = 0,
+            Level = level,
+            TrainingPoints = 0,
+            OverflowXp = 0,
+            LevelIsLocked = 0,
+            EquippedTeleportEffect = 0,
+        };
+    }
+
+    private void InitializeSpellbookBehavior() {
+        SpellbookBehavior = new ServerSpellbookBehavior {
+            SpellIdList = new List<SpellIDTracker>()
         };
     }
 

--- a/src/Director/Config/Imlight.ini
+++ b/src/Director/Config/Imlight.ini
@@ -33,6 +33,7 @@ StartingWorld = 1
 BaseGoldPouch = 1000000
 MaxLevel = 200
 MaxInventoryItems = 75
+MaxJewelsAllowed = 100
 MaxFriends = 100
 
 [Patch Server]

--- a/src/Director/Config/Imlight.ini
+++ b/src/Director/Config/Imlight.ini
@@ -32,6 +32,8 @@ StartingZone = WizardCity/WC_Streets/WC_Unicorn
 StartingWorld = 1
 BaseGoldPouch = 1000000
 MaxLevel = 200
+MaxInventoryItems = 75
+MaxFriends = 100
 
 [Patch Server]
 ; The internal name for the patch server. This is not a realm name.


### PR DESCRIPTION
Misleading branch name. Started as a fix for mounts but evolved into fixing all major problems with inventory/equipment.

## Fixes
* Fixed unreliable public item order, causing the wrong item to be unequipped right after attach
* Fixed mounts losing their model on Wizard reload

Largest thing of note is the `IClientBehaviorProvider<T>` and `IClientTypeProvider<T>`. Both of these interfaces should allow server side abstractions over the normal ones that come from the game client. Best examples given are the new Wizard behaviors.

The `Wizard` class has been split into server-side behaviors that derive from the aforementioned interfaces.

The `WizardObjectLoader` now uses these interface methods to gather client behaviors from the server types themselves.

## Changelog
* Added `MaxInventoryItems` to configuration
* Added `MaxJewelsAllowed` to configuration
* Added `IClientBehaviorProvider`
* Added `IClientTypeProvider`
* Changed `Wizard` to use server behaviors rather than monolithic type
* Moved `ChatLog` to `Models.Misc`
* Moved `InfractionModels` to `Models.Misc