### PR TITLE
`Ref/cleanup` --> `quality-assurance`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,3 +354,4 @@ src/.claudiaideconfig
 act.vault
 /src/Backend/ImlightEmbeddedDatabase/Databases/Playerdata/
 src/Director/cache
+src/cache

--- a/src/CoreLib/Game/Services/AttachService.cs
+++ b/src/CoreLib/Game/Services/AttachService.cs
@@ -22,9 +22,7 @@ namespace Imlight.CoreLib.Game.Services;
 internal class AttachService : MessageService {
     public AttachService(SessionActor sessionActor) : base(sessionActor) { }
 
-    protected static Props Props(SessionActor parentActor) {
-        return Akka.Actor.Props.Create(() => new AttachService(parentActor));
-    }
+    protected static Props Props(SessionActor parentActor) => Akka.Actor.Props.Create(() => new AttachService(parentActor));
 
     [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_ATTACH))]
     private void ReceiveAttach(GAME_5_PROTOCOL.MSG_ATTACH message) {
@@ -148,13 +146,6 @@ internal class AttachService : MessageService {
         TellOtherServices(msg);
     }
 
-    private bool GetWizardFromAccount(Account account, ulong charId, out Wizard character) {
-        var result = account.GetCharacter(charId);
-        character = result;
-
-        return result is not null;
-    }
-
     private SERVER_100_PROTOCOL.MSG_SERVERINFO GetGameServer() {
         var msg = new SERVER_100_PROTOCOL.MSG_QUERYSERVER();
 
@@ -175,8 +166,14 @@ internal class AttachService : MessageService {
         return rsp.ErrorCode == 0;
     }
 
+    private bool GetWizardFromAccount(Account account, ulong charId, out Wizard character) {
+        var result = account.GetCharacter(charId);
+        character = result;
+
+        return result is not null;
+    }
+
     private void SetAccountInternally(Account account) {
-        // Tell the SessionActor to set the account.
         TellOtherServices(new ACCOUNT_104_PROTOCOL.MSG_ACCOUNT() {
             Account = account
         });

--- a/src/CoreLib/Game/Services/AttachService.cs
+++ b/src/CoreLib/Game/Services/AttachService.cs
@@ -36,7 +36,7 @@ internal class AttachService : MessageService {
 
         // Tell the game server that the user has attached, and now we need to find a zone process for their
         // zone, or create a new one. This is an internal zone transfer that does not involve the client.
-        var zoneDetails = InternalZoneTransfer(message.ZoneName);
+        var zoneDetails = InternalZoneTransfer(message.ZoneName, message.Location);
         if (zoneDetails.ErrorCode != 0) {
             SendToSocket(new GAME_5_PROTOCOL.MSG_ATTACHFAILED { Error = zoneDetails.ErrorCode });
             return;
@@ -44,14 +44,8 @@ internal class AttachService : MessageService {
 
         // Set the character's location and zone to the ones given in the message.
         _wizard.SetZone(message.ZoneName, zoneDetails.ZoneDisplayName);
-
-        // The location is a string marked with commas. Parse it into a Vector3.
-        // We're compressing the orientation by a factor of 0.708 to fit it into a byte.
-        // This is to remain consistent with the client's representation of orientation.
-        var location = Util.GetVectorFromCompactString(message.Location);
-        var actualLocation = new Vector3(location.X, location.Y, location.Z);
-        _wizard.SetPersistentLocation(actualLocation);
-        _wizard.SetPersistentOrientation(location.W);
+        _wizard.SetPersistentLocation(zoneDetails.Location);
+        _wizard.SetPersistentOrientation(zoneDetails.Orientation);
 
         // Tiny anti-cheat measure. When the character object is created, we recalculate the game stats.
         CharacterHelper.RecalculateGameStats(_wizard);
@@ -98,7 +92,7 @@ internal class AttachService : MessageService {
 
             // Misc
             ShowSubscriberIcon = 0,
-            TestServer = 0
+            TestServer = 1
         };
 
         AddPlayerToZone(charGameObject, _wizard);
@@ -168,9 +162,10 @@ internal class AttachService : MessageService {
         this._wizard = character;
     }
 
-    private ZONE_102_PROTOCOL.MSG_ZONETRANSFERRSP InternalZoneTransfer(string zoneName) {
+    private ZONE_102_PROTOCOL.MSG_ZONETRANSFERRSP InternalZoneTransfer(string zoneName, string location) {
         var zoneMsg = new ZONE_102_PROTOCOL.MSG_ZONETRANSFER {
             DestinationZone = zoneName,
+            DestinationLocation = location,
             SendToClient = false
         };
         return AskOtherService<ZONE_102_PROTOCOL.MSG_ZONETRANSFERRSP>(zoneMsg);

--- a/src/CoreLib/Game/Services/AttachService.cs
+++ b/src/CoreLib/Game/Services/AttachService.cs
@@ -20,14 +20,94 @@ using static Imlight.Common.Caches.TypeCache;
 namespace Imlight.CoreLib.Game.Services;
 
 internal class AttachService : MessageService {
+    private Account _account;
+    private Wizard _wizard;
+
     public AttachService(SessionActor sessionActor) : base(sessionActor) { }
 
-    protected static Props Props(SessionActor parentActor) => Akka.Actor.Props.Create(() => new AttachService(parentActor));
+    protected static Props Props(SessionActor parentActor)
+        => Akka.Actor.Props.Create(() => new AttachService(parentActor));
 
     [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_ATTACH))]
     private void ReceiveAttach(GAME_5_PROTOCOL.MSG_ATTACH message) {
         // Use the session key given in the message to ensure that the user didn't bypass our login server.
         // The key will be associated with the account they're trying to log into.
+        ValidateAttach(message);
+
+        // Tell the game server that the user has attached, and now we need to find a zone process for their
+        // zone, or create a new one. This is an internal zone transfer that does not involve the client.
+        var zoneDetails = InternalZoneTransfer(message.ZoneName);
+        if (zoneDetails.ErrorCode != 0) {
+            SendToSocket(new GAME_5_PROTOCOL.MSG_ATTACHFAILED { Error = zoneDetails.ErrorCode });
+            return;
+        }
+
+        // Set the character's location and zone to the ones given in the message.
+        _wizard.SetZone(message.ZoneName, zoneDetails.ZoneDisplayName);
+
+        // The location is a string marked with commas. Parse it into a Vector3.
+        // We're compressing the orientation by a factor of 0.708 to fit it into a byte.
+        // This is to remain consistent with the client's representation of orientation.
+        var location = Util.GetVectorFromCompactString(message.Location);
+        var actualLocation = new Vector3(location.X, location.Y, location.Z);
+        var orientation = location.W / CharacterHelper.OrientationCompressionFactor;
+        _wizard.SetCachedLocation(actualLocation);
+        _wizard.SetCachedOrientation((byte) orientation);
+
+        // Tiny anti-cheat measure. When the character object is created, we recalculate the game stats.
+        CharacterHelper.RecalculateGameStats(_wizard);
+
+        // Get the best game server for this user.
+        var gameServer = GetGameServer();
+        _wizard.GameServerIp = gameServer.IP;
+        _wizard.GameServerPort = (ushort) gameServer.Port;
+
+        // Craft the GameObject for this Wizard.
+        var charGameObject = WizardObjectLoader.GetPlayerGameObject(_wizard);
+
+        // Set the mobile id to the one given by the zone.
+        charGameObject.m_nMobileID = zoneDetails.MobileId;
+
+        // Set the Wizard's GameObject reference to what we just created.
+        _wizard.GameObject = charGameObject;
+
+        // Serialize the GameObject and send it to the client.
+        var localGameObjectData = new CoreObjectSerializer().Serialize(charGameObject);
+        if (charGameObject is null || string.IsNullOrEmpty(localGameObjectData)) {
+            throw new ServiceRetryException($"User {message.UserID} failed to grab or deserialize " +
+                                            $"their player object.");
+        }
+
+        var loginCompleteMsg = new GAME_5_PROTOCOL.MSG_LOGINCOMPLETE() {
+            RealmName = "Centaur",
+
+            // Set character data.
+            Data = localGameObjectData,
+            IsCSR = _account.AuthLevel > AuthLevel.QualityAssurance ? 1 : 0,
+
+            // 0b0   - None
+            // 0b1   - Chat enabled
+            // 0b10  - Filtered chat
+            // ob100 - Open chat
+            Permissions = 0b1100_1111,
+
+            // Set zone data.
+            ZoneName = message.ZoneName,
+            ZoneID = message.ZoneID,
+            DynamicZoneID = zoneDetails.DynamicZoneId,
+            DynamicServerProcID = zoneDetails.DynamicZoneId,
+
+            // Misc
+            ShowSubscriberIcon = 0,
+            TestServer = 0
+        };
+
+        AddPlayerToZone(charGameObject, _wizard);
+        SendToSocket(loginCompleteMsg);
+        TellOtherServices(new SERVICE_101_PROTOCOL.MSG_ATTACHCOMPLETE());
+    }
+
+    private void ValidateAttach(GAME_5_PROTOCOL.MSG_ATTACH message) {
         if (!ValidateLoginKey(message.LoginKey, message.UserID, out var account)) {
             SendToSocket(new GAME_5_PROTOCOL.MSG_ATTACHFAILED() {
                 Error = 1,
@@ -50,106 +130,6 @@ internal class AttachService : MessageService {
         // other services denoting both the account and character this SessionActor just logged into.
         SetAccountInternally(account);
         SetCharacterInternally(wizard);
-
-        // Tell the game server that the user has attached, and now we need to find a zone process for their
-        // zone, or create a new one. This is an internal zone transfer that does not involve the client.
-        var zoneDetails = InternalZoneTransfer(message.ZoneName);
-        if (zoneDetails.ErrorCode != 0) {
-            SendToSocket(new GAME_5_PROTOCOL.MSG_ATTACHFAILED { Error = zoneDetails.ErrorCode });
-            return;
-        }
-
-        // Set the character's location and zone to the ones given in the message.
-        wizard.SetZone(message.ZoneName, zoneDetails.ZoneDisplayName);
-
-        // The location is a string marked with commas. Parse it into a Vector3.
-        // We're compressing the orientation by a factor of 0.708 to fit it into a byte.
-        // This is to remain consistent with the client's representation of orientation.
-        var location = Util.GetVectorFromCompactString(message.Location);
-        var actualLocation = new Vector3(location.X, location.Y, location.Z);
-        var orientation = location.W / CharacterHelper.OrientationCompressionFactor;
-        wizard.SetPersistentLocation(actualLocation);
-        wizard.SetPersistentOrientation((byte) orientation);
-
-        // Tiny anti-cheat measure. When the character object is created, we recalculate the game stats.
-        CharacterHelper.RecalculateGameStats(wizard);
-
-        // Get the best game server for this user.
-        var gameServer = GetGameServer();
-        wizard.GameServerIp = gameServer.IP;
-        wizard.GameServerPort = (ushort) gameServer.Port;
-
-        // Craft the GameObject for this Wizard.
-        var charGameObject = WizardObjectLoader.GetPlayerGameObject(wizard);
-
-        // Set the mobile id to the one given by the zone.
-        charGameObject.m_nMobileID = zoneDetails.MobileId;
-
-        // Set the Wizard's GameObject reference to what we just created.
-        wizard.GameObject = charGameObject;
-
-        // Serialize the GameObject and send it to the client.
-        var localGameObjectData = new CoreObjectSerializer().Serialize(charGameObject);
-        if (charGameObject is null || string.IsNullOrEmpty(localGameObjectData)) {
-            throw new ServiceRetryException($"User {message.UserID} failed to grab or deserialize " +
-                                            $"their player object.");
-        }
-
-        var loginCompleteMsg = new GAME_5_PROTOCOL.MSG_LOGINCOMPLETE() {
-            RealmName = "Centaur",
-
-            // Set character data.
-            Data = localGameObjectData,
-            IsCSR = account.AuthLevel > AuthLevel.QualityAssurance ? 1 : 0,
-
-            // 0b0   - None
-            // 0b1   - Chat enabled
-            // 0b10  - Filtered chat
-            // ob100 - Open chat
-            Permissions = 0b1100_1111,
-
-            // Set zone data.
-            ZoneName = message.ZoneName,
-            ZoneID = message.ZoneID,
-            DynamicZoneID = zoneDetails.DynamicZoneId,
-            DynamicServerProcID = zoneDetails.DynamicZoneId,
-
-            // Misc
-            ShowSubscriberIcon = 0,
-            TestServer = 0
-        };
-
-        var actualWizardName = WizardNameBank.GetEnglishName(wizard.PlayerNameBehavior.NameIndices, wizard.WizardAvatar.m_eGender);
-        AddPlayerToZone(charGameObject, wizard);
-
-        SendToSocket(loginCompleteMsg);
-
-        // Inform the other services that attach is complete.
-        TellOtherServices(new SERVICE_101_PROTOCOL.MSG_ATTACHCOMPLETE());
-    }
-
-    private ZONE_102_PROTOCOL.MSG_ZONETRANSFERRSP InternalZoneTransfer(string zoneName) {
-        var zoneMsg = new ZONE_102_PROTOCOL.MSG_ZONETRANSFER {
-            DestinationZone = zoneName,
-            SendToClient = false
-        };
-        return AskOtherService<ZONE_102_PROTOCOL.MSG_ZONETRANSFERRSP>(zoneMsg);
-    }
-
-    private void AddPlayerToZone(WizClientObject charObj, Wizard wizard) {
-        var msg = new ZONE_102_PROTOCOL.MSG_ADDPLAYER {
-            Player = SessionActor.ActorRef,
-            PlayerObject = charObj,
-            Wizard = wizard,
-            ActualWizardName = wizard.PlayerNameBehavior.GetWizardName(),
-        };
-        TellOtherServices(msg);
-    }
-
-    private SERVER_100_PROTOCOL.MSG_SERVERINFO GetGameServer() {
-        var msg = new SERVER_100_PROTOCOL.MSG_QUERYSERVER();
-
-        return AskServer<SERVER_100_PROTOCOL.MSG_SERVERINFO>(msg);
     }
 
     private bool ValidateLoginKey(ByteString key, ulong userId, out Account account) {
@@ -177,11 +157,39 @@ internal class AttachService : MessageService {
         TellOtherServices(new ACCOUNT_104_PROTOCOL.MSG_ACCOUNT() {
             Account = account
         });
+
+        this._account = account;
     }
 
     private void SetCharacterInternally(Wizard character) {
         TellOtherServices(new CHARACTER_103_PROTOCOL.MSG_SETACTIVEWIZARD {
             Wizard = character
         });
+
+        this._wizard = character;
+    }
+
+    private ZONE_102_PROTOCOL.MSG_ZONETRANSFERRSP InternalZoneTransfer(string zoneName) {
+        var zoneMsg = new ZONE_102_PROTOCOL.MSG_ZONETRANSFER {
+            DestinationZone = zoneName,
+            SendToClient = false
+        };
+        return AskOtherService<ZONE_102_PROTOCOL.MSG_ZONETRANSFERRSP>(zoneMsg);
+    }
+
+    private void AddPlayerToZone(WizClientObject charObj, Wizard wizard) {
+        var msg = new ZONE_102_PROTOCOL.MSG_ADDPLAYER {
+            Player = SessionActor.ActorRef,
+            PlayerObject = charObj,
+            Wizard = wizard,
+            ActualWizardName = wizard.PlayerNameBehavior.GetWizardName(),
+        };
+        TellOtherServices(msg);
+    }
+
+    private SERVER_100_PROTOCOL.MSG_SERVERINFO GetGameServer() {
+        var msg = new SERVER_100_PROTOCOL.MSG_QUERYSERVER();
+
+        return AskServer<SERVER_100_PROTOCOL.MSG_SERVERINFO>(msg);
     }
 }

--- a/src/CoreLib/Game/Services/AttachService.cs
+++ b/src/CoreLib/Game/Services/AttachService.cs
@@ -50,9 +50,8 @@ internal class AttachService : MessageService {
         // This is to remain consistent with the client's representation of orientation.
         var location = Util.GetVectorFromCompactString(message.Location);
         var actualLocation = new Vector3(location.X, location.Y, location.Z);
-        var orientation = location.W / CharacterHelper.OrientationCompressionFactor;
-        _wizard.SetCachedLocation(actualLocation);
-        _wizard.SetCachedOrientation((byte) orientation);
+        _wizard.SetPersistentLocation(actualLocation);
+        _wizard.SetPersistentOrientation(location.W);
 
         // Tiny anti-cheat measure. When the character object is created, we recalculate the game stats.
         CharacterHelper.RecalculateGameStats(_wizard);

--- a/src/CoreLib/Game/Services/MoveService.cs
+++ b/src/CoreLib/Game/Services/MoveService.cs
@@ -10,45 +10,60 @@ using Imlight.Common.ObjectProperty.PropertyReflection;
 using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.Shared.Packets;
 using Imlight.CoreLib.Shared.Resources;
+using Imlight.CoreLib.WizardData.Models.Player;
 using SharpDX;
 
 namespace Imlight.CoreLib.Game.Services;
 
-internal class MoveService : MessageService {
+internal class MoveService : MessageService, IWithTimers {
     private const byte MARK_MANA_COST_PERCENT = 20;
+    private const int FISH_INTERACTION_INTERVAL_IN_MILLI = 250;
 
+    public ITimerScheduler Timers { get; set; }
+
+    private readonly TimeSpan _fishInteractionInterval
+        = TimeSpan.FromMilliseconds(FISH_INTERACTION_INTERVAL_IN_MILLI);
     private TypeCache.CoreObject _activeCoreObject;
+    private Wizard _wizard;
+    private DateTime _lastMoveTime;
 
-    public MoveService(SessionActor sessionActor) : base(sessionActor) { }
+    public MoveService(SessionActor sessionActor) : base(sessionActor) {
+        // Instead of fishing for zone interactions per move, we'll start an interval of x milliseconds
+        // to check for zone interactions. This will enable the player to interact with the zone
+        // even if they aren't moving.
+        var intervalMsg = new ZONE_102_PROTOCOL.MSG_PLAYERMOVEINTERVAL();
+        Timers.StartPeriodicTimer("interaction", intervalMsg, _fishInteractionInterval, _fishInteractionInterval);
+    }
 
     protected static Props Props(SessionActor parentActor)
         => Akka.Actor.Props.Create(() => new MoveService(parentActor));
 
     [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_CLIENTMOVE))]
     private void ReceiveClientMove(GAME_5_PROTOCOL.MSG_CLIENTMOVE message) {
-        // MoveService saves the location of the player's game object.
-        // CharacterService saves the location of the player's character persistently.
+        // WizardService saves the location and orientation of the wizard.
+        // MoveService will broadcast the move to all other players in the zone and
+        // deals with interactions.
+        _activeCoreObject ??= GetActiveGameObject();
+        _wizard ??= GetActiveWizard();
 
-        this._activeCoreObject ??= GetActiveGameObject();
-
-        // Restore actual location information, as it is compressed by a factor of 4 and unsigned.
-        // Yaw is represented in radians in the client, but transmitted to the server as degrees.
-        var deflatedPos = new Vector3(message.LocationX, message.LocationY, message.LocationZ);
-        var deflatedDir = message.Direction;
-        var inflatedPos = DecompressLocation(deflatedPos);
-        var inflatedDir = DecompressDirection(deflatedDir);
-
-        _activeCoreObject.m_location = inflatedPos;
-        _activeCoreObject.m_orientation = new Vector3(0, 0, inflatedDir);
+        // Update the last move time.
+        _lastMoveTime = DateTime.Now;
 
         // Broadcast the move to all other players in the zone.
         BroadcastClientMove(message);
+    }
+
+    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_PLAYERMOVEINTERVAL))]
+    private void ReceiveZoneInteractionInterval(ZONE_102_PROTOCOL.MSG_PLAYERMOVEINTERVAL message) {
+        // Fish for interactions within the zone.
         SendZoneInteractionFishRequest();
     }
 
     [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_CLIENTMOVESTATE))]
-    private void ReceiveClientMoveState(GAME_5_PROTOCOL.MSG_CLIENTMOVESTATE message)
-        => BroadcastClientMoveState(message);
+    private void ReceiveClientMoveState(GAME_5_PROTOCOL.MSG_CLIENTMOVESTATE message) {
+        _activeCoreObject ??= GetActiveGameObject();
+        BroadcastClientMoveState(message);
+    }
 
     [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_JUMP))]
     private void ReceiveClientJump(GAME_5_PROTOCOL.MSG_JUMP message) {
@@ -144,8 +159,6 @@ internal class MoveService : MessageService {
     }
 
     private void BroadcastClientMove(GAME_5_PROTOCOL.MSG_CLIENTMOVE message) {
-        this._activeCoreObject ??= GetActiveGameObject();
-
         var serverMoveMsg = new GAME_5_PROTOCOL.MSG_SERVERMOVE {
             LocationX = message.LocationX,
             LocationY = message.LocationY,
@@ -157,8 +170,6 @@ internal class MoveService : MessageService {
     }
 
     private void BroadcastClientMoveState(GAME_5_PROTOCOL.MSG_CLIENTMOVESTATE message) {
-        this._activeCoreObject ??= GetActiveGameObject();
-
         var stateMsg = new GAME_5_PROTOCOL.MSG_MOVESTATE {
             NewState = message.NewState,
             GlobalID = _activeCoreObject.m_globalID
@@ -183,15 +194,4 @@ internal class MoveService : MessageService {
 
     private static byte CompressDirection(float direction)
         => (byte) Math.Round(direction / Math.PI / 2 * 250);
-
-    private static Vector3 DecompressLocation(Vector3 location) {
-        var x = unchecked((short) location.X) * 4.0f;
-        var y = unchecked((short) location.Y) * 4.0f;
-        var z = unchecked((short) location.Z) * 4.0f;
-
-        return new Vector3(x, y, z);
-    }
-
-    private static float DecompressDirection(float direction)
-        => (float) (direction * Math.PI * 2 / 250);
 }

--- a/src/CoreLib/Game/Services/MoveService.cs
+++ b/src/CoreLib/Game/Services/MoveService.cs
@@ -18,7 +18,7 @@ namespace Imlight.CoreLib.Game.Services;
 internal class MoveService : MessageService, IWithTimers {
     private const byte MARK_MANA_COST_PERCENT = 20;
     private const int FISH_INTERACTION_INTERVAL_IN_MILLI = 250;
-    private const int MOVE_THRESHOLD_IN_MILLI = 1000;
+    private const int MOVE_THRESHOLD_IN_MILLI = FISH_INTERACTION_INTERVAL_IN_MILLI * 2;
 
     public ITimerScheduler Timers { get; set; }
 

--- a/src/CoreLib/Game/Services/MoveService.cs
+++ b/src/CoreLib/Game/Services/MoveService.cs
@@ -18,14 +18,18 @@ namespace Imlight.CoreLib.Game.Services;
 internal class MoveService : MessageService, IWithTimers {
     private const byte MARK_MANA_COST_PERCENT = 20;
     private const int FISH_INTERACTION_INTERVAL_IN_MILLI = 250;
+    private const int MOVE_THRESHOLD_IN_MILLI = 1000;
 
     public ITimerScheduler Timers { get; set; }
 
     private readonly TimeSpan _fishInteractionInterval
         = TimeSpan.FromMilliseconds(FISH_INTERACTION_INTERVAL_IN_MILLI);
+    private readonly TimeSpan _moveThreshold
+        = TimeSpan.FromMilliseconds(MOVE_THRESHOLD_IN_MILLI);
     private TypeCache.CoreObject _activeCoreObject;
     private Wizard _wizard;
     private DateTime _lastMoveTime;
+    private bool _sentStopMoveState;
 
     public MoveService(SessionActor sessionActor) : base(sessionActor) {
         // Instead of fishing for zone interactions per move, we'll start an interval of x milliseconds
@@ -48,6 +52,7 @@ internal class MoveService : MessageService, IWithTimers {
 
         // Update the last move time.
         _lastMoveTime = DateTime.Now;
+        _sentStopMoveState = false;
 
         // Broadcast the move to all other players in the zone.
         BroadcastClientMove(message);
@@ -55,14 +60,31 @@ internal class MoveService : MessageService, IWithTimers {
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_PLAYERMOVEINTERVAL))]
     private void ReceiveZoneInteractionInterval(ZONE_102_PROTOCOL.MSG_PLAYERMOVEINTERVAL message) {
+        if (_activeCoreObject is null) {
+            return;
+        }
+
         // Fish for interactions within the zone.
         SendZoneInteractionFishRequest();
+
+        // While we're here, we're going to check to see if the player has been idle for
+        // too long. In such a case, we'll send a move state message to the client.
+        if (DateTime.Now - _lastMoveTime > _moveThreshold && !_sentStopMoveState) {
+            var moveStateMsg = new GAME_5_PROTOCOL.MSG_CLIENTMOVESTATE { NewState = 0 };
+            BroadcastClientMoveState(moveStateMsg);
+
+            // Set the flag to true so we don't send the move state message again.
+            // This will be reset the next time we notice the client move again.
+            _sentStopMoveState = true;
+        }
     }
 
     [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_CLIENTMOVESTATE))]
     private void ReceiveClientMoveState(GAME_5_PROTOCOL.MSG_CLIENTMOVESTATE message) {
         _activeCoreObject ??= GetActiveGameObject();
         BroadcastClientMoveState(message);
+
+        _lastMoveTime = DateTime.Now;
     }
 
     [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_JUMP))]

--- a/src/CoreLib/Game/Services/MoveService.cs
+++ b/src/CoreLib/Game/Services/MoveService.cs
@@ -15,30 +15,31 @@ using SharpDX;
 namespace Imlight.CoreLib.Game.Services;
 
 internal class MoveService : MessageService {
+    private const byte MARK_MANA_COST_PERCENT = 20;
 
-    private const byte MarkManaCostPercent = 20;
+    private TypeCache.CoreObject _activeCoreObject;
 
     public MoveService(SessionActor sessionActor) : base(sessionActor) { }
 
-    protected static Props Props(SessionActor parentActor) {
-        return Akka.Actor.Props.Create(() => new MoveService(parentActor));
-    }
+    protected static Props Props(SessionActor parentActor)
+        => Akka.Actor.Props.Create(() => new MoveService(parentActor));
 
     [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_CLIENTMOVE))]
     private void ReceiveClientMove(GAME_5_PROTOCOL.MSG_CLIENTMOVE message) {
         // MoveService saves the location of the player's game object.
         // CharacterService saves the location of the player's character persistently.
 
+        this._activeCoreObject ??= GetActiveGameObject();
+
         // Restore actual location information, as it is compressed by a factor of 4 and unsigned.
         // Yaw is represented in radians in the client, but transmitted to the server as degrees.
-        var x = unchecked((short) message.LocationX) * 4.0f;
-        var y = unchecked((short) message.LocationY) * 4.0f;
-        var z = unchecked((short) message.LocationZ) * 4.0f;
-        var direction = (float) (message.Direction * Math.PI * 2 / 250);
+        var deflatedPos = new Vector3(message.LocationX, message.LocationY, message.LocationZ);
+        var deflatedDir = message.Direction;
+        var inflatedPos = DecompressLocation(deflatedPos);
+        var inflatedDir = DecompressDirection(deflatedDir);
 
-        var activeCharacterObject = GetActiveGameObject();
-        activeCharacterObject.m_location = new Vector3(x, y, z);
-        activeCharacterObject.m_orientation = new Vector3(0, 0, direction);
+        _activeCoreObject.m_location = inflatedPos;
+        _activeCoreObject.m_orientation = new Vector3(0, 0, inflatedDir);
 
         // Broadcast the move to all other players in the zone.
         BroadcastClientMove(message);
@@ -46,15 +47,8 @@ internal class MoveService : MessageService {
     }
 
     [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_CLIENTMOVESTATE))]
-    private void ReceiveClientMoveState(GAME_5_PROTOCOL.MSG_CLIENTMOVESTATE message) {
-        var globalId = GetActiveGameObject().m_globalID;
-
-        var stateMsg = new GAME_5_PROTOCOL.MSG_MOVESTATE {
-            NewState = message.NewState,
-            GlobalID = globalId
-        };
-        ZoneBroadcast(stateMsg);
-    }
+    private void ReceiveClientMoveState(GAME_5_PROTOCOL.MSG_CLIENTMOVESTATE message)
+        => BroadcastClientMoveState(message);
 
     [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_JUMP))]
     private void ReceiveClientJump(GAME_5_PROTOCOL.MSG_JUMP message) {
@@ -67,7 +61,7 @@ internal class MoveService : MessageService {
         var wizard = GetActiveWizard();
 
         // If the character doesn't have enough mana, return.
-        if (wizard.GameStats.m_currentMana < wizard.GameStats.m_baseMana / MarkManaCostPercent) {
+        if (wizard.GameStats.m_currentMana < wizard.GameStats.m_baseMana / MARK_MANA_COST_PERCENT) {
             var failedRsp = new GAME_5_PROTOCOL.MSG_MARK_LOCATION_RESPONSE {
                 Result = 0,
                 MarkType = "1"
@@ -79,7 +73,7 @@ internal class MoveService : MessageService {
         wizard.SetMarkedLocation(wizard.Location, wizard.Orientation, wizard.Zone);
 
         var oldMana = wizard.GameStats.m_currentMana;
-        var newMana = oldMana - (wizard.GameStats.m_baseMana * ((float) MarkManaCostPercent / 100));
+        var newMana = oldMana - (wizard.GameStats.m_baseMana * ((float) MARK_MANA_COST_PERCENT / 100));
         wizard.GameStats.m_currentMana = (int) newMana;
 
         SendToSocket(new WIZARD_12_PROTOCOL.MSG_UPDATEMANA() {
@@ -110,12 +104,15 @@ internal class MoveService : MessageService {
 
         // If we are in the same zone as the marked location, teleport to it.
         if (wizard.MarkedZone == wizard.Zone) {
+            var deflatedPos = CompressLocation(wizard.MarkedLocation);
+            var deflatedDir = CompressDirection(wizard.MarkedOrientation.Z);
+
             var serverTeleportRsp = new GAME_5_PROTOCOL.MSG_SERVERTELEPORT {
                 // Compress the location by a factor of 4 and convert to unsigned.
-                Direction = (byte) (wizard.MarkedOrientation.Z / Math.PI / 2 * 250),
-                LocationX = (ushort) (wizard.MarkedLocation.X / 4),
-                LocationY = (ushort) (wizard.MarkedLocation.Y / 4),
-                LocationZ = (ushort) (wizard.MarkedLocation.Z / 4),
+                Direction = deflatedDir,
+                LocationX = (ushort) deflatedPos.X,
+                LocationY = (ushort) deflatedPos.Y,
+                LocationZ = (ushort) deflatedPos.Z,
                 MobileID = wizard.GameObject.m_nMobileID,
             };
             var recallRsp = new GAME_5_PROTOCOL.MSG_MARK_LOCATION_RESPONSE {
@@ -136,13 +133,7 @@ internal class MoveService : MessageService {
         }
         // If we're not in the same zone, send a zone transfer prior to the server teleport.
         else {
-            var zoneTransfer = new ZONE_102_PROTOCOL.MSG_ZONETRANSFER {
-                DestinationLocation =
-                    Util.GetCompactStringFromVector(wizard.MarkedLocation, wizard.MarkedOrientation),
-                DestinationZone = wizard.MarkedZone,
-                SendToClient = true,
-            };
-            TellOtherServices(zoneTransfer);
+            DoZoneTransfer(wizard.MarkedZone);
 
             var recallRsp = new GAME_5_PROTOCOL.MSG_MARK_LOCATION_RESPONSE {
                 Result = 1,
@@ -153,25 +144,54 @@ internal class MoveService : MessageService {
     }
 
     private void BroadcastClientMove(GAME_5_PROTOCOL.MSG_CLIENTMOVE message) {
-        // Query the mobile ID from the CharacterService
-        var mobileId = GetActiveGameObject().m_nMobileID;
+        this._activeCoreObject ??= GetActiveGameObject();
 
         var serverMoveMsg = new GAME_5_PROTOCOL.MSG_SERVERMOVE {
             LocationX = message.LocationX,
             LocationY = message.LocationY,
             LocationZ = message.LocationZ,
             Direction = message.Direction,
-            MobileID = mobileId,
+            MobileID = _activeCoreObject.m_nMobileID,
         };
         ZoneBroadcast(serverMoveMsg);
     }
 
+    private void BroadcastClientMoveState(GAME_5_PROTOCOL.MSG_CLIENTMOVESTATE message) {
+        this._activeCoreObject ??= GetActiveGameObject();
+
+        var stateMsg = new GAME_5_PROTOCOL.MSG_MOVESTATE {
+            NewState = message.NewState,
+            GlobalID = _activeCoreObject.m_globalID
+        };
+        ZoneBroadcast(stateMsg);
+    }
+
     private void SendZoneInteractionFishRequest() {
-        var characterObj = GetActiveGameObject();
         var msg = new ZONE_102_PROTOCOL.MSG_FISHINTERACTION() {
-            CoreObject = characterObj,
+            CoreObject = _activeCoreObject,
             Suspect = SessionActor.ActorRef
         };
+
         TellOtherServices(msg);
     }
+
+    private static Vector3 CompressLocation(Vector3 location) => new Vector3(
+            (float) Math.Round(location.X / 4),
+            (float) Math.Round(location.Y / 4),
+            (float) Math.Round(location.Z / 4)
+        );
+
+    private static byte CompressDirection(float direction)
+        => (byte) Math.Round(direction / Math.PI / 2 * 250);
+
+    private static Vector3 DecompressLocation(Vector3 location) {
+        var x = unchecked((short) location.X) * 4.0f;
+        var y = unchecked((short) location.Y) * 4.0f;
+        var z = unchecked((short) location.Z) * 4.0f;
+
+        return new Vector3(x, y, z);
+    }
+
+    private static float DecompressDirection(float direction)
+        => (float) (direction * Math.PI * 2 / 250);
 }

--- a/src/CoreLib/Game/Services/WizardService.cs
+++ b/src/CoreLib/Game/Services/WizardService.cs
@@ -12,14 +12,15 @@ using Imlight.CoreLib.WizardData.Models.Player;
 namespace Imlight.CoreLib.Game.Services;
 
 public class WizardService : MessageService {
+    private const float ORIENTATION_TOLERANCE = 1.035f;
+
     private Wizard _activeWizard;
     private TypeCache.CoreObject _activeWizardGameObject;
 
     public WizardService(SessionActor sessionActor) : base(sessionActor) { }
 
-    protected static Props Props(SessionActor parentActor) {
-        return Akka.Actor.Props.Create(() => new WizardService(parentActor));
-    }
+    protected static Props Props(SessionActor parentActor)
+        => Akka.Actor.Props.Create(() => new WizardService(parentActor));
 
     protected override void OnDispose() {
         ((System.IDisposable) _activeWizard).Dispose();
@@ -75,9 +76,13 @@ public class WizardService : MessageService {
             unchecked((short) message.LocationX * 4),
             unchecked((short) message.LocationY * 4),
             unchecked((short) message.LocationZ * 4));
-
         _activeWizard.SetCachedLocation(position);
-        _activeWizard.SetCachedOrientation(message.Direction);
+
+        // Direction is a byte and it's packed. Unpack it and convert it to radians.
+        var initDir = message.Direction;
+        var degrees = initDir * (360f / byte.MaxValue) * ORIENTATION_TOLERANCE;
+        var radians = degrees * (System.Math.PI / 180f);
+        _activeWizard.SetCachedOrientation((byte) radians);
     }
 
     #endregion

--- a/src/CoreLib/Game/Services/ZoneService.cs
+++ b/src/CoreLib/Game/Services/ZoneService.cs
@@ -194,7 +194,11 @@ public class ZoneService : MessageService {
                 SessionSlot = 0,
                 SessionID = 0,
                 TargetPlayerID = character.CharId,
-                TransitionID = 1
+                TransitionID = 1,
+                FallbackIP = character.GameServerIp,
+                FallbackTCPPort = character.GameServerPort,
+                FallbackUDPPort = character.GameServerPort,
+                FallbackZone = character.Zone
             };
             SendToSocket(serverTransfer);
         }

--- a/src/CoreLib/Game/Services/ZoneService.cs
+++ b/src/CoreLib/Game/Services/ZoneService.cs
@@ -155,8 +155,9 @@ public class ZoneService : MessageService {
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_FISHINTERACTION))]
     private void ReceiveZoneInteraction(ZONE_102_PROTOCOL.MSG_FISHINTERACTION message) {
+        // This is an exception. Sometimes the MoveService interval happens as we zone transfer.
         if (ZoneActor is null) {
-            throw new Exception("Zone Reference was null.");
+            return;
         }
 
         ZoneActor.Forward(message);

--- a/src/CoreLib/Game/Services/ZoneService.cs
+++ b/src/CoreLib/Game/Services/ZoneService.cs
@@ -29,7 +29,12 @@ public class ZoneService : MessageService {
     protected static Props Props(SessionActor parentActor) => Akka.Actor.Props.Create(() => new ZoneService(parentActor));
 
     protected override void OnPreDispose() {
-        var globalId = GetActiveGameObject().m_globalID;
+        var gameObj = GetActiveGameObject();
+        if (gameObj is null) {
+            return;
+        }
+
+        var globalId = gameObj.m_globalID;
 
         // If the zone reference is not null, we'll tell the zone to remove the player.
         ZoneActor?.Tell(new ZONE_102_PROTOCOL.MSG_REMOVEPLAYER() {

--- a/src/CoreLib/Game/Services/ZoneService.cs
+++ b/src/CoreLib/Game/Services/ZoneService.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Imlight.Common;
 using Imlight.Common.Caches;
@@ -15,14 +16,17 @@ using Imlight.CoreLib.Shared.Resources;
 namespace Imlight.CoreLib.Game.Services;
 
 public class ZoneService : MessageService {
+    private const int ZONE_REMOVAL_WAIT_TIME_IN_SECONDS = 4;
+    private const int ZONE_TRANSFER_CLEANUP_WAIT_TIME_IN_SECONDS = 1;
+
     public IActorRef ZoneActor;
+
+    private readonly TimeSpan _zoneRemovalWaitTime = TimeSpan.FromSeconds(ZONE_REMOVAL_WAIT_TIME_IN_SECONDS);
     private bool _isTransferQueued;
 
     public ZoneService(SessionActor sessionActor) : base(sessionActor) { }
 
-    protected static Props Props(SessionActor parentActor) {
-        return Akka.Actor.Props.Create(() => new ZoneService(parentActor));
-    }
+    protected static Props Props(SessionActor parentActor) => Akka.Actor.Props.Create(() => new ZoneService(parentActor));
 
     protected override void OnPreDispose() {
         var globalId = GetActiveGameObject().m_globalID;
@@ -99,6 +103,7 @@ public class ZoneService : MessageService {
 
     [MessageHandler(typeof(WIZARD2_53_PROTOCOL.MSG_ZONEHOP))]
     private void ReceiveZoneHop(WIZARD2_53_PROTOCOL.MSG_ZONEHOP message) {
+        // This message is sent when the client has enabled classic mode and wants to reload their current zone.
         var character = GetActiveWizard();
 
         _isTransferQueued = true;
@@ -120,7 +125,7 @@ public class ZoneService : MessageService {
 
     [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_ZONETRANSFERNACK))]
     private void ReceiveZoneTransferNack(GAME_5_PROTOCOL.MSG_ZONETRANSFERNACK message) {
-        // The client has denied the zone transfer. We can now send the server transfer message.
+        // The client has denied the zone transfer.
         Logger.Debug("Client was not OK with zone transfer! Possibly patching.");
     }
 
@@ -172,29 +177,40 @@ public class ZoneService : MessageService {
 
         // Remove the player from their current zone. We're awaiting a reply so the zone can properly clean up
         // before we continue on potentially a different thread.
-        var removePlayerMsg = new ZONE_102_PROTOCOL.MSG_REMOVEPLAYER() {
-            Player = SessionActor.ActorRef,
-            GlobalId = GetActiveGameObject().m_globalID,
-            IsPlayerStillConnected = true
-        };
-        _ = ZoneActor.Ask(removePlayerMsg).Result;
+        try {
+            var removePlayerMsg = new ZONE_102_PROTOCOL.MSG_REMOVEPLAYER() {
+                Player = SessionActor.ActorRef,
+                GlobalId = GetActiveGameObject().m_globalID,
+                IsPlayerStillConnected = true
+            };
+            _ = ZoneActor.Ask(removePlayerMsg, _zoneRemovalWaitTime).Result;
+        }
+        catch {
+            Logger.Warning("Zone removal timeout of {0} seconds exceeded.", Logger.Args(ZONE_REMOVAL_WAIT_TIME_IN_SECONDS));
+        }
+        finally {
+            // The zone has removed the player, but the client may not have had time to clean up
+            // all the zone items. We'll wait a short time here before we send zone transfer.
+            var delay = TimeSpan.FromSeconds(ZONE_TRANSFER_CLEANUP_WAIT_TIME_IN_SECONDS);
+            Task.Run(async () => await Task.Delay(delay)).Wait();
 
-        // When we send this message, the client will disconnect from the current zone and reconnect to the next.
-        // This means attach will happen again, so this is all we need to do here.
-        var serverTransfer = new GAME_5_PROTOCOL.MSG_SERVERTRANSFER() {
-            IP = character.GameServerIp,
-            TCPPort = character.GameServerPort,
-            UDPPort = character.GameServerPort,
-            UserID = account.AccountId,
-            CharID = character.CharId,
-            ZoneName = character.QueuedZoneName,
-            Location = character.QueuedZoneLocation,
-            Slot = 0,
-            SessionSlot = 0,
-            SessionID = 0,
-            TargetPlayerID = character.CharId,
-            TransitionID = 1
-        };
-        SendToSocket(serverTransfer);
+            // When we send this message, the client will disconnect from the current zone and reconnect to the next.
+            // This means attach will happen again, so this is all we need to do here.
+            var serverTransfer = new GAME_5_PROTOCOL.MSG_SERVERTRANSFER() {
+                IP = character.GameServerIp,
+                TCPPort = character.GameServerPort,
+                UDPPort = character.GameServerPort,
+                UserID = account.AccountId,
+                CharID = character.CharId,
+                ZoneName = character.QueuedZoneName,
+                Location = character.QueuedZoneLocation,
+                Slot = 0,
+                SessionSlot = 0,
+                SessionID = 0,
+                TargetPlayerID = character.CharId,
+                TransitionID = 1
+            };
+            SendToSocket(serverTransfer);
+        }
     }
 }

--- a/src/CoreLib/Game/Services/ZoneService.cs
+++ b/src/CoreLib/Game/Services/ZoneService.cs
@@ -43,78 +43,28 @@ public class ZoneService : MessageService {
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONETRANSFER))]
     private void ReceiveZoneTransferRequest(ZONE_102_PROTOCOL.MSG_ZONETRANSFER message) {
-        // This is an internal zone transfer message. It's meant to be the very first message sent to the
-        // SessionActor in regards to a zone transfer. We're going to cache the destination zone and location,
-        // then start the zone transfer handshake with the client.
-
-        // Avoid duplicate transfer requests.
         if (_isTransferQueued) {
             return;
         }
 
-        var character = GetActiveWizard();
-
-        // If the zone is ready and we're sending to client, begin the zone transfer handshake with the client.
+        // Sending the server transfer request to the server will allocate and load the zone.
         var zoneDetails = AskServer<ZONE_102_PROTOCOL.MSG_ZONETRANSFERRSP>(message);
-        if (zoneDetails.ErrorCode == 0 && message.SendToClient) {
-            // Check if the destination zone is the same as the current zone. If so, we move the player to the
-            // destination coordinates using a SERVERTELEPORT.
-            if (message.DestinationZone == character.Zone) {
-                // Split coordinate string by commas.
-                var coords = message.DestinationLocation.Split(',').ToArray();
-                // Put split string coordinates into Vector3.
-                var destinationCoords = new SharpDX.Vector3(
-                    float.Parse(coords[0]) / 4,
-                    float.Parse(coords[1]) / 4,
-                    float.Parse(coords[2]) / 4);
-
-                var serverTele = new GAME_5_PROTOCOL.MSG_SERVERTELEPORT() {
-                    LocationX = (ushort) destinationCoords.X,
-                    LocationY = (ushort) destinationCoords.Y,
-                    LocationZ = (ushort) destinationCoords.Z,
-                    Direction = 0,
-                    MobileID = GetActiveGameObject().m_nMobileID,
-                };
-                SendToSocket(serverTele);
+        if (message.SendToClient && zoneDetails.ErrorCode == 0) {
+            // Check if the destination zone is the same as the current zone. If so, just teleport the player.
+            if (message.DestinationZone == GetActiveWizard().Zone) {
+                DoTeleport(message.DestinationLocation);
                 return;
             }
 
-            _isTransferQueued = true;
-
-            // Ask the client if it's okay with being transferred.
-            var msg = new GAME_5_PROTOCOL.MSG_ZONETRANSFERREQUEST {
-                ZoneName = message.DestinationZone,
-                SendAck = 1
-            };
-            SendToSocket(msg);
-
-            character.QueuedZoneName = message.DestinationZone;
-            character.QueuedZoneLocation = message.DestinationLocation;
+            ReadyClientForZoneTransfer(message);
         }
-
-        // If we're not sending this to client, this is an internal transfer, meaning we can immediately
-        // setup the new details.
-        if (!message.SendToClient) {
-            ZoneActor = zoneDetails.ZoneActorRef;
+        else {
+            // If we're not sending this message to the client, it means the zone is being loaded
+            // for MSG_ATTACH. In which case, the client is already prepared for the zone transfer.
+            SetZone(zoneDetails.ZoneActorRef);
         }
 
         Sender.Tell(zoneDetails);
-    }
-
-    [MessageHandler(typeof(WIZARD2_53_PROTOCOL.MSG_ZONEHOP))]
-    private void ReceiveZoneHop(WIZARD2_53_PROTOCOL.MSG_ZONEHOP message) {
-        // This message is sent when the client has enabled classic mode and wants to reload their current zone.
-        var character = GetActiveWizard();
-
-        _isTransferQueued = true;
-        var zoneTransferRequestMessage = new GAME_5_PROTOCOL.MSG_ZONETRANSFERREQUEST {
-            ZoneName = character.Zone,
-            SendAck = 0
-        };
-        SendToSocket(zoneTransferRequestMessage);
-
-        character.QueuedZoneName = character.Zone;
-        character.QueuedZoneLocation = Util.GetCompactStringFromVector(character.Location, character.Orientation);
     }
 
     [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_ZONETRANSFERACK))]
@@ -132,6 +82,22 @@ public class ZoneService : MessageService {
     [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_RETRYTELEPORT))]
     private void ReceiveRetryTeleport(GAME_5_PROTOCOL.MSG_RETRYTELEPORT message) {
         DoZoneTransfer();
+    }
+
+    [MessageHandler(typeof(WIZARD2_53_PROTOCOL.MSG_ZONEHOP))]
+    private void ReceiveZoneHop(WIZARD2_53_PROTOCOL.MSG_ZONEHOP message) {
+        // This message is sent when the client has enabled classic mode and wants to reload their current zone.
+        var character = GetActiveWizard();
+
+        _isTransferQueued = true;
+        var zoneTransferRequestMessage = new GAME_5_PROTOCOL.MSG_ZONETRANSFERREQUEST {
+            ZoneName = character.Zone,
+            SendAck = 0
+        };
+        SendToSocket(zoneTransferRequestMessage);
+
+        character.QueuedZoneName = character.Zone;
+        character.QueuedZoneLocation = Util.GetCompactStringFromVector(character.Location, character.Orientation);
     }
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ADDPLAYER))]
@@ -170,6 +136,25 @@ public class ZoneService : MessageService {
         }
 
         ZoneActor.Forward(message);
+    }
+
+    private void SetZone(IActorRef actorRef) {
+        ZoneActor = actorRef;
+    }
+
+    private void ReadyClientForZoneTransfer(ZONE_102_PROTOCOL.MSG_ZONETRANSFER message) {
+        var character = GetActiveWizard();
+        _isTransferQueued = true;
+
+        // Ask the client if it's okay with being transferred.
+        var msg = new GAME_5_PROTOCOL.MSG_ZONETRANSFERREQUEST {
+            ZoneName = message.DestinationZone,
+            SendAck = 1
+        };
+        SendToSocket(msg);
+
+        character.QueuedZoneName = message.DestinationZone;
+        character.QueuedZoneLocation = message.DestinationLocation;
     }
 
     private void DoZoneTransfer() {
@@ -213,5 +198,17 @@ public class ZoneService : MessageService {
             };
             SendToSocket(serverTransfer);
         }
+    }
+
+    private void DoTeleport(string location) {
+        var coords = Util.GetVectorFromCompactString(location);
+        var serverTele = new GAME_5_PROTOCOL.MSG_SERVERTELEPORT() {
+            LocationX = (ushort) coords.X,
+            LocationY = (ushort) coords.Y,
+            LocationZ = (ushort) coords.Z,
+            Direction = 0,
+            MobileID = GetActiveGameObject().m_nMobileID,
+        };
+        SendToSocket(serverTele);
     }
 }

--- a/src/CoreLib/Game/WizardObjectLoader.cs
+++ b/src/CoreLib/Game/WizardObjectLoader.cs
@@ -25,6 +25,11 @@ public static class WizardObjectLoader {
         clientObject.m_characterId = (GID) character.CharId;
         clientObject.m_permID = 0; // What is this?
 
+        // If the mobile ID isn't null, this game object currently exists in a wizard zone.
+        if (character.GameObject is not null) {
+            clientObject.m_nMobileID = character.GameObject.m_nMobileID;
+        }
+
         // Create the object at the location set in the character.
         clientObject.m_location = character.Location;
         clientObject.m_orientation = character.Orientation;

--- a/src/CoreLib/Game/Zone/WizardZone.cs
+++ b/src/CoreLib/Game/Zone/WizardZone.cs
@@ -18,6 +18,8 @@ using Imlight.Common.Caches;
 using Imlight.Common.MessageLayer;
 using Imlight.Common.ObjectProperty;
 using Imlight.CoreLib.WizardData.Models.Player;
+using Imlight.CoreLib.Shared.Resources;
+using SharpDX;
 
 namespace Imlight.CoreLib.Game.Zone;
 
@@ -26,6 +28,7 @@ public class WizardZone : ReceiveProtocolDispatcher {
 
     public string ZoneName { get; }
     public string ZoneDisplayName { get; set; }
+    public WizZoneData ZoneData { get; set; }
 
     private readonly uint _dynamicZoneId;
     private readonly IActorRef _objectSupervisorRef;
@@ -53,9 +56,8 @@ public class WizardZone : ReceiveProtocolDispatcher {
     }
 
     // Akka.NET ctor
-    public static Props Props(string zoneName) {
-        return Akka.Actor.Props.Create(() => new WizardZone(zoneName));
-    }
+    public static Props Props(string zoneName)
+        => Akka.Actor.Props.Create(() => new WizardZone(zoneName));
 
     protected override void PreRestart(Exception reason, object message) {
         Logger.Error("Zone {ZoneName} restarts for: {Exception}", Logger.Args(ZoneName, reason));
@@ -237,16 +239,46 @@ public class WizardZone : ReceiveProtocolDispatcher {
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONETRANSFER))]
     private void ReceiveZoneTransfer(ZONE_102_PROTOCOL.MSG_ZONETRANSFER message) {
-        // This is step 1 of the zone transfer process.
-        // There's nothing we need to do here except for telling the sender the zone details and allocating a dynamic
-        // zone ID for them.
-        Sender.Tell(new ZONE_102_PROTOCOL.MSG_ZONETRANSFERRSP {
+        var rsp = new ZONE_102_PROTOCOL.MSG_ZONETRANSFERRSP {
             ZoneActorRef = Self,
             DynamicZoneId = _dynamicZoneId,
             ErrorCode = 0,
             MobileId = GenerateMobileId(),
             ZoneDisplayName = ZoneDisplayName
-        });
+        };
+
+        // The location given is a ByteString. If it's coordinates, then we need to parse it.
+        // Otherwise, it's a location within this zone. Search through locations to see if we can find it.
+        var actualLocation = Vector3.Zero;
+        var actualOrientation = 0.0f;
+
+        var location = Util.GetVectorFromCompactString(message.DestinationLocation);
+        if (location.X != 0 || location.Y != 0 || location.Z != 0) {
+            actualLocation = new Vector3(location.X, location.Y, location.Z);
+            actualOrientation = location.W;
+        }
+        else {
+            // We need to find the location in this zone.
+            var searchedLoc = ZoneData.m_locationList.FirstOrDefault(x => x.m_locName == message.DestinationLocation);
+            if (searchedLoc is null) {
+                // We weren't able to find the location. This is an error.
+                Logger.Error("Zone {ZoneName} tried to transfer to an unknown location: {Location}",
+                    Logger.Args(ZoneName, message.DestinationLocation));
+
+                rsp.ErrorCode = 1;
+            }
+            else {
+                // We found the location. Set the actual location and orientation.
+                var locPos = searchedLoc.m_location;
+                var locOri = searchedLoc.m_direction;
+                actualLocation = locPos;
+                actualOrientation = locOri;
+            }
+        }
+
+        rsp.Location = actualLocation;
+        rsp.Orientation = actualOrientation;
+        Sender.Tell(rsp);
     }
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ADDPLAYER))]

--- a/src/CoreLib/Game/Zone/WizardZone.cs
+++ b/src/CoreLib/Game/Zone/WizardZone.cs
@@ -293,13 +293,8 @@ public class WizardZone : ReceiveProtocolDispatcher {
 
         _zonePlayers.Remove(message.Player);
 
-        // Wait a little while until sending the reply back, just in case the zone objects have not yet been cleaned.
-        var s = Sender;
-        Task.Run(async () => {
-            await Task.Delay(TimeSpan.FromSeconds(1));
-            var rsp = new ZONE_102_PROTOCOL.MSG_REMOVEPLAYERRSP();
-            s.Tell(rsp);
-        }).Wait();
+        var rsp = new ZONE_102_PROTOCOL.MSG_REMOVEPLAYERRSP();
+        Sender.Tell(rsp);
 
         Logger.Debug("Player {Name} removed from zone {ZoneName}.",
             Logger.Args(message.Player.Path.Name, ZoneName));

--- a/src/CoreLib/Game/Zone/WizardZoneLoader.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneLoader.cs
@@ -153,6 +153,8 @@ public static class WizardZoneLoader {
             Logger.Error("Zone {ZoneName} could not load {ZoneDataFileName} as it was missing or invalid.",
                 Logger.Args(s_zone.ZoneName, ZoneDataFileName));
         }
+
+        s_zone.ZoneData = s_zoneData;
     }
 
     /// <summary>

--- a/src/CoreLib/Game/Zone/WizardZoneObject.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneObject.cs
@@ -136,6 +136,10 @@ public class WizardZoneObject : ReceiveProtocolDispatcher {
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_FISHINTERACTION))]
     protected void ReceiveZoneInteraction(ZONE_102_PROTOCOL.MSG_FISHINTERACTION message) {
+        if (message.CoreObject is null) {
+            return;
+        }
+
         // An actor is asking if our current game object is within a certain interaction radius.
         if (IsInRadius(message.CoreObject)) {
             // Keep track of the objects already within radius as to not trigger duplicate events.

--- a/src/CoreLib/Login/Services/GameTransitionService.cs
+++ b/src/CoreLib/Login/Services/GameTransitionService.cs
@@ -3,7 +3,6 @@
  * Proprietary and confidential.
  */
 
-using System.Net;
 using Akka.Actor;
 using Imlight.Common;
 using Imlight.Common.Caches;
@@ -11,8 +10,6 @@ using Imlight.Common.IO;
 using Imlight.Common.ObjectProperty.PropertyReflection;
 using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.Shared.Packets;
-using Imlight.CoreLib.Shared.Resources;
-using SharpDX;
 using Imlight.CoreLib.Shared.Resources;
 using Imlight.CoreLib.WizardData.Models.Player;
 using SharpDX;
@@ -22,9 +19,8 @@ namespace Imlight.CoreLib.Login.Services;
 internal class GameTransitionService : MessageService {
     public GameTransitionService(SessionActor sessionActor) : base(sessionActor) { }
 
-    protected static Props Props(SessionActor parentActor) {
-        return Akka.Actor.Props.Create(() => new GameTransitionService(parentActor));
-    }
+    protected static Props Props(SessionActor parentActor)
+        => Akka.Actor.Props.Create(() => new GameTransitionService(parentActor));
 
     [MessageHandler(typeof(LOGIN_7_PROTOCOL.MSG_SELECTCHARACTER))]
     private void ReceiveSelectCharacter(LOGIN_7_PROTOCOL.MSG_SELECTCHARACTER message) {
@@ -49,23 +45,26 @@ internal class GameTransitionService : MessageService {
         var serverEnqueueResult = (LOGIN_7_PROTOCOL.MSG_CHARACTERSELECTED) SessionActor.EnqueueToServer(gameServer.ActorRef);
         var allocatedKey = CreateSessionKey(gameServer.ActorRef, account);
 
-        Logger.Information("Sending login client {ID} to game server {IP}:{Port}.",
-            Logger.Args(SessionActor.SessionID, gameServer.IP, gameServer.Port));
+        var wizardNAme = character.PlayerNameBehavior.GetWizardName();
+        Logger.Information("Sending wizard {name} to game server {IP}:{Port}.",
+            Logger.Args(wizardNAme, gameServer.IP, gameServer.Port));
 
+        // If this character was just made, their default location is Vector3.Zero.
+        // In such a case, we'll default them to a location called "Start," which the game client
+        // usually has a location for.
         var stringLocation = character.Location == Vector3.Zero
             ? "Start"
             : Util.GetCompactStringFromVector(character.Location, character.Orientation);
 
-        // Craft a successful message. This will instead be cached if the server is full.
         var charSelectedMsg = new LOGIN_7_PROTOCOL.MSG_CHARACTERSELECTED() {
             // Set details about the game server.
             IP = gameServer.IP,
             TCPPort = gameServer.Port,
             UDPPort = gameServer.Port,
-            Key = allocatedKey,                   // Loggerin server -> game server session key.
+            Key = allocatedKey,                   // Login server -> game server session key.
             PrepPhase = 0,                        // (0|1): Player is in queue.
             Slot = 0,                             // The player's position in said queue.
-            LoginServer = "Imlight.Login",       // TODO: This should be sourced from elsewhere.
+            LoginServer = "Imlight.Login",        // TODO: This should be sourced from elsewhere.
 
             // Set details about the character.
             UserID = account.AccountId,

--- a/src/CoreLib/Shared/Networking/MessageService.cs
+++ b/src/CoreLib/Shared/Networking/MessageService.cs
@@ -11,6 +11,7 @@ using Imlight.Common.MessageLayer;
 using Imlight.CoreLib.Game.Services;
 using Imlight.CoreLib.Game.Zone;
 using Imlight.CoreLib.Shared.Packets;
+using Imlight.CoreLib.Shared.Resources;
 using Imlight.CoreLib.WizardData.Implementations;
 using Imlight.CoreLib.WizardData.Models.Player;
 
@@ -184,6 +185,16 @@ public abstract class MessageService : ReceiveProtocolDispatcher {
         }
 
         return response.ZoneObject;
+    }
+
+    protected void DoZoneTransfer(string destinationZone, string destinationLocation = "") {
+        // If the destination location is nothing, default it to "Start."
+        var zoneTransfer = new ZONE_102_PROTOCOL.MSG_ZONETRANSFER {
+            DestinationLocation = destinationLocation == "" ? "Start" : destinationLocation,
+            DestinationZone = destinationZone,
+            SendToClient = true,
+        };
+        TellOtherServices(zoneTransfer);
     }
 
     /// <summary>

--- a/src/CoreLib/Shared/Networking/SessionActor.cs
+++ b/src/CoreLib/Shared/Networking/SessionActor.cs
@@ -51,14 +51,12 @@ public class SessionActor : ReceiveActor, IDisposable {
     private readonly IActorRef _actorFactoryRef;
     private readonly Dictionary<IActorRef, MessageService> _services;
     private readonly SocketAsyncEventArgs _socketSendArgs = new();
-    private readonly CancellationTokenSource _cts = new();
-    private bool _isSending;
-    private bool _isDisposed;
     private List<IMessage> _preInitMessages;
     private readonly TokenBucket _tokenBucket;
-
     private readonly Stack<SocketAsyncEventArgs> _receiveEventArgPool = new();
     private readonly List<Type> _suppressedPackets;
+    private bool _isSending;
+    private bool _isDisposed;
 
     // ctor
     public SessionActor(Socket socket, ushort sessionId, IActorRef server) {
@@ -262,10 +260,8 @@ public class SessionActor : ReceiveActor, IDisposable {
         // Dispose self.
         ActorRef.Tell(PoisonPill.Instance);
         Socket?.Close();
-        _cts.Cancel();
 
         _socketSendArgs?.Dispose();
-        _cts?.Dispose();
         Socket?.Dispose();
     }
 
@@ -459,15 +455,12 @@ public class SessionActor : ReceiveActor, IDisposable {
             }
         }
 
-        // Reset the buffer before putting it back into the pool.
-        e.SetBuffer(null, 0, 0);
-        _receiveEventArgPool.Push(e);
-
-        var newArgs = new SocketAsyncEventArgs();
-        newArgs.Completed += (_, e) => OnReceiveCompleted(e);
-        newArgs.SetBuffer(new byte[_bufferSize], 0, _bufferSize);
-        newArgs.AcceptSocket = this.Socket;
+        var newArgs = GetReceiveEventArgsFromPool();
         ProcessReceive(newArgs);
+
+        // Reset the buffer before putting it back into the pool.
+        e.SetBuffer(new byte[_bufferSize], 0, _bufferSize);
+        _receiveEventArgPool.Push(e);
     }
 
     private void SendToSocket(IMessage message) {
@@ -481,6 +474,9 @@ public class SessionActor : ReceiveActor, IDisposable {
                       "Asynchronous send operation already in progress.", Logger.Args(SessionID));
             return;
         }
+        if (_isDisposed) {
+            return;
+        }
 
         var data = MessageSerializer.Encode(message);
         _isSending = true;
@@ -491,16 +487,12 @@ public class SessionActor : ReceiveActor, IDisposable {
         if (!willRaiseEvent) {
             OnSendCompleted(_socketSendArgs);
         }
-
-        var scopedMessageName = message
-            .GetType()
-            .ToString()
-            .Split('.')[^1]
-            .Replace('+', '.');
-        if (!_suppressedPackets.Contains(message.GetType())) {
-            Logger.Verbose("SessionActor {Id} sent message {MessageName}",
-                Logger.Args(SessionID, scopedMessageName));
+        else {
+            Logger.Warning("SessionActor {Id} sent message {MessageName} synchronously.",
+                Logger.Args(SessionID, message.GetType().Name));
         }
+
+        LogSentPacket(message);
     }
 
     private void OnSendCompleted(SocketAsyncEventArgs e) {
@@ -512,16 +504,7 @@ public class SessionActor : ReceiveActor, IDisposable {
     }
 
     private void HandlePacket(IMessage packet) {
-        // Logger the incoming packet.
-        var scopedMessageName = packet
-            .GetType()
-            .ToString()
-            .Split('.')[^1]
-            .Replace('+', '.');
-        if (!_suppressedPackets.Contains(packet.GetType())) {
-            Logger.Verbose("SessionActor {SessionId} received KiNP packet {ScopedMessageName}",
-                Logger.Args(SessionID, scopedMessageName));
-        }
+        LogReceivedPacket(packet);
 
         // Iterate through services and forward the message to any service that can handle the message.
         var wasDispatched = false;
@@ -580,25 +563,47 @@ public class SessionActor : ReceiveActor, IDisposable {
     }
 
     private SocketAsyncEventArgs GetReceiveEventArgsFromPool() {
-        lock (_receiveEventArgPool) {
-            if (_receiveEventArgPool.Count > 0) {
-                return _receiveEventArgPool.Pop();
-            }
-            else if (_receiveEventArgPool.Count < 5) {
-                // Create a new SocketAsyncEventArgs if the pool is empty and the pool limit has not been reached.
-                var receiveEventArgs = new SocketAsyncEventArgs();
-                receiveEventArgs.Completed += (_, e) => OnReceiveCompleted(e);
-                receiveEventArgs.AcceptSocket = Socket;
-                receiveEventArgs.SetBuffer(new byte[_bufferSize], 0, _bufferSize);
+        if (_receiveEventArgPool.Count > 0) {
+            return _receiveEventArgPool.Pop();
+        }
+        else if (_receiveEventArgPool.Count < 5) {
+            // Create a new SocketAsyncEventArgs if the pool is empty and the pool limit has not been reached.
+            var receiveEventArgs = new SocketAsyncEventArgs();
+            receiveEventArgs.Completed += (_, e) => OnReceiveCompleted(e);
+            receiveEventArgs.AcceptSocket = Socket;
+            receiveEventArgs.SetBuffer(new byte[_bufferSize], 0, _bufferSize);
 
-                return receiveEventArgs;
-            }
+            return receiveEventArgs;
         }
 
         SendOldContextException(new SessionFatalException($"SessionActor [{SessionID}] receive argument " +
                                                           $"pool over maximum allowed count " +
                                                           $"of {_asyncReceivePoolCount}."));
         return null;
+    }
+
+    private void LogReceivedPacket(IMessage packet) {
+        var scopedMessageName = packet
+            .GetType()
+            .ToString()
+            .Split('.')[^1]
+            .Replace('+', '.');
+        if (!_suppressedPackets.Contains(packet.GetType())) {
+            Logger.Verbose("SessionActor {SessionId} received KiNP packet {ScopedMessageName}",
+                Logger.Args(SessionID, scopedMessageName));
+        }
+    }
+
+    private void LogSentPacket(IMessage packet) {
+        var scopedMessageName = packet
+            .GetType()
+            .ToString()
+            .Split('.')[^1]
+            .Replace('+', '.');
+        if (!_suppressedPackets.Contains(packet.GetType())) {
+            Logger.Verbose("SessionActor {SessionId} sent KiNP packet {ScopedMessageName}",
+                Logger.Args(SessionID, scopedMessageName));
+        }
     }
 
     #endregion

--- a/src/CoreLib/Shared/Networking/SessionActor.cs
+++ b/src/CoreLib/Shared/Networking/SessionActor.cs
@@ -260,7 +260,7 @@ public class SessionActor : ReceiveActor, IDisposable {
         SendDisposeToServices();
 
         // Dispose self.
-        Context.Stop(Self);
+        ActorRef.Tell(PoisonPill.Instance);
         Socket?.Close();
         _cts.Cancel();
 
@@ -410,6 +410,8 @@ public class SessionActor : ReceiveActor, IDisposable {
 
     private void OnReceiveCompleted(SocketAsyncEventArgs e) {
         if (!_tokenBucket.TryAcquire()) {
+            Logger.Warning("SessionActor {SessionId} failed to acquire token.", Logger.Args(SessionID));
+
             // The rate limit was reached.
             var failedAcquisitionCount = _tokenBucket.GetFailedAcquisitionCount();
             if (failedAcquisitionCount >= _tokenBucketFailedAcquisitionLimit) {
@@ -436,6 +438,8 @@ public class SessionActor : ReceiveActor, IDisposable {
             return;
         }
         if (e.BytesTransferred <= 0) {
+            // If the bytes transferred is 0, the socket has disconnected.
+            this.Dispose();
             return;
         }
 
@@ -449,6 +453,9 @@ public class SessionActor : ReceiveActor, IDisposable {
             // If the session still isn't created, cache all non-control messages for later processing.
             foreach (var message in packet) {
                 _preInitMessages.Add(message);
+
+                Logger.Verbose("SessionActor {Id} cached message {MessageName} for later processing.",
+                    Logger.Args(SessionID, message.GetType().Name));
             }
         }
 

--- a/src/CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
+++ b/src/CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
@@ -230,4 +230,10 @@ public class ZONE_102_PROTOCOL : IServerProtocol
         public bool Failure;
         public string Error;
     }
+
+    public class MSG_PLAYERMOVEINTERVAL : IServerMessage
+    {
+        public byte MessageOrder { get; } = 22;
+        public byte ServiceID { get; } = 102;
+    }
 }

--- a/src/CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
+++ b/src/CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
@@ -12,6 +12,7 @@ using Imlight.Common.ObjectProperty.PropertyReflection;
 using Imlight.CoreLib.Game.Zone;
 using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.WizardData.Models.Player;
+using SharpDX;
 
 namespace Imlight.CoreLib.Shared.Packets;
 
@@ -41,6 +42,8 @@ public class ZONE_102_PROTOCOL : IServerProtocol
 		public ushort MobileId;
 		public uint DynamicZoneId;
         public string ZoneDisplayName;
+        public Vector3 Location;
+        public float Orientation;
 		public uint ErrorCode;
 	}
 

--- a/src/CoreLib/Shared/Resources/Util.cs
+++ b/src/CoreLib/Shared/Resources/Util.cs
@@ -16,7 +16,7 @@ public static class Util {
         => $"{vector.X},{vector.Y},{vector.Z},{orientation.Z}";
 
     public static Vector4 GetVectorFromCompactString(string loc) {
-        if (!loc.Contains(',')) {
+        if (loc.Split(',').Length != 4) {
             return Vector4.Zero;
         }
 

--- a/src/CoreLib/Shared/Services/ControlService.cs
+++ b/src/CoreLib/Shared/Services/ControlService.cs
@@ -29,9 +29,7 @@ public class ControlService : MessageService {
         SendSessionOffer();
     }
 
-    protected static Props Props(SessionActor parentActor) {
-        return Akka.Actor.Props.Create(() => new ControlService(parentActor));
-    }
+    protected static Props Props(SessionActor parentActor) => Akka.Actor.Props.Create(() => new ControlService(parentActor));
 
     protected override void ConfigureReceivers() {
         // These are sent from self on interval to remind the actor of the session heartbeat.
@@ -43,6 +41,7 @@ public class ControlService : MessageService {
     }
 
     private void SendSessionOffer() {
+        // Ask the game client for a session.
         var currentUnixTimestamp = (uint) (DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds;
         var timestampUpper = (int) (currentUnixTimestamp >> 32);
         var timestampLower = (int) (currentUnixTimestamp & uint.MaxValue);
@@ -74,6 +73,7 @@ public class ControlService : MessageService {
 
     [MessageHandler(typeof(ControlMessageProtocol.SessionAccept))]
     private void ReceiveSessionAccept(ControlMessageProtocol.SessionAccept message) {
+        // The game client approves of the agreed upon session.
         _responseStopwatch.Stop();
         if (message.SessionId != SessionActor.SessionID) {
             throw new Exception($"SessionActor [{SessionActor.SessionID}] misaligned Session ID.");
@@ -181,7 +181,7 @@ public class ControlService : MessageService {
             return;
         }
 
-        Logger.Debug("SessionActor {SessionID} " +
+        Logger.Verbose("SessionActor {SessionID} " +
                   "did not return a SessionAccept message in time", Logger.Args(SessionActor.SessionID));
         CloseSession();
     }

--- a/src/CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/CoreLib/WizardData/Models/Player/Wizard.cs
@@ -122,7 +122,7 @@ public class Wizard : IDisposable {
 
     public void SetCachedLocation(Vector3 loc) => Location = loc;
 
-    public void SetCachedOrientation(byte direction) => Orientation = new Vector3(0, 0, direction * OrientationCompressionFactor);
+    public void SetCachedOrientation(float direction) => Orientation = new Vector3(0, 0, direction);
 
     public void SetPersistentLocation(Vector3 loc) {
         Location = loc;
@@ -133,11 +133,6 @@ public class Wizard : IDisposable {
 
     public void SetPersistentOrientation(float orientation) {
         Orientation = new Vector3(0, 0, orientation);
-        SetPersistentOrientation(Orientation);
-    }
-
-    private void SetPersistentOrientation(Vector3 orientation) {
-        Orientation = orientation;
 
         // Persistent save.
         WizardCollection.UpdateCharacterLocation(this, Location, Orientation.Z);

--- a/src/CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/CoreLib/WizardData/Models/Player/Wizard.cs
@@ -131,8 +131,13 @@ public class Wizard : IDisposable {
         WizardCollection.UpdateCharacterLocation(this, loc, Orientation.Z);
     }
 
-    public void SetPersistentOrientation(byte direction) {
-        Orientation = new Vector3(0, 0, direction * OrientationCompressionFactor);
+    public void SetPersistentOrientation(float orientation) {
+        Orientation = new Vector3(0, 0, orientation);
+        SetPersistentOrientation(Orientation);
+    }
+
+    private void SetPersistentOrientation(Vector3 orientation) {
+        Orientation = orientation;
 
         // Persistent save.
         WizardCollection.UpdateCharacterLocation(this, Location, Orientation.Z);

--- a/src/Director/Program.cs
+++ b/src/Director/Program.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Globalization;
 using Akka.Actor;
 using Imlight.Common;
 using Imlight.Common.Configuration;
@@ -120,12 +121,12 @@ internal static class Program {
     private static void CreateEmbeddedDatabaseAccounts() {
         Logger.Information("Creating embedded database accounts. If you don't see anything, they already exist!");
 
-#if DEBUG
+        #if DEBUG
         // Generic developer accounts
         for (int i = 1; i <= 3; i++) {
             DatabaseUtilities.CreateEmbeddedDatabaseAccount($"dev{i}", $"dev{i}@r101.com", "dev9999", AuthLevel.Administrator);
         }
-#endif
+        #endif
 
         // Dev accounts; Hi, devs! Feel free to make your own account and add it here.
         new Jooty("jooty", "2342", "jay@r101net", AuthLevel.Administrator);
@@ -142,7 +143,7 @@ internal static class Program {
         // Hall Monitor accounts.
         new PokemonHacker("pk", "7878", "pk@r101.net", AuthLevel.HallMonitor);
         new Tilr("tilr", "8080", "tilr@r101.net", AuthLevel.HallMonitor);
-        
+
         // Quality Assurance accounts
         new B("b", "1121", "b@r101.net", AuthLevel.QualityAssurance);
         new Dalnakii("dalnakii", "0091", "b@r101.net", AuthLevel.QualityAssurance);
@@ -169,24 +170,37 @@ internal static class Program {
 
         // Write the boot type.
         // Soon in the future Imlight will actually have different boot types. For now, it's just L&G, which stands
-        // for Loggerin & Game.
+        // for Login & Game server.
         Console.ForegroundColor = ConsoleColor.DarkCyan;
         Console.Write("   :: L&G Boot ::    ");
         Console.ForegroundColor = ConsoleColor.White;
 
-        // Write version.
+        // Write the version. Our schema is NNyWWc, where NN is the two-digit year, and WW is the week of the year.
+        // c is the build configuration, which is either DEBUG or RELEASE.
         var buildConfiguration = GetBuildConfiguration();
         Console.Write(@"|___/");
         Console.ForegroundColor = ConsoleColor.DarkGray;
-        Console.Write($"   ({MajorVersion}-v{Version} {buildConfiguration})\n");
+
+        // Get the current year and week of the year.
+        var year = DateTime.Now.Year.ToString().Substring(2);
+        DateTime today = DateTime.Now;
+        int quarter = (today.Month - 1) / 3 + 1;
+        // Get the ISO week number
+        int week = CultureInfo.InvariantCulture.Calendar.GetWeekOfYear(
+                        today,
+                        CalendarWeekRule.FirstDay,
+                        DayOfWeek.Monday);
+
+        Console.Write($"   ({buildConfiguration} {year}Q{quarter}.{week}c)\n");
         Console.WriteLine("");
     }
 
     private static string GetBuildConfiguration() {
-#if DEBUG
-        return "DEBUG";
-#else
-			return "RELEASE";
-#endif
+        #if DEBUG
+            return "dev";
+        #else
+            // We're calling release builds canary since we're not public and deploying to QA instead.
+		    return "canary";
+        #endif
     }
 }

--- a/src/Director/Program.cs
+++ b/src/Director/Program.cs
@@ -191,7 +191,7 @@ internal static class Program {
                         CalendarWeekRule.FirstDay,
                         DayOfWeek.Monday);
 
-        Console.Write($"   ({buildConfiguration} {year}Q{quarter}.{week}c)\n");
+        Console.Write($"   ({MajorVersion} {year}Q{quarter}.{week}c {buildConfiguration})\n");
         Console.WriteLine("");
     }
 


### PR DESCRIPTION
## Fixes
* Fixed server transfer sometimes not being sent
* Fixed new arrivals in zone not seeing movement of existing zone players
* Fixed player sliding
* Fixed zone transfer orientation
* Fixed re-log orientation

## Changelog
* Added `DoZoneTransfer` to base class `MessageService`
* `SessionActor` now disposes on data loss rather than waiting for failed heartbeat
* `SessionActor` now has a hard limit of receive/send arguments
* Changed version schema
* Players now check on interval for zone interactions rather than relying on `MSG_CLIENTMOVE`. This should let players still be able to interact with the zone even if they aren't moving.
* `Wizard` now saves orientation in radians rather than degrees.
* Cleaned up `MoveService`
* Cleaned up `AttachService`
* Cleaned up `GameTransitionService`
* Cleaned up `ZoneService`

## Not Fixed
- [x] `WizardService` has bad math, and re-logging will cause the player to spawn in the wrong orientation. Unsure how to get the proper value out of what the client is sending.
- [ ] In very rare instances, the session actor will fail to receive `MSG_ATTACH` after a server transfer, causing the client to hang indefinitely in a loading screen.