### PR TITLE
`Feat/events` --> `quality-assurance`

### DIFF
--- a/src/Common/Caches/ServerTypeCache.cs
+++ b/src/Common/Caches/ServerTypeCache.cs
@@ -131,7 +131,7 @@ public static class ServerTypeCache {
         [Property(0x8177DA98, 31)] public TriggerObjectInfo m_triggerObjInfo;
     }
 
-    // Don't look at me, this is what the game uses.
+    // ? Why does this exist?
     public class TriggerObjectBase : CoreObjectInfo {
         // todo: need actual hashes here
         public override uint GetHash() => 0x068C265B;

--- a/src/Common/Caches/ServerTypeCache.cs
+++ b/src/Common/Caches/ServerTypeCache.cs
@@ -24,20 +24,86 @@ namespace Imlight.Common.Caches;
 */
 
 public static class ServerTypeCache {
-    public static PropertyClass? Dispatch(uint hash) {
-        return hash switch {
-            0x06DAAC43 => new WizZoneTriggers(),
-            0x068C265B => new Trigger(),
-            0x1B6EF770 => new WizZoneVolumes(),
-            0x1B7B55F6 => new Volume(),
-            0x774C0B33 => new ResDisplayText(),
-            0x3C626744 => new ResPlaySound(),
-            0xDa51FA8 => new ZoneRouter(),
-            478486736 => new CombatSigil(),
-            16312488 => new ResPlayCinematic(),
-            _ => null
-        };
-    }
+    public static PropertyClass? Dispatch(uint hash) => hash switch {
+        0x06DAAC43 => new WizZoneTriggers(),
+        0x068C265B => new Trigger(),
+        0x1B6EF770 => new WizZoneVolumes(),
+        0x1B7B55F6 => new Volume(),
+        0x774C0B33 => new ResDisplayText(),
+        0x3C626744 => new ResPlaySound(),
+        0xDa51FA8 => new ZoneRouter(),
+        478486736 => new CombatSigil(),
+        16312488 => new ResPlayCinematic(),
+        338444955 => new ResActorDialog(),
+        703672453 => new ResAddGold(),
+        1320311385 => new ResAddMagicXP(),
+        475964190 => new ResLoot(),
+        1936095675 => new ResPostQuestEvent(),
+        1774023420 => new ResAddSpell(),
+        1627552040 => new ResAddTrainingPoints(),
+        185712126 => new ResModifyEntry(),
+        461317711 => new ResIncrementEntry(),
+        1202940500 => new ResAddMissionDoor(),
+        1989908347 => new ResItemLoot(),
+        1875038822 => new ResAddMaxGold(),
+        822278902 => new ResDeleteItem(),
+        794463279 => new ResAddHealth(),
+        412163800 => new ResPostEvent(),
+        552459800 => new ResRemoveDynaMod(),
+        3938346 => new ResAddDynaMod(),
+        526762782 => new ResWait(),
+        475497368 => new ResEmote(),
+        798482874 => new ResAddEncounterXP(),
+        1534247075 => new ResMarkZoneNoWarn(),
+        807468757 => new ResDownloadPackage(),
+        1787561491 => new ResAddTreasureSpell(),
+        1263108441 => new ResModifyTriggerObject(),
+        723600258 => new ResSpawn(),
+        682171658 => new ResReInteract(),
+        101365432 => new ResDownloadElement(),
+        803366521 => new ResRemoveTriggerObject(),
+        1279893472 => new ResCompleteQuestGoal(),
+        2041850521 => new ResAddBadge(),
+        798724538 => new ResAddEncounter(),
+        1383450208 => new ResDespawn(),
+        1874483934 => new ResRemoveEntry(),
+        1962253934 => new ResFallthrough(),
+        1471095109 => new ResultOption(),
+        309059205 => new ResMaxPotions(),
+        1714192944 => new ResRemoveMissionDoor(),
+        633964307 => new ResAddCraftingSlot(),
+        1826857186 => new ResTimeStampEntry(),
+        1383058250 => new ResToggleQuestEffect(),
+        577427349 => new ResDespawnLeashedObject(),
+        837967761 => new ResRemoveEffect(),
+        1505576005 => new ResSpawnLeashedObject(),
+        53623319 => new ResAddEffect(),
+        1893729846 => new ResAddTriggerObject(),
+        228794493 => new ResTeleport(),
+        1375195018 => new ResSetPips(),
+        1100956089 => new ResClearHand(),
+        151650171 => new ResGiveSpell(),
+        266932982 => new ResUpdatePips(),
+        919520188 => new ResSyncScript(),
+        43418311 => new ResAddEnergy(),
+        66638275 => new ResAddElixir(),
+        1254124953 => new ResGivePowerPip(),
+        875336888 => new ResSetGardeningLevel(),
+        2128108307 => new ResDownloadBrowser(),
+        638582544 => new ResSetFishingLevel(),
+        1980688359 => new ResAddMana(),
+        1887868329 => new ResClearSpellbook(),
+        1952853362 => new ResClearExperience(),
+        742393364 => new ResShowGUI(),
+        82637767 => new ResCinematic(),
+        1895914322 => new ResAddRecipe(),
+        1144211986 => new ResControlBackgroundMusic(),
+        513283589 => new ResUnlockShadowMagic(),
+        145615551 => new ResStartStagedCinematic(),
+        74783451 => new ResReduceMana(),
+        1486342711 => new ResInitiateCombat(),
+        _ => null
+    };
 
     public class WizZoneTriggers : PropertyClass {
         public override uint GetHash() => 0x06DAAC43;
@@ -189,6 +255,535 @@ public static class ServerTypeCache {
         [Property(0x66ECE9B3, 31)] public ByteString m_unknown_string_3;
         [Property(0xA4092DFC, 31)] public bool m_unknown_bool_8;
         [Property(0x61437E16, 31)] public bool m_unknown_bool_9;
+    }
+
+    public class ResActorDialog : TypeCache.Result {
+        public override uint GetHash() => 338444955;
+
+        // Property: m_dialogPrefix (unknown)
+
+        [Property(1972573231, 7)] public ByteString m_activePersona;
+        [Property(3056380390, 7)] public ByteString m_registryEntry;
+        [Property(1310859212, 7)] public ActorDialog m_dialog;
+        [Property(2305471533, 31)] public ByteString m_quest;
+        [Property(2057644325, 7)] public bool m_broadcastToZone;
+        [Property(482239118, 7)] public bool m_displayInQuestList;
+        [Property(707400068, 7)] public bool m_oneShot;
+    }
+
+    public class ResAddGold : TypeCache.Result {
+        public override uint GetHash() => 703672453;
+
+        [Property(219423808, 7)] public int m_gold;
+        [Property(2305508654, 7)] public ByteString m_sourceType;
+    }
+
+    public class ResAddMagicXP : TypeCache.Result {
+        public override uint GetHash() => 1320311385;
+
+        // Property: m_experience (int)
+        // Property: m_magicSchool (string)
+        [Property(2305508654, 7)] public ByteString m_sourceType;
+    }
+
+    public class ResLoot : TypeCache.Result {
+        public override uint GetHash() => 475964190;
+
+        // Property: m_lootTable (string)
+    }
+
+    public class ResPostQuestEvent : TypeCache.Result {
+        public override uint GetHash() => 1936095675;
+
+        [Property(3493260286, 7)] public ByteString m_eventName;
+        // Property: m_subEventName (unknown)
+    }
+
+    public class ResAddSpell : TypeCache.Result {
+        public override uint GetHash() => 1774023420;
+
+        // Property: m_spellName (string)
+    }
+
+    public class ResAddTrainingPoints : TypeCache.Result {
+        public override uint GetHash() => 1627552040;
+
+        // Property: m_sourceType (string)
+        // Property: m_trainingPoints (int)
+    }
+
+    public class ResModifyEntry : TypeCache.Result {
+        public override uint GetHash() => 185712126;
+
+        // Property: m_questName (unknown)
+
+        [Property(2055270734, 7)] public ByteString m_entryName;
+        [Property(1388902362, 7)] public bool m_isQuestRegistry;
+        [Property(812990455, 7)] public int m_value;
+        [Property(1702112846, 7)] public ByteString m_questName;
+    }
+
+    public class ResIncrementEntry : TypeCache.Result {
+        public override uint GetHash() => 461317711;
+
+        // Property: m_entryName (string)
+        // Property: m_isQuestRegistry (int)
+        // Property: m_questName (unknown)
+    }
+
+    public class ResAddMissionDoor : TypeCache.Result {
+        public override uint GetHash() => 1202940500;
+
+        // Property: m_advanced (int)
+        // Property: m_clientTag (unknown)
+        // Property: m_missionDoorLoc (unknown)
+        // Property: m_missionDoorTag (string)
+        // Property: m_missionDoorZone (unknown)
+        // Property: m_useQuestAsOriginator (int)
+    }
+
+    public class ResItemLoot : TypeCache.Result {
+        public override uint GetHash() => 1989908347;
+
+        // Property: m_itemTemplateID (int)
+        // Property: m_lootOptions (string)
+        // Property: m_sendLootMessage (int)
+        // Property: m_sourceType (string)
+    }
+
+    public class ResAddMaxGold : TypeCache.Result {
+        public override uint GetHash() => 1875038822;
+
+        // Property: m_maxGoldToAdd (int)
+    }
+
+    public class ResDeleteItem : TypeCache.Result {
+        public override uint GetHash() => 822278902;
+
+        // Property: m_itemTemplateID (int)
+        // Property: m_quantity (int)
+        // Property: m_sourceType (string)
+    }
+
+    public class ResAddHealth : TypeCache.Result {
+        public override uint GetHash() => 794463279;
+
+        // Property: m_healthFlat (int)
+        // Property: m_healthPercent (float)
+        // Property: m_useFlat (int)
+    }
+
+    public class ResPostEvent : TypeCache.Result {
+        public override uint GetHash() => 412163800;
+
+        // Property: m_eventName (string)
+        // Property: m_subEventName (unknown) // Deserialization fails if this is made a string. 72 bits
+
+        [Property(3493260286, 31)] public string m_eventName;
+    }
+
+    public class ResRemoveDynaMod : TypeCache.Result {
+        public override uint GetHash() => 552459800;
+
+        [Property(1601665858, 31)] public ByteString m_dynaModClientTag;
+        [Property(1110452292, 31)] public bool m_useQuestAsOriginator;
+    }
+
+    public class ResAddDynaMod : TypeCache.Result {
+        public override uint GetHash() => 3938346;
+
+        [Property(1601665858, 31)] public ByteString m_dynaModClientTag;
+        [Property(1110452292, 31)] public bool m_dynaModRemove;
+        [Property(1494302749, 31)] public bool m_useQuestAsOriginator;
+        [Property(2072855560, 31)] public ByteString m_dynaModState;
+        [Property(2171167736, 8388615)] public ByteString m_zoneName;
+    }
+
+    public class ResWait : TypeCache.Result {
+        public override uint GetHash() => 526762782;
+
+        [Property(2403101108, 31)] public uint m_secondsToWait; // 128 bits
+    }
+
+    public class ResEmote : TypeCache.Result {
+        public override uint GetHash() => 475497368;
+
+        // Property: m_emoteName (string)
+        // Property: m_emoteState (string)
+        // Property: m_loop (int)
+        // Property: m_particleAsset (unknown)
+        // Property: m_particleNode (unknown)
+        // Property: m_personaName (unknown)
+        // Property: m_soundAsset (unknown)
+        // Property: m_usePersona (int)
+        // Property: m_useTarget (int)
+    }
+
+    public class ResAddEncounterXP : TypeCache.Result {
+        public override uint GetHash() => 798482874;
+
+        // Property: m_experience (int)
+    }
+
+    public class ResMarkZoneNoWarn : TypeCache.Result {
+        public override uint GetHash() => 1534247075;
+
+    }
+
+    public class ResDownloadPackage : TypeCache.Result {
+        public override uint GetHash() => 807468757;
+
+        [Property(2325737891, 31)] public List<ByteString> m_packageList;
+    }
+
+    public class ResAddTreasureSpell : TypeCache.Result {
+        public override uint GetHash() => 1787561491;
+
+        // Property: m_sourceType (string)
+        // Property: m_spellName (string)
+    }
+
+    public class ResModifyTriggerObject : TypeCache.Result {
+        public override uint GetHash() => 1263108441;
+
+        [Property(3336963211, 31)] public ByteString m_triggerObjName;
+        [Property(2067625387, 31)] public bool m_triggerObjState;
+    }
+
+    public class ResSpawn : TypeCache.Result {
+        public override uint GetHash() => 723600258;
+
+        // Not confident about these types
+        [Property(1481718190, 31)] public ulong m_spawnID;  // 128 bits
+        [Property(142527940, 31)] public bool m_activate; // 65 bits
+    }
+
+    public class ResReInteract : TypeCache.Result {
+        public override uint GetHash() => 682171658;
+
+        // Property: m_actorType (string)
+        // Property: m_delay (int)
+        // Property: m_personaName (string)
+        // Property: m_source (int)
+    }
+
+    public class ResDownloadElement : TypeCache.Result {
+        public override uint GetHash() => 101365432;
+
+        // Property: m_elementPackageList (string)
+    }
+
+    public class ResRemoveTriggerObject : TypeCache.Result {
+        public override uint GetHash() => 803366521;
+
+        // Property: m_triggerObjName (string)
+    }
+
+    public class ResCompleteQuestGoal : TypeCache.Result {
+        public override uint GetHash() => 1279893472;
+
+        // Property: m_goalName (string)
+        // Property: m_questName (string)
+    }
+
+    public class ResAddBadge : TypeCache.Result {
+        public override uint GetHash() => 2041850521;
+
+        // Property: m_badgeName (string)
+    }
+
+    public class ResAddEncounter : TypeCache.Result {
+        public override uint GetHash() => 798724538;
+
+        // Property: m_experience (int)
+    }
+
+    public class ResDespawn : TypeCache.Result {
+        public override uint GetHash() => 1383450208;
+
+        // Property: m_despawnEffect (unknown) // uint perhaps?
+        // Property: m_spawnID (int)
+        // Property: m_templateID (int)
+    }
+
+    public class ResRemoveEntry : TypeCache.Result {
+        public override uint GetHash() => 1874483934;
+
+        // Property: m_entryName (string)
+        // Property: m_isQuestRegistry (int)
+        // Property: m_questName (unknown)
+    }
+
+    public class ResCinematicActor : TypeCache.Result {
+        public override uint GetHash() => 16312488;
+
+        // Property: m_blocking (int)
+        // Property: m_cinematicName (string)
+        // Property: m_endAtActor (int)
+        // Property: m_endAtTargetActor (int)
+        // Property: m_endLoc (string)
+        // Property: m_objectTemplateID (int)
+        // Property: m_router (string)
+        // Property: m_routing (string)
+        // Property: m_startAtActor (int)
+        // Property: m_startAtTargetActor (int)
+        // Property: m_startLoc (string)
+        // Property: m_unique (int)
+        // Property: m_uniqueBusyMsg (unknown)
+        // Property: m_uniqueName (unknown)
+    }
+
+    public class ResFallthrough : TypeCache.Result {
+        public override uint GetHash() => 1962253934;
+
+        // Property: m_options (string)
+    }
+
+    public class ResultOption : TypeCache.Result {
+        public override uint GetHash() => 1471095109;
+
+        // Property: m_requirements (string)
+        // Property: m_results (string)
+    }
+
+    public class ResMaxPotions : TypeCache.Result {
+        public override uint GetHash() => 309059205;
+
+        // Property: m_potionsToAdd (int)
+        // Property: m_sourceType (string)
+    }
+
+    public class ResRemoveMissionDoor : TypeCache.Result {
+        public override uint GetHash() => 1714192944;
+
+        // Property: m_missionDoorTag (string)
+        // Property: m_useQuestAsOriginator (int)
+    }
+
+    public class ResAddCraftingSlot : TypeCache.Result {
+        public override uint GetHash() => 633964307;
+
+        // Property: m_slotDelta (int)
+        // Property: m_sourceType (string)
+    }
+
+    public class ResTimeStampEntry : TypeCache.Result {
+        public override uint GetHash() => 1826857186;
+
+        // Property: m_coolDownTime (int)
+        // Property: m_registryEntry (string)
+    }
+
+    public class ResToggleQuestEffect : TypeCache.Result {
+        public override uint GetHash() => 1383058250;
+
+        // Property: m_addEffect (int)
+        // Property: m_effectName (string)
+    }
+
+    public class ResDespawnLeashedObject : TypeCache.Result {
+        public override uint GetHash() => 577427349;
+
+        // Property: m_followerTemplateID (int)
+    }
+
+    public class ResRemoveEffect : TypeCache.Result {
+        public override uint GetHash() => 837967761;
+
+        // Property: m_effectName (string)
+        // Property: m_useOriginatorID (int)
+    }
+
+    public class ResSpawnLeashedObject : TypeCache.Result {
+        public override uint GetHash() => 1505576005;
+
+        // Property: m_followerTemplateID (int)
+    }
+
+    public class ResAddEffect : TypeCache.Result {
+        public override uint GetHash() => 53623319;
+
+        // Property: m_effectName (unknown)
+        // Property: m_playerOnly (int)
+        // Property: m_spEffectInfo (string)
+    }
+
+    public class ResAddTriggerObject : TypeCache.Result {
+        public override uint GetHash() => 1893729846;
+
+        // Property: m_triggerObjName (string)
+        // Property: m_triggerObjState (string)
+    }
+
+    public class ResSetPips : TypeCache.Result {
+        public override uint GetHash() => 1375195018;
+
+        // Property: m_numPips (int)
+        // Property: m_subCircle (int)
+    }
+
+    public class ResClearHand : TypeCache.Result {
+        public override uint GetHash() => 1100956089;
+
+        // Property: m_subCircle (int)
+    }
+
+    public class ResGiveSpell : TypeCache.Result {
+        public override uint GetHash() => 151650171;
+
+        // Property: m_spellName (string)
+        // Property: m_subCircle (int)
+    }
+
+    public class ResUpdatePips : TypeCache.Result {
+        public override uint GetHash() => 266932982;
+
+    }
+
+    public class ResSyncScript : TypeCache.Result {
+        public override uint GetHash() => 919520188;
+
+        // Property: m_function (string)
+        // Property: m_script (string)
+    }
+
+    public class ResAddEnergy : TypeCache.Result {
+        public override uint GetHash() => 43418311;
+
+        // Property: m_energyFlat (int)
+        // Property: m_energyPercent (int)
+        // Property: m_sourceType (string)
+        // Property: m_useFlat (int)
+    }
+
+    public class ResAddElixir : TypeCache.Result {
+        public override uint GetHash() => 66638275;
+
+        // Property: m_sourceType (string)
+        // Property: m_templateID (int)
+    }
+
+    public class ResGivePowerPip : TypeCache.Result {
+        public override uint GetHash() => 1254124953;
+
+        // Property: m_subCircle (int)
+    }
+
+    public class ResSetGardeningLevel : TypeCache.Result {
+        public override uint GetHash() => 875336888;
+
+        // Property: m_level (int)
+    }
+
+    public class ResDownloadBrowser : TypeCache.Result {
+        public override uint GetHash() => 2128108307;
+
+    }
+
+    public class ResSetFishingLevel : TypeCache.Result {
+        public override uint GetHash() => 638582544;
+
+        // Property: m_level (int)
+    }
+
+    public class ResAddMana : TypeCache.Result {
+        public override uint GetHash() => 1980688359;
+
+        [Property(2305508654, 7)] public ByteString m_sourceType;
+        [Property(1926272286, 7)] public int m_manaFlat;
+        [Property(1293619909, 7)] public float m_manaPercent;
+        [Property(138922614, 7)] public int m_overfill;
+        [Property(2040055687, 7)] public bool m_useFlat;
+    }
+
+    public class ResClearSpellbook : TypeCache.Result {
+        public override uint GetHash() => 1887868329;
+
+    }
+
+    public class ResClearExperience : TypeCache.Result {
+        public override uint GetHash() => 1952853362;
+
+    }
+
+    public class ResShowGUI : TypeCache.Result {
+        public override uint GetHash() => 742393364;
+
+        [Property(2274463339, 31)] public ByteString m_guiDisplay;
+        [Property(2717603296, 31)] public ByteString m_guiFile;
+    }
+
+    public class ResCinematic : TypeCache.Result {
+        public override uint GetHash() => 82637767;
+
+        // Property: m_blocking (int)
+        // Property: m_cinematicName (string)
+        // Property: m_endAtActor (int)
+        // Property: m_endAtTargetActor (int)
+        // Property: m_endLoc (string)
+        // Property: m_objectTemplateID (int)
+        // Property: m_router (string)
+        // Property: m_routing (string)
+        // Property: m_startAtActor (int)
+        // Property: m_startAtTargetActor (int)
+        // Property: m_startLoc (string)
+        // Property: m_unique (int)
+        // Property: m_uniqueBusyMsg (unknown)
+        // Property: m_uniqueName (unknown)
+    }
+
+    public class ResAddRecipe : TypeCache.Result {
+        public override uint GetHash() => 1895914322;
+
+        // Property: m_recipeName (string)
+        // Property: m_sourceType (string)
+    }
+
+    public class ResClientNotifyText : TypeCache.Result {
+        public override uint GetHash() => 2001472307;
+
+        // Property: m_allInZone (int)
+        // Property: m_text (string)
+        // Property: m_type (int)
+    }
+
+    public class ResControlBackgroundMusic : TypeCache.Result {
+        public override uint GetHash() => 1144211986;
+
+        // Property: m_action (string)
+        // Property: m_fadeTime (int)
+        // Property: m_router (string)
+
+        [Property(1734553689, 31)] public ByteString m_action;
+    }
+
+    public class ResUnlockShadowMagic : TypeCache.Result {
+        public override uint GetHash() => 513283589;
+
+    }
+
+    public class ResStartStagedCinematic : TypeCache.Result {
+        public override uint GetHash() => 145615551;
+
+        // Property: m_bIncludeAllPlayersInZone (int)
+        // Property: m_cinematicName (string)
+        // Property: m_stageName (string)
+    }
+
+    public class ResReduceMana : TypeCache.Result {
+        public override uint GetHash() => 74783451;
+
+        // Property: m_manaPercent (float)
+    }
+
+    public class ResInitiateCombat : TypeCache.Result {
+        public override uint GetHash() => 1486342711;
+
+        // Property: m_aggroActor (int)
+        // Property: m_aggroRadius (int)
+        // Property: m_aggroTarget (int)
+        // Property: m_allPlayers (bool)
+        // Property: m_sigilLabel (string)
     }
 
     public class CombatSigil : CoreObjectInfo {

--- a/src/CoreLib/Game/Events/ResultDispatcher.cs
+++ b/src/CoreLib/Game/Events/ResultDispatcher.cs
@@ -1,0 +1,42 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+using Akka.Actor;
+using Imlight.Common.Caches;
+using Imlight.CoreLib.Shared.Packets;
+using static Imlight.Common.Caches.ServerTypeCache;
+using static Imlight.Common.Caches.TypeCache;
+
+namespace Imlight.CoreLib.Game.Events;
+
+internal static class ResultDispatcher {
+    internal static void DispatchResult(IActorRef zoneRef, IActorRef playerRef, Result result) {
+        switch (result) {
+            case ServerTypeCache.ResTeleport resTeleport:
+                Teleport(playerRef, resTeleport);
+                break;
+            case ResDisplayText resDisplayText:
+                DisplayText(playerRef, resDisplayText);
+                break;
+        }
+    }
+
+    private static void Teleport(IActorRef playerRef, ServerTypeCache.ResTeleport resTeleport) {
+        var msg = new ZONE_102_PROTOCOL.MSG_ZONETRANSFER {
+            DestinationZone = resTeleport.m_destinationZone,
+            DestinationLocation = resTeleport.m_destinationLoc,
+            SendToClient = true
+        };
+        playerRef.Tell(msg);
+    }
+
+    private static void DisplayText(IActorRef playerRef, ResDisplayText resDisplayText) {
+        var msg = new GAME_5_PROTOCOL.MSG_CLIENTNOTIFYTEXT {
+            NotifyText = resDisplayText.m_text,
+            Type = resDisplayText.m_type,
+        };
+        playerRef.Tell(msg);
+    }
+}

--- a/src/CoreLib/Game/GameServer.cs
+++ b/src/CoreLib/Game/GameServer.cs
@@ -56,9 +56,8 @@ public class GameServer : Server {
             Logger.Args(serverName, serverPort));
     }
 
-    public static Props Props(string serverName, ushort serverPort) {
-        return Akka.Actor.Props.Create(() => new GameServer(serverName, serverPort));
-    }
+    public static Props Props(string serverName, ushort serverPort)
+        => Akka.Actor.Props.Create(() => new GameServer(serverName, serverPort));
 
     [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_CREATEKEY))]
     private void ReceiveCreateKey(SERVER_100_PROTOCOL.MSG_CREATEKEY message) {

--- a/src/CoreLib/Game/Services/ZoneService.cs
+++ b/src/CoreLib/Game/Services/ZoneService.cs
@@ -25,6 +25,7 @@ public class ZoneService : MessageService, IWithTimers {
     private const int ZONE_REMOVAL_WAIT_TIME_IN_SECONDS = 8;
     private const int ZONE_TRANSFER_CLEANUP_WAIT_TIME_IN_SECONDS = 1;
     private const float TELEPORT_EFFECTS_TIME = 2.0f;
+    private const string ENTER_ZONE_EVENT_NAME = "EnterZone";
 
     public IActorRef ZoneActor;
     public ITimerScheduler Timers { get; set; }
@@ -123,7 +124,7 @@ public class ZoneService : MessageService, IWithTimers {
         character.QueuedZoneLocation = Util.GetCompactStringFromVector(character.Location, character.Orientation);
     }
 
-    // This button and the GotoDorm button are locked client-side until level 2. 
+    // This button and the GotoDorm button are locked client-side until level 2.
     // jooty, again? cmon man
     [MessageHandler(typeof(WIZARD_12_PROTOCOL.MSG_GOHOME))]
     private void ReceiveGoHome(WIZARD_12_PROTOCOL.MSG_GOHOME message) {
@@ -145,7 +146,7 @@ public class ZoneService : MessageService, IWithTimers {
         Timers.StartSingleTimer("zonetransfer", tpmsg, delay);
     }
 
-    // This button and the GoHome button are locked client-side until level 2. 
+    // This button and the GoHome button are locked client-side until level 2.
     // jooty, again? cmon man
     [MessageHandler(typeof(WIZARD_12_PROTOCOL.MSG_GOTODORM))]
     private void ReceiveGotoDorm(WIZARD_12_PROTOCOL.MSG_GOTODORM message) {
@@ -174,6 +175,14 @@ public class ZoneService : MessageService, IWithTimers {
             SendCantGoHomeEffect(timeHomeLastClicked);
         }
         SendHomeButtonData();
+
+        var postEventMsg = new ZONE_102_PROTOCOL.MSG_POSTEVENT {
+            ZoneActor = ZoneActor,
+            EventName = ENTER_ZONE_EVENT_NAME,
+            SenderActor = SessionActor.ActorRef,
+            SenderGameObject = GetActiveGameObject()
+        };
+        ZoneActor.Tell(postEventMsg);
     }
 
     [MessageHandler(typeof(WIZARD_12_PROTOCOL.MSG_WORLDTELEPORTREQUEST))]

--- a/src/CoreLib/Game/Zone/WizardZone.cs
+++ b/src/CoreLib/Game/Zone/WizardZone.cs
@@ -20,6 +20,7 @@ using Imlight.CoreLib.Shared.Resources;
 using Imlight.CoreLib.Shared.Character;
 using static Imlight.Common.Caches.TypeCache;
 using Imlight.Common.IO;
+using static Imlight.Common.Caches.ServerTypeCache;
 
 namespace Imlight.CoreLib.Game.Zone;
 
@@ -44,10 +45,11 @@ public class WizardZone : ReceiveProtocolDispatcher, IWithTimers {
     public ITimerScheduler Timers { get; set; }
 
     private readonly uint _dynamicZoneId;
-    private readonly IActorRef _objectSupervisorRef; // Supervisor for all objects in this zone.
-    private readonly IActorRef _sigilSupervisorRef;  // Supervisor for all sigils in this zone.
-    private readonly IActorRef _duelSupervisorRef;   // Supervisor for all duels in this zone.
-    private readonly IActorRef _playerSupervisorRef; // Supervisor for all players in this zone.
+    private readonly IActorRef _objectSupervisorRef;  // Supervisor for all objects in this zone.
+    private readonly IActorRef _sigilSupervisorRef;   // Supervisor for all sigils in this zone.
+    private readonly IActorRef _duelSupervisorRef;    // Supervisor for all duels in this zone.
+    private readonly IActorRef _playerSupervisorRef;  // Supervisor for all players in this zone.
+    private readonly IActorRef _triggerSupervisorRef; // Supervisor for all triggers in this zone.
     private readonly string _mobileIdLock = string.Empty;
     private ushort _reservedMobileIdCounter;
     private ushort _nonreservedMobileIdCounter = RESERVED_MOBILE_ID_MAX + 1;
@@ -62,6 +64,7 @@ public class WizardZone : ReceiveProtocolDispatcher, IWithTimers {
         _sigilSupervisorRef = CreateSigilSupervisor();
         _duelSupervisorRef = CreateDuelSupervisor();
         _playerSupervisorRef = CreatePlayerSupervisor();
+        _triggerSupervisorRef = CreateTriggerSupervisor();
 
         // Load and initialize this zone.
         WizardZoneLoader.LoadZoneData(this, Self);
@@ -108,6 +111,11 @@ public class WizardZone : ReceiveProtocolDispatcher, IWithTimers {
 
     private IActorRef CreatePlayerSupervisor() {
         var props = WizardZonePlayerSupervisor.Props(Self);
+        return Context.ActorOf(props);
+    }
+
+    private IActorRef CreateTriggerSupervisor() {
+        var props = WizardZoneTriggerSupervisor.Props();
         return Context.ActorOf(props);
     }
 
@@ -299,6 +307,14 @@ public class WizardZone : ReceiveProtocolDispatcher, IWithTimers {
         // Inform the object supervisor to create an actor representation and add it to the zone objects list.
         _objectSupervisorRef.Tell(message);
     }
+
+    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ADDTRIGGER))]
+    private void ReceiveAddTrigger(ZONE_102_PROTOCOL.MSG_ADDTRIGGER message)
+        => _triggerSupervisorRef.Forward(message);
+
+    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_POSTEVENT))]
+    private void ReceivePostEvent(ZONE_102_PROTOCOL.MSG_POSTEVENT message)
+        => _triggerSupervisorRef.Forward(message);
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_FISHINTERACTION))]
     private void ReceiveZoneInteraction(ZONE_102_PROTOCOL.MSG_FISHINTERACTION message) {

--- a/src/CoreLib/Game/Zone/WizardZoneLoader.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneLoader.cs
@@ -114,10 +114,14 @@ public static class WizardZoneLoader {
                     Logger.Args(zoneName, benchmarkTimer.ElapsedMilliseconds));
                 benchmarkTimer.Restart();
 
-                CreateZoneVolumesWithTriggers();
+                CreateZoneVolumes();
                 Logger.Debug("{0} Created volumes in {Time}ms.",
                     Logger.Args(zoneName, benchmarkTimer.ElapsedMilliseconds));
                 benchmarkTimer.Restart();
+
+                CreateZoneTriggers();
+                Logger.Debug("{0} Created triggers in {Time}ms.",
+                    Logger.Args(zoneName, benchmarkTimer.ElapsedMilliseconds));
 
                 benchmarkTimer.Stop();
 
@@ -307,9 +311,8 @@ public static class WizardZoneLoader {
     /// Creates the volumes for the zone based on the loaded volume data.
     /// </summary>
     /// <exception cref="NullReferenceException"></exception>
-    private static void CreateZoneVolumesWithTriggers() {
+    private static void CreateZoneVolumes() {
         if (s_zoneVolumes is null)  { throw new NullReferenceException(nameof(s_zoneVolumes));  }
-        if (s_zoneTriggers is null) { throw new NullReferenceException(nameof(s_zoneTriggers)); }
 
         var triggers = GetTriggerDataFromDatabase();
 
@@ -326,36 +329,28 @@ public static class WizardZoneLoader {
             // For some reason, the volume type has two `m_templateID` fields, but only the duplicate one is used.
             newObj.m_templateID = volume.m_templateID; // I've never seen this templateID be anything but 1700.
 
-            // Set the volume's trigger data. This is dumbly complicated so I'll try to explain it.
-            // The `Trigger` type has a list of volume names (`m_volumes`) that it is associated with. However, these
-            // are not the names of volumes. Instead, you'll find these names in the `Volume` types
-            // `m_enterEvents` or `m_exitEvents`.
-            var volumeEnterEvents = (
-                from triggerName in volume.m_enterEvents
-                from trigger in triggers
-                from triggerVolumeNames in trigger.m_fireEvents
-                where triggerVolumeNames == triggerName
-                select trigger
-            ).ToList();
-            var volumeExitEvents = (
-                from triggerName in volume.m_exitEvents
-                from trigger in triggers
-                from triggerVolumeNames in trigger.m_fireEvents
-                where triggerVolumeNames == triggerName
-                select trigger
-            ).ToList();
-
-            if (volumeEnterEvents.Count <= 0) {
-                Logger.Verbose("Volume {VolumeName} in zone {ZoneName} has no triggers associated with it.",
-                    Logger.Args(volume.m_volumeName, s_zone.ZoneName));
-            }
-
             // Write a message citing the details of this volume, and send a message to the zone.
             var msg = new ZONE_102_PROTOCOL.MSG_ADDVOLUME {
                 CoreObject = newObj,
                 Volume = volume,
-                EnterEvents = volumeEnterEvents,
-                ExitEvents = volumeExitEvents
+            };
+            s_zoneActorRef.Tell(msg);
+        }
+    }
+
+    /// <summary>
+    /// Creates zone triggers by retrieving trigger data from the database and sending it to the zone actor.
+    /// </summary>
+    private static void CreateZoneTriggers() {
+        if (s_zoneTriggers is null) {
+            return;
+        }
+
+        var triggers = GetTriggerDataFromDatabase();
+
+        foreach (var trigger in triggers) {
+            var msg = new ZONE_102_PROTOCOL.MSG_ADDTRIGGER {
+                Trigger = trigger
             };
             s_zoneActorRef.Tell(msg);
         }

--- a/src/CoreLib/Game/Zone/WizardZoneObjectSupervisor.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneObjectSupervisor.cs
@@ -65,9 +65,7 @@ public class WizardZoneObjectSupervisor : ReceiveProtocolDispatcher {
         var props = WizardZoneVolume.Props(message.CoreObject,
                                            null,
                                            _wizardZoneRef,
-                                           message.Volume,
-                                           message.EnterEvents,
-                                           message.ExitEvents);
+                                           message.Volume);
         CreateActorAndRespond(props);
     }
 

--- a/src/CoreLib/Game/Zone/WizardZoneTrigger.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneTrigger.cs
@@ -29,10 +29,28 @@ internal class WizardZoneTrigger : ReceiveProtocolDispatcher {
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_POSTEVENT))]
     private void ReceivePostEvent(ZONE_102_PROTOCOL.MSG_POSTEVENT message) {
         // todo: requirements
-        // todo: cooldowns
+        if (_trigger.m_cooldown > 0 && !CooldownCheck(message.SenderActor)) {
+            return;
+        }
 
         foreach (var ev in _trigger.m_results.m_results) {
             ResultDispatcher.DispatchResult(this.Sender, message.SenderActor, ev);
         }
+    }
+
+    private bool CooldownCheck(IActorRef playerRef) {
+        if (_cooldowns.TryGetValue(playerRef, out var lastTriggered)) {
+            if (DateTime.Now - lastTriggered < TimeSpan.FromSeconds(_trigger.m_cooldown)) {
+                return false;
+            }
+            else {
+                _cooldowns[playerRef] = DateTime.Now;
+            }
+        }
+        else {
+            _cooldowns.Add(playerRef, DateTime.Now);
+        }
+
+        return true;
     }
 }

--- a/src/CoreLib/Game/Zone/WizardZoneTrigger.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneTrigger.cs
@@ -4,14 +4,17 @@
  */
 
 using Akka.Actor;
-using Imlight.Common;
+using Imlight.CoreLib.Game.Events;
 using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.Shared.Packets;
+using System;
+using System.Collections.Generic;
 using static Imlight.Common.Caches.ServerTypeCache;
 
 namespace Imlight.CoreLib.Game.Zone;
 
 internal class WizardZoneTrigger : ReceiveProtocolDispatcher {
+    private readonly Dictionary<IActorRef, DateTime> _cooldowns = new(); // todo
     private Trigger _trigger;
 
     // Akka.NET ctor
@@ -25,6 +28,10 @@ internal class WizardZoneTrigger : ReceiveProtocolDispatcher {
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_POSTEVENT))]
     private void ReceivePostEvent(ZONE_102_PROTOCOL.MSG_POSTEVENT message) {
-        Logger.Information("Received event {0}", Logger.Args(message.EventName));
+        // todo: requirements
+
+        foreach (var ev in _trigger.m_results.m_results) {
+            ResultDispatcher.DispatchResult(this.Sender, message.SenderActor, ev);
+        }
     }
 }

--- a/src/CoreLib/Game/Zone/WizardZoneTrigger.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneTrigger.cs
@@ -14,7 +14,7 @@ using static Imlight.Common.Caches.ServerTypeCache;
 namespace Imlight.CoreLib.Game.Zone;
 
 internal class WizardZoneTrigger : ReceiveProtocolDispatcher {
-    private readonly Dictionary<IActorRef, DateTime> _cooldowns = new(); // todo
+    private readonly Dictionary<IActorRef, DateTime> _cooldowns = new();
     private Trigger _trigger;
 
     // Akka.NET ctor
@@ -29,6 +29,7 @@ internal class WizardZoneTrigger : ReceiveProtocolDispatcher {
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_POSTEVENT))]
     private void ReceivePostEvent(ZONE_102_PROTOCOL.MSG_POSTEVENT message) {
         // todo: requirements
+        // todo: cooldowns
 
         foreach (var ev in _trigger.m_results.m_results) {
             ResultDispatcher.DispatchResult(this.Sender, message.SenderActor, ev);

--- a/src/CoreLib/Game/Zone/WizardZoneTrigger.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneTrigger.cs
@@ -1,0 +1,30 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+using Akka.Actor;
+using Imlight.Common;
+using Imlight.CoreLib.Shared.Networking;
+using Imlight.CoreLib.Shared.Packets;
+using static Imlight.Common.Caches.ServerTypeCache;
+
+namespace Imlight.CoreLib.Game.Zone;
+
+internal class WizardZoneTrigger : ReceiveProtocolDispatcher {
+    private Trigger _trigger;
+
+    // Akka.NET ctor
+    public static Props Props()
+        => Akka.Actor.Props.Create(() => new WizardZoneTrigger());
+
+    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ADDTRIGGER))]
+    private void ReceiveAddTrigger(ZONE_102_PROTOCOL.MSG_ADDTRIGGER message) {
+        this._trigger = message.Trigger;
+    }
+
+    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_POSTEVENT))]
+    private void ReceivePostEvent(ZONE_102_PROTOCOL.MSG_POSTEVENT message) {
+        Logger.Information("Received event {0}", Logger.Args(message.EventName));
+    }
+}

--- a/src/CoreLib/Game/Zone/WizardZoneTriggerSupervisor.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneTriggerSupervisor.cs
@@ -1,0 +1,39 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+using Akka.Actor;
+using Imlight.CoreLib.Shared.Networking;
+using Imlight.CoreLib.Shared.Packets;
+using System.Collections.Generic;
+using System.Linq;
+using static Imlight.Common.Caches.ServerTypeCache;
+
+namespace Imlight.CoreLib.Game.Zone;
+
+internal class WizardZoneTriggerSupervisor : ReceiveProtocolDispatcher {
+    private readonly Dictionary<Trigger, IActorRef> _triggers = new();
+
+    // Akka.NET ctor
+    public static Props Props()
+        => Akka.Actor.Props.Create(() => new WizardZoneTriggerSupervisor());
+
+    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ADDTRIGGER))]
+    private void ReceiveAddTrigger(ZONE_102_PROTOCOL.MSG_ADDTRIGGER message) {
+        var triggerActor = Context.ActorOf(WizardZoneTrigger.Props());
+        _triggers.Add(message.Trigger, triggerActor);
+
+        // Tell the trigger about it's own creation.
+        triggerActor.Forward(message);
+    }
+
+    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_POSTEVENT))]
+    private void ReceivePostEvent(ZONE_102_PROTOCOL.MSG_POSTEVENT message) {
+        foreach (var (trigger, actor) in _triggers) {
+            if (trigger.m_fireEvents.Any(x => x == message.EventName)) {
+                actor.Forward(message);
+            }
+        }
+    }
+}

--- a/src/CoreLib/Game/Zone/WizardZoneVolume.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneVolume.cs
@@ -84,41 +84,4 @@ public class WizardZoneVolume : WizardZoneObject {
 
         Sender.Tell(rsp);
     }
-
-    private static void DoResult(Result result, IActorRef actor) {
-        switch (result) {
-            case ServerTypeCache.ResTeleport resTeleport:
-                SendZoneTransfer(actor, resTeleport);
-                break;
-            case ResDisplayText resDisplayText:
-                SendDisplayText(actor, resDisplayText);
-                break;
-            case ResPlaySound resPlaySound:
-                SendPlaySound(actor, resPlaySound);
-                break;
-        }
-    }
-
-    private static void SendZoneTransfer(IActorRef suspect, ServerTypeCache.ResTeleport resTeleport) {
-        var msg = new ZONE_102_PROTOCOL.MSG_ZONETRANSFER {
-            DestinationZone = resTeleport.m_destinationZone,
-            DestinationLocation = resTeleport.m_destinationLoc,
-            SendToClient = true
-        };
-        suspect.Tell(msg);
-    }
-
-    private static void SendDisplayText(IActorRef suspect, ResDisplayText resDisplayText) {
-        var msg = new GAME_5_PROTOCOL.MSG_CLIENTNOTIFYTEXT {
-            NotifyText = resDisplayText.m_text,
-            Type = resDisplayText.m_type,
-        };
-        suspect.Tell(msg);
-    }
-
-    private static void SendPlaySound(IActorRef suspect, ResPlaySound resPlaySound) {
-        // todo: implement
-        var msg = new GAME_5_PROTOCOL.MSG_PLAYSOUND { SoundFilename = resPlaySound.m_soundName };
-        suspect.Tell(msg);
-    }
 }

--- a/src/CoreLib/Game/Zone/WizardZoneVolume.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneVolume.cs
@@ -18,53 +18,55 @@ namespace Imlight.CoreLib.Game.Zone;
 /// A volume is a space in the game world that can be used to trigger events when a player enters or exits it.
 /// </summary>
 public class WizardZoneVolume : WizardZoneObject {
-    private readonly List<Trigger> _enterEvents;
-    private readonly List<Trigger> _exitEvents;
+    private Volume _volume;
 
     // ctor
     public WizardZoneVolume(CoreObject activeGameObject,
                             CoreTemplate template,
                             IActorRef wizardZoneRef,
-                            Volume volume,
-                            List<Trigger> enterEvents,
-                            List<Trigger> exitEvents)
+                            Volume volume)
         : base(activeGameObject, template, wizardZoneRef) {
-        this._enterEvents = enterEvents;
-        this._exitEvents = exitEvents;
         base.InteractionRadius = volume.m_radius;
+        this._volume = volume;
     }
 
     // Akka.NET ctor
     public static Props Props(CoreObject activeGameObject,
                               CoreTemplate template,
                               IActorRef wizardZoneRef,
-                              Volume volume,
-                              List<Trigger> enterEvents,
-                              List<Trigger> exitEvents)
+                              Volume volume)
         => Akka.Actor.Props.Create(() => new WizardZoneVolume(activeGameObject,
                                                               template,
                                                               wizardZoneRef,
-                                                              volume,
-                                                              enterEvents,
-                                                              exitEvents));
+                                                              volume));
 
     protected override void OnPlayerInteractionEnter(CoreObject player, IActorRef suspect) {
         base.OnPlayerInteractionEnter(player, suspect);
 
-        foreach (var enterEvent in _enterEvents) {
-            foreach (var eventResult in enterEvent.m_results.m_results) {
-                DoResult(eventResult, suspect);
-            }
+        foreach (var enterEvent in _volume.m_enterEvents) {
+            var postEventMsg = new ZONE_102_PROTOCOL.MSG_POSTEVENT {
+                EventName = enterEvent,
+                ZoneActor = WizardZoneRef,
+                SenderActor = suspect,
+                SenderGameObject = player
+            };
+
+            WizardZoneRef.Tell(postEventMsg);
         }
     }
 
     protected override void OnPlayerInteractionExit(CoreObject player, IActorRef suspect) {
         base.OnPlayerInteractionExit(player, suspect);
 
-        foreach (var exitEvent in _exitEvents) {
-            foreach (var eventResult in exitEvent.m_results.m_results) {
-                DoResult(eventResult, suspect);
-            }
+        foreach (var exitEvent in _volume.m_exitEvents) {
+            var postEventMsg = new ZONE_102_PROTOCOL.MSG_POSTEVENT {
+                EventName = exitEvent,
+                ZoneActor = WizardZoneRef,
+                SenderActor = suspect,
+                SenderGameObject = player
+            };
+
+            WizardZoneRef.Tell(postEventMsg);
         }
     }
 

--- a/src/CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
+++ b/src/CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
@@ -126,8 +126,13 @@ public class ZONE_102_PROTOCOL : IServerProtocol {
 
         public TypeCache.CoreObject CoreObject;
         public ServerTypeCache.Volume Volume;
-        public List<Trigger> EnterEvents;
-        public List<Trigger> ExitEvents;
+    }
+
+    public class MSG_ADDTRIGGER : IServerMessage {
+        public byte MessageOrder { get; } = 12;
+        public byte ServiceID { get; } = 102;
+
+        public ServerTypeCache.Trigger Trigger;
     }
 
     public class MSG_FISHINTERACTION : IServerMessage {
@@ -262,5 +267,15 @@ public class ZONE_102_PROTOCOL : IServerProtocol {
 
         public IActorRef Player;
         public ulong GlobalId;
+    }
+
+    public class MSG_POSTEVENT : IServerMessage {
+        public byte MessageOrder { get; } = 31;
+        public byte ServiceID { get; } = 102;
+
+        public IActorRef ZoneActor;
+        public ByteString EventName;
+        public IActorRef SenderActor;
+        public CoreObject? SenderGameObject;
     }
 }


### PR DESCRIPTION
## Changelog

- Added a bunch of missing type structures not serialized with the client
- Added `WizardZoneTrigger`.
- Added `WizardZoneTriggerSupervisor`
- Added `ResultDispatcher`
- Added players to post event `EnterZone` upon zone entrance
- Added trigger cooldowns

## Writings

Changes the way we think about zone "volumes" and "triggers." To be clear, zone volumes are 3D areas inside of a zone that may trigger a "event" if a player were to enter or leave. Our events are also referred to as "triggers," and a `WizardZone` is in charge of monitoring them. Not all events may be posted by a volume, but all volumes post an event.

In short: a player enters a _volume_, posting an _event_ to the `WizardZone` to activate a _trigger_.

Another objective of this PR is to make posting an event generic. As a volume posts an event to the `WizardZone`, completing a quest goal may also post an event to the same `WizardZone`, with the sender as context.

A trigger has a number of requirements (which are not included in this PR) and results. These results include a number of dynamic changes, such as changing the player's health or teleporting them. The `ResultDispatcher` serves to handle any of the expected results.