### PR TITLE
`Feat/state machine` --> `quality-assurance`

### DIFF
--- a/src/CoreLib/Game/Combat/CombatDuelSubCircle.cs
+++ b/src/CoreLib/Game/Combat/CombatDuelSubCircle.cs
@@ -120,7 +120,7 @@ public class CombatDuelSubCircle {
         };
         ParticipantActor.Tell(msg);
 
-        PlayEntranceAnimation(participantObject);
+        PlayEntranceAnimation(participantObject, actor);
 
         return this.CombatParticipant;
     }
@@ -462,12 +462,12 @@ public class CombatDuelSubCircle {
         };
     }
 
-    private async Task PlayEntranceAnimation(CoreObject participantObject) {
+    private async Task PlayEntranceAnimation(CoreObject participantObject, IActorRef participantActor) {
         // Set the state of the participant to entering sigil.
-        _duelActor.ZoneBroadcast(new GAME_5_PROTOCOL.MSG_ENTERSTATE() {
-            GameObjectID = participantObject.m_globalID,
-            State = (uint) NPCStates.Sigil
-        });
+        var stateMsg = new CHARACTER_103_PROTOCOL.MSG_ENTERSTATE {
+            StateName = "Sigil"
+        };
+        participantActor.Tell(stateMsg);
 
         // Send aggro to the participant.
         _duelActor.ZoneBroadcast(new WIZARD_12_PROTOCOL.MSG_AGGRO {
@@ -488,10 +488,10 @@ public class CombatDuelSubCircle {
         await Task.Delay((int) (AGGRO_TIME_IN_SECONDS * 1000));
 
         // Set state to stationary.
-        _duelActor.ZoneBroadcast(new GAME_5_PROTOCOL.MSG_ENTERSTATE() {
-            GameObjectID = participantObject.m_globalID,
-            State = (uint) NPCStates.Stationary
-        });
+        stateMsg = new CHARACTER_103_PROTOCOL.MSG_ENTERSTATE {
+            StateName = "Stationary"
+        };
+        participantActor.Tell(stateMsg);
     }
 
     private PipCount DetermineStartingPips() {

--- a/src/CoreLib/Game/Events/ResultDispatcher.cs
+++ b/src/CoreLib/Game/Events/ResultDispatcher.cs
@@ -6,6 +6,7 @@
 using Akka.Actor;
 using Imlight.Common.Caches;
 using Imlight.CoreLib.Shared.Packets;
+using Imlight.CoreLib.WizardData.Models.Player;
 using static Imlight.Common.Caches.ServerTypeCache;
 using static Imlight.Common.Caches.TypeCache;
 
@@ -19,6 +20,9 @@ internal static class ResultDispatcher {
                 break;
             case ResDisplayText resDisplayText:
                 DisplayText(playerRef, resDisplayText);
+                break;
+            case ResAddDynaMod resAddDynaMod:
+                AddDynaMod(playerRef, zoneRef, resAddDynaMod);
                 break;
         }
     }
@@ -37,6 +41,19 @@ internal static class ResultDispatcher {
             NotifyText = resDisplayText.m_text,
             Type = resDisplayText.m_type,
         };
+        playerRef.Tell(msg);
+    }
+
+    private static void AddDynaMod(IActorRef playerRef, IActorRef zoneRef, ResAddDynaMod resAddDynaMod) {
+        var msg = new CHARACTER_103_PROTOCOL.MSG_ADDDYNAMOD {
+            DynaMod = resAddDynaMod,
+            ContextActor = playerRef
+        };
+
+        // Inform the zone of this state change. This will actually change the object state.
+        zoneRef.Tell(msg);
+
+        // Inform the player of this state change. This will add the modification persistently.
         playerRef.Tell(msg);
     }
 }

--- a/src/CoreLib/Game/Events/ResultDispatcher.cs
+++ b/src/CoreLib/Game/Events/ResultDispatcher.cs
@@ -24,6 +24,9 @@ internal static class ResultDispatcher {
             case ResAddDynaMod resAddDynaMod:
                 AddDynaMod(playerRef, zoneRef, resAddDynaMod);
                 break;
+            case ResRemoveDynaMod resRemoveDynaMod:
+                RemoveDynaMod(playerRef, zoneRef, resRemoveDynaMod);
+                break;
         }
     }
 
@@ -54,6 +57,19 @@ internal static class ResultDispatcher {
         zoneRef.Tell(msg);
 
         // Inform the player of this state change. This will add the modification persistently.
+        playerRef.Tell(msg);
+    }
+
+    private static void RemoveDynaMod(IActorRef playerRef, IActorRef zoneRef, ResRemoveDynaMod resRemoveDynaMod) {
+        var msg = new CHARACTER_103_PROTOCOL.MSG_REMOVEDYNAMOD {
+            DynaMod = resRemoveDynaMod,
+            ContextActor = playerRef
+        };
+
+        // Inform the zone of this state change. This will actually change the object state.
+        zoneRef.Tell(msg);
+
+        // Inform the player of this state change. This will remove the modification persistently.
         playerRef.Tell(msg);
     }
 }

--- a/src/CoreLib/Game/GameServiceFactory.cs
+++ b/src/CoreLib/Game/GameServiceFactory.cs
@@ -30,7 +30,8 @@ public class GameServiceFactory : ServiceFactory {
         typeof(CombatService),
         typeof(InteractService),
         typeof(ShopService),
-        typeof(AuctionHouseService)
+        typeof(AuctionHouseService),
+        typeof(DynaModService),
     };
 
     public static Props Props() {

--- a/src/CoreLib/Game/Services/DynaModService.cs
+++ b/src/CoreLib/Game/Services/DynaModService.cs
@@ -1,0 +1,63 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+using Akka.Actor;
+using Imlight.Common;
+using Imlight.Common.Caches;
+using Imlight.Common.Cryptography;
+using Imlight.CoreLib.Shared.Networking;
+using Imlight.CoreLib.Shared.Packets;
+
+namespace Imlight.CoreLib.Game.Services;
+
+public class DynaModService : MessageService {
+    public DynaModService(SessionActor sessionActor) : base(sessionActor) { }
+
+    protected static Props Props(SessionActor parentActor)
+        => Akka.Actor.Props.Create(() => new DynaModService(parentActor));
+
+    [MessageHandler(typeof(CHARACTER_103_PROTOCOL.MSG_ENTERSTATE))]
+    private void ReceiveEnterState(CHARACTER_103_PROTOCOL.MSG_ENTERSTATE message) {
+        var activeWizard = GetActiveWizard();
+        var activeWizardGameObject = GetActiveGameObject();
+
+        var objState = activeWizard.EnterState(message.StateName);
+        if (objState is null) {
+            Logger.Error("Failed to enter state {0} for wizard {1}", Logger.Args(message.StateName, activeWizard.CharId));
+            return;
+        }
+
+        // Echo the state change to the client.
+        var stateMsg = new GAME_5_PROTOCOL.MSG_ENTERSTATE {
+            GameObjectID = activeWizardGameObject.m_globalID,
+            State = StringHash.Compute(message.StateName)
+        };
+
+        var isPublicStateChange = !objState.m_privateState;
+        if (isPublicStateChange) {
+            ZoneBroadcast(stateMsg, false);
+        }
+        else {
+            SendToSocket(stateMsg);
+        }
+    }
+
+    [MessageHandler(typeof(CHARACTER_103_PROTOCOL.MSG_ADDDYNAMOD))]
+    private void ReceiveAddDynaMod(CHARACTER_103_PROTOCOL.MSG_ADDDYNAMOD message) {
+        var wizard = GetActiveWizard();
+        var zoneName = message.DynaMod.m_zoneName;
+        var dynaModClientTag = message.DynaMod.m_dynaModClientTag;
+        var dynaModState = message.DynaMod.m_dynaModState;
+
+        wizard.AddDynamod(zoneName, dynaModClientTag, dynaModState);
+    }
+
+    private void ReceiveRemoveDynaMod(CHARACTER_103_PROTOCOL.MSG_REMOVEDYNAMOD message) {
+        var wizard = GetActiveWizard();
+        var dynaModClientTag = message.DynaMod.m_dynaModClientTag;
+
+        wizard.RemoveDynamod(dynaModClientTag);
+    }
+}

--- a/src/CoreLib/Game/Services/DynaModService.cs
+++ b/src/CoreLib/Game/Services/DynaModService.cs
@@ -54,6 +54,7 @@ public class DynaModService : MessageService {
         wizard.AddDynamod(zoneName, dynaModClientTag, dynaModState);
     }
 
+    [MessageHandler(typeof(CHARACTER_103_PROTOCOL.MSG_REMOVEDYNAMOD))]
     private void ReceiveRemoveDynaMod(CHARACTER_103_PROTOCOL.MSG_REMOVEDYNAMOD message) {
         var wizard = GetActiveWizard();
         var dynaModClientTag = message.DynaMod.m_dynaModClientTag;

--- a/src/CoreLib/Game/Services/WizardService.cs
+++ b/src/CoreLib/Game/Services/WizardService.cs
@@ -9,6 +9,8 @@ using Imlight.CoreLib.Shared.Packets;
 using Imlight.Common.Caches;
 using Imlight.CoreLib.WizardData.Models.Player;
 using Imlight.CoreLib.Shared.Character;
+using Imlight.Common.Cryptography;
+using Imlight.Common;
 
 namespace Imlight.CoreLib.Game.Services;
 
@@ -91,6 +93,28 @@ public class WizardService : MessageService {
             MaxEnergy = baseStats.m_petEnergy
         };
         SendToSocket(petEnergyMessage);
+    }
+
+    [MessageHandler(typeof(CHARACTER_103_PROTOCOL.MSG_ENTERSTATE))]
+    private void ReceiveEnterState(CHARACTER_103_PROTOCOL.MSG_ENTERSTATE message) {
+        var objState = _activeWizard.EnterState(message.StateName);
+        if (objState is null) {
+            Logger.Error("Failed to enter state {0} for wizard {1}", Logger.Args(message.StateName, _activeWizard.CharId));
+            return;
+        }
+
+        // Echo the state change to the client.
+        var stateMsg = new GAME_5_PROTOCOL.MSG_ENTERSTATE {
+            GameObjectID = _activeWizardGameObject.m_globalID,
+            State = StringHash.Compute(message.StateName)
+        };
+
+        var isPublicStateChange = !objState.m_privateState;
+        if (isPublicStateChange) {
+            ZoneBroadcast(stateMsg, false);
+        } else {
+            SendToSocket(stateMsg);
+        }
     }
 
     #endregion

--- a/src/CoreLib/Game/Services/WizardService.cs
+++ b/src/CoreLib/Game/Services/WizardService.cs
@@ -95,28 +95,6 @@ public class WizardService : MessageService {
         SendToSocket(petEnergyMessage);
     }
 
-    [MessageHandler(typeof(CHARACTER_103_PROTOCOL.MSG_ENTERSTATE))]
-    private void ReceiveEnterState(CHARACTER_103_PROTOCOL.MSG_ENTERSTATE message) {
-        var objState = _activeWizard.EnterState(message.StateName);
-        if (objState is null) {
-            Logger.Error("Failed to enter state {0} for wizard {1}", Logger.Args(message.StateName, _activeWizard.CharId));
-            return;
-        }
-
-        // Echo the state change to the client.
-        var stateMsg = new GAME_5_PROTOCOL.MSG_ENTERSTATE {
-            GameObjectID = _activeWizardGameObject.m_globalID,
-            State = StringHash.Compute(message.StateName)
-        };
-
-        var isPublicStateChange = !objState.m_privateState;
-        if (isPublicStateChange) {
-            ZoneBroadcast(stateMsg, false);
-        } else {
-            SendToSocket(stateMsg);
-        }
-    }
-
     #endregion
 
     #region Game Handlers

--- a/src/CoreLib/Game/States/StateFactory.cs
+++ b/src/CoreLib/Game/States/StateFactory.cs
@@ -1,0 +1,54 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+using Imlight.Common;
+using Imlight.Common.ObjectProperty;
+using Imlight.CoreLib.Shared.Resources;
+using System;
+using System.Collections.Generic;
+using static Imlight.Common.Caches.TypeCache;
+
+namespace Imlight.CoreLib.Game.States;
+
+internal class StateFactory : RootDirectoryResourceSingleton<StateFactory>, IMemoryStreamDisposable {
+    protected override string DirectoryName => "StateData/";
+
+    private readonly Dictionary<string, ObjStateSet> _objectStateSets = new();
+
+    protected override void AfterLoad() {
+        var serializer = new FileSerializer();
+        var counter = 0;
+
+        foreach (var file in base.Files) {
+            var fileRecord = file.Key;
+            var fileStream = file.Value;
+
+            var set = serializer.OpenClass<ObjStateSet>(fileStream);
+            if (set is null) {
+                Logger.Error("Could not deserialize {0} as {1}", Logger.Args(fileRecord.FileName, nameof(ObjStateSet)));
+                continue;
+            }
+
+            _objectStateSets.Add(set.m_stateSetName, set);
+            counter++;
+        }
+
+        Logger.Information("Loaded {0} state sets.", Logger.Args(counter));
+    }
+
+    internal static ObjStateSet GetStateSet(string setName) {
+        if (Instance._objectStateSets.TryGetValue(setName, out var set)) {
+            return set;
+        }
+
+        return null;
+    }
+
+    public void DisposeStream() {
+        foreach (var streams in base.Files.Values) {
+            streams.Dispose();
+        }
+    }
+}

--- a/src/CoreLib/Game/Zone/WizardZone.cs
+++ b/src/CoreLib/Game/Zone/WizardZone.cs
@@ -354,12 +354,8 @@ public class WizardZone : ReceiveProtocolDispatcher, IWithTimers {
     [MessageHandler(typeof(CHARACTER_103_PROTOCOL.MSG_ADDDYNAMOD))]
     private void ReceiveAddDynaMod(CHARACTER_103_PROTOCOL.MSG_ADDDYNAMOD message) {
         // Inform all zone objects of this state change.
-        var msg = new ZONE_102_PROTOCOL.MSG_ZONEOBJECTBROADCAST {
-            Source = message.ContextActor,
-            Messages = new IServerMessage[] { message }
-        };
-        _objectSupervisorRef.Tell(msg);
-        _sigilSupervisorRef.Tell(msg);
+        _objectSupervisorRef.Tell(message);
+        _sigilSupervisorRef.Tell(message);
     }
 
     #endregion

--- a/src/CoreLib/Game/Zone/WizardZone.cs
+++ b/src/CoreLib/Game/Zone/WizardZone.cs
@@ -351,6 +351,17 @@ public class WizardZone : ReceiveProtocolDispatcher, IWithTimers {
         _playerSupervisorRef.Forward(message);
     }
 
+    [MessageHandler(typeof(CHARACTER_103_PROTOCOL.MSG_ADDDYNAMOD))]
+    private void ReceiveAddDynaMod(CHARACTER_103_PROTOCOL.MSG_ADDDYNAMOD message) {
+        // Inform all zone objects of this state change.
+        var msg = new ZONE_102_PROTOCOL.MSG_ZONEOBJECTBROADCAST {
+            Source = message.ContextActor,
+            Messages = new IServerMessage[] { message }
+        };
+        _objectSupervisorRef.Tell(msg);
+        _sigilSupervisorRef.Tell(msg);
+    }
+
     #endregion
 
     private Vector4 GetLocationFromString(ByteString location) {

--- a/src/CoreLib/Game/Zone/WizardZoneCreature.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneCreature.cs
@@ -323,10 +323,13 @@ public class WizardZoneCreature : WizardZoneObject, IWithTimers {
             .FirstOrDefault(x => x is NPCBehaviorTemplate) as NPCBehaviorTemplate;
         var equipmentBehaviorTemplate = Template.m_behaviors
             .FirstOrDefault(x => x is EquipmentBehaviorTemplate) as EquipmentBehaviorTemplate;
+        var objectStateBehaviorTemplate = Template.m_behaviors
+            .FirstOrDefault(x => x is ObjectStateBehaviorTemplate) as ObjectStateBehaviorTemplate;
 
         CreatePathBehavior(pathBehaviorTemplate, pathMovementBehavior);
         CreateNPCBehavior(npcBehaviorTemplate, duelistBehaviorTemplate);
         CreateEquipmentBehavior(equipmentBehaviorTemplate);
+        CreateStateBehavior(objectStateBehaviorTemplate);
     }
 
     private void CreatePathBehavior(PathBehaviorTemplate pathTemplate, PathMovementBehaviorTemplate movementTemplate) {
@@ -433,6 +436,11 @@ public class WizardZoneCreature : WizardZoneObject, IWithTimers {
     private void CreateDeckBehavior(DeckBehaviorTemplate deckBehaviorTemplate) {
         var deckBehaviorInstance = new ServerCreatureSpellbookBehavior(deckBehaviorTemplate);
         this.Behaviors.Add(deckBehaviorInstance);
+    }
+
+    private void CreateStateBehavior(ObjectStateBehaviorTemplate objectStateBehaviorTemplate) {
+        var stateBehaviorInstance = new ServerObjectStateBehavior(objectStateBehaviorTemplate.m_stateSetName);
+        this.Behaviors.Add(stateBehaviorInstance);
     }
 
     private void EquipItem(WizItemTemplate template) {

--- a/src/CoreLib/Game/Zone/WizardZoneCreature.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneCreature.cs
@@ -18,6 +18,7 @@ using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.Shared.Packets;
 using Imlight.CoreLib.Shared.Resources;
 using Imlight.CoreLib.WizardData.Implementations;
+using Imlight.CoreLib.WizardData.Models.Player;
 using SharpDX;
 using static Imlight.Common.Caches.TypeCache;
 
@@ -92,11 +93,11 @@ public class WizardZoneCreature : WizardZoneObject, IWithTimers {
             => new WizardZoneCreature(activeGameObject, template, path, startingNodeIndex, wizardZoneRef));
     }
 
-    protected override void OnPlayerJoin(CoreObject player, IActorRef playerActor) {
+    protected override void OnPlayerJoin(CoreObject player, IActorRef playerActor, Wizard wizard) {
         // Since we're not constantly updating the position of the game object, we need to
         // update the position of the game object when a player joins.
         ActiveGameObject.m_location = GetPosition();
-        base.OnPlayerJoin(player, playerActor);
+        base.OnPlayerJoin(player, playerActor, wizard);
 
         // Inform the new player that this creature is moving.
         // MOVESTATE: 0 = stopped, 1 = moving.

--- a/src/CoreLib/Game/Zone/WizardZoneCreature.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneCreature.cs
@@ -52,7 +52,6 @@ public class WizardZoneCreature : WizardZoneObject, IWithTimers {
     protected DateTime _lastMoveTime;
     protected ServerNPCBehavior _npcBehavior;
     protected ServerPathBehavior _pathBehavior;
-    protected ServerObjectStateBehavior _stateBehavior;
     protected IActorRef _combatAiActor;
 
     // ctor
@@ -314,32 +313,6 @@ public class WizardZoneCreature : WizardZoneObject, IWithTimers {
         WizardZoneRef.Tell(msg);
     }
 
-    [MessageHandler(typeof(CHARACTER_103_PROTOCOL.MSG_ENTERSTATE))]
-    private void ReceiveEnterState(CHARACTER_103_PROTOCOL.MSG_ENTERSTATE message) {
-        var objState = _stateBehavior.SetState(message.StateName);
-        if (objState is null) {
-            Logger.Error("Failed to enter state {0} for creature {1}", Logger.Args(message.StateName, ActiveGameObject.m_debugName));
-            return;
-        }
-
-        // Echo the state change to the client.
-        var stateMsg = new GAME_5_PROTOCOL.MSG_ENTERSTATE {
-            GameObjectID = ActiveGameObject.m_globalID,
-            State = StringHash.Compute(message.StateName)
-        };
-
-        var isPublicStateChange = !objState.m_privateState;
-        if (isPublicStateChange) {
-            var zoneBroadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
-                Message = stateMsg,
-                Selfless = true,
-                Sender = Self
-            };
-            WizardZoneRef.Tell(zoneBroadcastMsg);
-        }
-
-    }
-
     private void CreateBehaviorsFromTemplate() {
         var pathBehaviorTemplate = Template.m_behaviors
             .FirstOrDefault(x => x is PathBehaviorTemplate) as PathBehaviorTemplate;
@@ -351,13 +324,10 @@ public class WizardZoneCreature : WizardZoneObject, IWithTimers {
             .FirstOrDefault(x => x is NPCBehaviorTemplate) as NPCBehaviorTemplate;
         var equipmentBehaviorTemplate = Template.m_behaviors
             .FirstOrDefault(x => x is EquipmentBehaviorTemplate) as EquipmentBehaviorTemplate;
-        var objectStateBehaviorTemplate = Template.m_behaviors
-            .FirstOrDefault(x => x is ObjectStateBehaviorTemplate) as ObjectStateBehaviorTemplate;
 
         CreatePathBehavior(pathBehaviorTemplate, pathMovementBehavior);
         CreateNPCBehavior(npcBehaviorTemplate, duelistBehaviorTemplate);
         CreateEquipmentBehavior(equipmentBehaviorTemplate);
-        CreateStateBehavior(objectStateBehaviorTemplate);
     }
 
     private void CreatePathBehavior(PathBehaviorTemplate pathTemplate, PathMovementBehaviorTemplate movementTemplate) {
@@ -464,11 +434,6 @@ public class WizardZoneCreature : WizardZoneObject, IWithTimers {
     private void CreateDeckBehavior(DeckBehaviorTemplate deckBehaviorTemplate) {
         var deckBehaviorInstance = new ServerCreatureSpellbookBehavior(deckBehaviorTemplate);
         this.Behaviors.Add(deckBehaviorInstance);
-    }
-
-    private void CreateStateBehavior(ObjectStateBehaviorTemplate objectStateBehaviorTemplate) {
-        _stateBehavior = new ServerObjectStateBehavior(objectStateBehaviorTemplate.m_stateSetName);
-        this.Behaviors.Add(_stateBehavior);
     }
 
     private void EquipItem(WizItemTemplate template) {

--- a/src/CoreLib/Game/Zone/WizardZoneCreature.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneCreature.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Akka.Actor;
 using Imlight.Common;
 using Imlight.Common.Caches;
+using Imlight.Common.Cryptography;
 using Imlight.Common.ObjectProperty;
 using Imlight.CoreLib.Game.Combat;
 using Imlight.CoreLib.Game.Effects;
@@ -51,6 +52,7 @@ public class WizardZoneCreature : WizardZoneObject, IWithTimers {
     protected DateTime _lastMoveTime;
     protected ServerNPCBehavior _npcBehavior;
     protected ServerPathBehavior _pathBehavior;
+    protected ServerObjectStateBehavior _stateBehavior;
     protected IActorRef _combatAiActor;
 
     // ctor
@@ -312,6 +314,32 @@ public class WizardZoneCreature : WizardZoneObject, IWithTimers {
         WizardZoneRef.Tell(msg);
     }
 
+    [MessageHandler(typeof(CHARACTER_103_PROTOCOL.MSG_ENTERSTATE))]
+    private void ReceiveEnterState(CHARACTER_103_PROTOCOL.MSG_ENTERSTATE message) {
+        var objState = _stateBehavior.SetState(message.StateName);
+        if (objState is null) {
+            Logger.Error("Failed to enter state {0} for creature {1}", Logger.Args(message.StateName, ActiveGameObject.m_debugName));
+            return;
+        }
+
+        // Echo the state change to the client.
+        var stateMsg = new GAME_5_PROTOCOL.MSG_ENTERSTATE {
+            GameObjectID = ActiveGameObject.m_globalID,
+            State = StringHash.Compute(message.StateName)
+        };
+
+        var isPublicStateChange = !objState.m_privateState;
+        if (isPublicStateChange) {
+            var zoneBroadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
+                Message = stateMsg,
+                Selfless = true,
+                Sender = Self
+            };
+            WizardZoneRef.Tell(zoneBroadcastMsg);
+        }
+
+    }
+
     private void CreateBehaviorsFromTemplate() {
         var pathBehaviorTemplate = Template.m_behaviors
             .FirstOrDefault(x => x is PathBehaviorTemplate) as PathBehaviorTemplate;
@@ -439,8 +467,8 @@ public class WizardZoneCreature : WizardZoneObject, IWithTimers {
     }
 
     private void CreateStateBehavior(ObjectStateBehaviorTemplate objectStateBehaviorTemplate) {
-        var stateBehaviorInstance = new ServerObjectStateBehavior(objectStateBehaviorTemplate.m_stateSetName);
-        this.Behaviors.Add(stateBehaviorInstance);
+        _stateBehavior = new ServerObjectStateBehavior(objectStateBehaviorTemplate.m_stateSetName);
+        this.Behaviors.Add(_stateBehavior);
     }
 
     private void EquipItem(WizItemTemplate template) {

--- a/src/CoreLib/Game/Zone/WizardZoneLoader.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneLoader.cs
@@ -19,6 +19,7 @@ using Imlight.CoreLib.WizardData.Implementations;
 using SharpDX;
 using static Imlight.Common.Caches.TypeCache;
 using static Imlight.Common.Caches.ServerTypeCache;
+using Imlight.Common.Cryptography;
 
 namespace Imlight.CoreLib.Game.Zone;
 

--- a/src/CoreLib/Game/Zone/WizardZoneNpc.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneNpc.cs
@@ -11,6 +11,7 @@ using Imlight.Common.ObjectProperty;
 using Imlight.Common.ObjectProperty.PropertyReflection;
 using Imlight.CoreLib.Shared.Packets;
 using Imlight.CoreLib.WizardData.Collections;
+using Imlight.CoreLib.WizardData.Models.Player;
 using System.Collections.Generic;
 using System.Linq;
 using static Imlight.Common.Caches.TypeCache;
@@ -65,8 +66,8 @@ public class WizardZoneNpc : WizardZoneObject {
     public static Props Props(CoreObject activeGameObject, CoreTemplate template, IActorRef wizardZoneRef)
         => Akka.Actor.Props.Create(() => new WizardZoneNpc(activeGameObject, template, wizardZoneRef));
 
-    protected override void OnPlayerJoin(CoreObject player, IActorRef suspect) {
-        base.OnPlayerJoin(player, suspect);
+    protected override void OnPlayerJoin(CoreObject player, IActorRef suspect, Wizard wizard) {
+        base.OnPlayerJoin(player, suspect, wizard);
 
         if (IsShopkeeper) {
             var wizBangMsg = new GAME_5_PROTOCOL.MSG_WIZBANG {

--- a/src/CoreLib/Game/Zone/WizardZoneObject.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneObject.cs
@@ -231,6 +231,10 @@ public class WizardZoneObject : ReceiveProtocolDispatcher, IClientTypeProvider<W
         WizardZoneRef.Tell(zoneBroadcastMsg);
     }
 
+    [MessageHandler(typeof(CHARACTER_103_PROTOCOL.MSG_ADDDYNAMOD))]
+    private void ReceiveAddDynaMod(CHARACTER_103_PROTOCOL.MSG_ADDDYNAMOD message)
+        => EnterState(message.DynaMod.m_dynaModState, message.ContextActor);
+
     protected void SpawnSelf() {
         var msg = new GAME_5_PROTOCOL.MSG_NEWOBJECT { Data = _zoneObjectSerializer.Serialize(GetClientTypeAlternative()) };
 

--- a/src/CoreLib/Game/Zone/WizardZoneObject.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneObject.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Akka.Actor;
 using Imlight.Common;
 using Imlight.Common.Caches;
+using Imlight.Common.Cryptography;
 using Imlight.Common.ObjectProperty;
 using Imlight.CoreLib.Shared.Behaviors;
 using Imlight.CoreLib.Shared.Networking;
@@ -29,6 +30,7 @@ public class WizardZoneObject : ReceiveProtocolDispatcher, IClientTypeProvider<W
     protected readonly IActorRef WizardZoneRef;
     protected readonly List<BehaviorInstance> Behaviors = new();
     protected float InteractionRadius = 300f;
+    protected ServerObjectStateBehavior StateBehavior;
 
     private readonly List<CoreObject> _objsInRadius;
     private readonly CoreObjectSerializer _zoneObjectSerializer = new CoreObjectSerializer()
@@ -43,6 +45,10 @@ public class WizardZoneObject : ReceiveProtocolDispatcher, IClientTypeProvider<W
         this.Template = template;
         this.WizardZoneRef = wizardZoneRef;
         this._objsInRadius = new List<CoreObject>();
+
+        if (template.m_behaviors.Any(x => x is ObjectStateBehaviorTemplate)) {
+            CreateStateBehavior(template.m_behaviors.OfType<ObjectStateBehaviorTemplate>().First());
+        }
     }
 
     // Akka.NET ctor
@@ -198,6 +204,31 @@ public class WizardZoneObject : ReceiveProtocolDispatcher, IClientTypeProvider<W
     protected void ReceiveStatusCheck(ZONE_102_PROTOCOL.MSG_OBJECTSTATUSCHECK message) =>
         OnStatusCheck();
 
+    [MessageHandler(typeof(CHARACTER_103_PROTOCOL.MSG_ENTERSTATE))]
+    private void ReceiveEnterState(CHARACTER_103_PROTOCOL.MSG_ENTERSTATE message) {
+        var objState = StateBehavior.SetState(message.StateName);
+        if (objState is null) {
+            Logger.Error("Failed to enter state {0} for creature {1}", Logger.Args(message.StateName, ActiveGameObject.m_debugName));
+            return;
+        }
+
+        // Echo the state change to the client.
+        var stateMsg = new GAME_5_PROTOCOL.MSG_ENTERSTATE {
+            GameObjectID = ActiveGameObject.m_globalID,
+            State = StringHash.Compute(message.StateName)
+        };
+
+        var isPublicStateChange = !objState.m_privateState;
+        if (isPublicStateChange) {
+            var zoneBroadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
+                Message = stateMsg,
+                Selfless = true,
+                Sender = Self
+            };
+            WizardZoneRef.Tell(zoneBroadcastMsg);
+        }
+    }
+
     protected void SpawnSelf() {
         var msg = new GAME_5_PROTOCOL.MSG_NEWOBJECT { Data = _zoneObjectSerializer.Serialize(GetClientTypeAlternative()) };
 
@@ -215,6 +246,11 @@ public class WizardZoneObject : ReceiveProtocolDispatcher, IClientTypeProvider<W
         var sqrtRadius = InteractionRadius * InteractionRadius;
 
         return sqrtDist <= sqrtRadius;
+    }
+
+    private void CreateStateBehavior(ObjectStateBehaviorTemplate objectStateBehaviorTemplate) {
+        StateBehavior = new ServerObjectStateBehavior(objectStateBehaviorTemplate.m_stateSetName);
+        this.Behaviors.Add(StateBehavior);
     }
 
     public WizClientObject GetClientTypeAlternative() {

--- a/src/CoreLib/Game/Zone/WizardZoneObject.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneObject.cs
@@ -15,6 +15,7 @@ using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.Shared.Packets;
 using Imlight.CoreLib.Shared.Resources;
 using Imlight.CoreLib.WizardData.Implementations;
+using Imlight.CoreLib.WizardData.Models.Player;
 using SharpDX;
 using static Imlight.Common.Caches.TypeCache;
 
@@ -46,7 +47,8 @@ public class WizardZoneObject : ReceiveProtocolDispatcher, IClientTypeProvider<W
         this.WizardZoneRef = wizardZoneRef;
         this._objsInRadius = new List<CoreObject>();
 
-        if (template.m_behaviors.Any(x => x is ObjectStateBehaviorTemplate)) {
+        if (template is not null &&
+            template.m_behaviors.Any(x => x is ObjectStateBehaviorTemplate)) {
             CreateStateBehavior(template.m_behaviors.OfType<ObjectStateBehaviorTemplate>().First());
         }
     }
@@ -78,7 +80,7 @@ public class WizardZoneObject : ReceiveProtocolDispatcher, IClientTypeProvider<W
     /// </summary>
     /// <param name="player">The player object that joined the zone.</param>
     /// <param name="suspect">The actor reference of the player that joined the zone.</param>
-    protected virtual void OnPlayerJoin(CoreObject player, IActorRef suspect) {
+    protected virtual void OnPlayerJoin(CoreObject player, IActorRef suspect, Wizard wizard) {
         // If the player spawns within this object, add them to the list of objects in radius.
         if (IsInRadius(player)) {
             _objsInRadius.Add(player);
@@ -87,6 +89,13 @@ public class WizardZoneObject : ReceiveProtocolDispatcher, IClientTypeProvider<W
         // When a new player joins, we need to send them the object data.
         var msg = new GAME_5_PROTOCOL.MSG_NEWOBJECT { Data = _zoneObjectSerializer.Serialize(GetClientTypeAlternative()) };
         suspect.Tell(msg);
+
+        // Check this player's dynamic modifications. If they have any, apply them.
+        var dynamod = wizard.DynamodSet.Dynamods
+            .FirstOrDefault(x => StringHash.Compute(x.ClientTag) == ActiveGameObject.m_zoneTagID);
+        if (dynamod != null) {
+            EnterState(dynamod.ModState, suspect);
+        }
 
         Sender.Tell(new ZONE_102_PROTOCOL.MSG_ADDOBJECTRSP());
     }
@@ -159,7 +168,7 @@ public class WizardZoneObject : ReceiveProtocolDispatcher, IClientTypeProvider<W
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ADDPLAYER))]
     protected virtual void ReceiveAddPlayer(ZONE_102_PROTOCOL.MSG_ADDPLAYER message)
-        => OnPlayerJoin(message.PlayerObject, message.Player);
+        => OnPlayerJoin(message.PlayerObject, message.Player, message.Wizard);
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_REMOVEPLAYER))]
     protected virtual void ReceiveRemovePlayer(ZONE_102_PROTOCOL.MSG_REMOVEPLAYER message)
@@ -206,27 +215,20 @@ public class WizardZoneObject : ReceiveProtocolDispatcher, IClientTypeProvider<W
 
     [MessageHandler(typeof(CHARACTER_103_PROTOCOL.MSG_ENTERSTATE))]
     private void ReceiveEnterState(CHARACTER_103_PROTOCOL.MSG_ENTERSTATE message) {
-        var objState = StateBehavior.SetState(message.StateName);
-        if (objState is null) {
-            Logger.Error("Failed to enter state {0} for creature {1}", Logger.Args(message.StateName, ActiveGameObject.m_debugName));
-            return;
-        }
+        EnterState(message.StateName, Sender);
 
-        // Echo the state change to the client.
+        // Broadcast the state change to all players.
         var stateMsg = new GAME_5_PROTOCOL.MSG_ENTERSTATE {
             GameObjectID = ActiveGameObject.m_globalID,
             State = StringHash.Compute(message.StateName)
         };
 
-        var isPublicStateChange = !objState.m_privateState;
-        if (isPublicStateChange) {
-            var zoneBroadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
-                Message = stateMsg,
-                Selfless = true,
-                Sender = Self
-            };
-            WizardZoneRef.Tell(zoneBroadcastMsg);
-        }
+        var zoneBroadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
+            Message = stateMsg,
+            Selfless = true,
+            Sender = Self
+        };
+        WizardZoneRef.Tell(zoneBroadcastMsg);
     }
 
     protected void SpawnSelf() {
@@ -239,6 +241,21 @@ public class WizardZoneObject : ReceiveProtocolDispatcher, IClientTypeProvider<W
             Sender = Self
         };
         WizardZoneRef.Tell(broadcastMsg);
+    }
+
+    protected void EnterState(string newStateName, IActorRef sender) {
+        var objState = StateBehavior.SetState(newStateName);
+        if (objState is null) {
+            Logger.Error("Failed to enter state {0} for creature {1}", Logger.Args(newStateName, ActiveGameObject.m_debugName));
+            return;
+        }
+
+        var stateMsg = new GAME_5_PROTOCOL.MSG_ENTERSTATE {
+            GameObjectID = ActiveGameObject.m_globalID,
+            State = StringHash.Compute(newStateName)
+        };
+
+        sender.Tell(stateMsg);
     }
 
     private bool IsInRadius(CoreObject obj1) {

--- a/src/CoreLib/Game/Zone/WizardZoneObjectSupervisor.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneObjectSupervisor.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Akka.Actor;
 using Imlight.Common;
+using Imlight.Common.Cryptography;
 using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.Shared.Packets;
 using static Imlight.Common.Caches.TypeCache;
@@ -98,6 +99,17 @@ public class WizardZoneObjectSupervisor : ReceiveProtocolDispatcher {
         var rsp = new ZONE_102_PROTOCOL.MSG_QUERYZONEOBJECTRSP { ZoneObject = obj };
 
         Sender.Tell(rsp);
+    }
+
+    [MessageHandler(typeof(CHARACTER_103_PROTOCOL.MSG_ADDDYNAMOD))]
+    private void ReceiveAddDynaMod(CHARACTER_103_PROTOCOL.MSG_ADDDYNAMOD message) {
+        foreach (var obj in _objects) {
+            if (obj.Value.ActiveGameObject.m_zoneTagID != StringHash.Compute(message.DynaMod.m_dynaModClientTag)) {
+                continue;
+            }
+
+            obj.Key.Tell(message);
+        }
     }
 
     private void CreateActorAndRespond(Props props) {

--- a/src/CoreLib/Game/Zone/WizardZoneSigil.cs
+++ b/src/CoreLib/Game/Zone/WizardZoneSigil.cs
@@ -10,6 +10,7 @@ using Imlight.Common.Caches;
 using Imlight.CoreLib.Game.Sigils;
 using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.Shared.Packets;
+using Imlight.CoreLib.WizardData.Models.Player;
 using static Imlight.Common.Caches.TypeCache;
 
 namespace Imlight.CoreLib.Game.Zone;
@@ -40,9 +41,9 @@ public class WizardZoneSigil : WizardZoneObject {
     public static Props Props(CoreObject activeGameObject, string sigilType, CoreTemplate template, IActorRef wizardZoneRef)
         => Akka.Actor.Props.Create(() => new WizardZoneSigil(activeGameObject, sigilType, template, wizardZoneRef));
 
-    protected override void OnPlayerJoin(CoreObject player, IActorRef suspect) {
+    protected override void OnPlayerJoin(CoreObject player, IActorRef suspect, Wizard wizard) {
         if (_activeDuel is not null) {
-            base.OnPlayerJoin(player, suspect);
+            base.OnPlayerJoin(player, suspect, wizard);
 
             // Inform the active duel of the new player.
             var msg = new ZONE_102_PROTOCOL.MSG_ADDPLAYER {

--- a/src/CoreLib/Shared/Behaviors/ServerObjectStateBehavior.cs
+++ b/src/CoreLib/Shared/Behaviors/ServerObjectStateBehavior.cs
@@ -34,6 +34,8 @@ using System;
 using System.Linq;
 using Imlight.Common;
 using Imlight.CoreLib.Game.States;
+using Imlight.CoreLib.WizardData.Models.Player;
+using Newtonsoft.Json;
 using static Imlight.Common.Caches.TypeCache;
 
 namespace Imlight.CoreLib.Shared.Behaviors;
@@ -41,8 +43,8 @@ namespace Imlight.CoreLib.Shared.Behaviors;
 public sealed class ServerObjectStateBehavior : ServerBehaviorInstance {
     public override bool NoTransfer { get; set; } = true;
 
-    private readonly string _stateSetName;
-    private readonly ObjStateSet _stateSet;
+    [JsonIgnore] private readonly string _stateSetName;
+    [JsonIgnore] private readonly ObjStateSet _stateSet;
 
     // ctor
     public ServerObjectStateBehavior(string stateSetName) {

--- a/src/CoreLib/Shared/Behaviors/ServerObjectStateBehavior.cs
+++ b/src/CoreLib/Shared/Behaviors/ServerObjectStateBehavior.cs
@@ -1,0 +1,121 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+/*
+Notes:
+
+State Catorgories:
+
+A "StateSet" has a number of categories, which have their own independent states. For example. NPCs have a state set "NPCMobileStates,"
+which has categories "Fundamental," "Primary," "Locomotive," and "NPCInteracting." Each category has its own set of states.
+An object may be in multiple states at once, but only one state per category.
+
+An npc's "fundamental" state may be "Alive," but in the "Locomotive" category, it may be "walking." These states are independent of each other,
+but a state change in one category may force a state change in another category. For example, if an NPC dies, it may be forced to stop walking.
+
+States themselves:
+
+A "state" is a specific phase that an object is in. There are states for dead/alive, walking/running/idle, and interacting with objects. Being in a state
+may change the object's behavior, like blocking movement or disallowing certain actions. Every time a state changes, the server will
+update the client with the new state, so long as the state is not private (_privateState).
+
+There are also state transitions. Each state will declare which states it is capable of transforming into. Some state changes may have an intermediate
+state known as a "transition state." Transition states are explicitly declared with the `m_autoTransition` field, and have a `m_transitionTime` field.
+When a state is changed to a state that has a transition state, the object will first enter the transition state, then the final state.
+
+Entering a state may also play an animation.
+
+A state also has a number of blocked states that it cannot be in while that state is active. The blocked states extend beyond the category of the state.
+*/
+
+using System;
+using System.Linq;
+using Imlight.Common;
+using Imlight.CoreLib.Game.States;
+using static Imlight.Common.Caches.TypeCache;
+
+namespace Imlight.CoreLib.Shared.Behaviors;
+
+public sealed class ServerObjectStateBehavior : ServerBehaviorInstance {
+    public override bool NoTransfer { get; set; } = true;
+
+    private readonly string _stateSetName;
+    private readonly ObjStateSet _stateSet;
+
+    // ctor
+    public ServerObjectStateBehavior(string stateSetName) {
+        _stateSetName = stateSetName;
+        _stateSet = StateFactory.GetStateSet(stateSetName)
+            ?? throw new ArgumentException($"StateSet '{stateSetName}' not found."); ;
+
+        SetDefaultStates();
+    }
+
+    // This is a no transfer behavior !!
+    public override BehaviorInstance GetClientBehaviorInstance() => throw new NotImplementedException();
+
+    public void SetState(string categoryName, string stateName) {
+        // Determine if the category and state given exist
+        var category = GetCategory(categoryName);
+        if (category == null) {
+            Logger.Error("Category {0} not found in {1} {2}", Logger.Args(categoryName, typeof(ObjStateSet), _stateSet));
+            return;
+        }
+
+        var newState = GetState(categoryName, stateName);
+        if (newState == null) {
+            Logger.Error("State {0} not found in {1} {2}", Logger.Args(stateName, typeof(ObjStateCategory), category));
+            return;
+        }
+
+        // Determine if this transition is possible given the current state.
+        // We'll throw a warning if the state is not allowed to transition to the new state, but continue regardless
+        // because we are the server and we can do whatever we want.
+        var currentState = GetCategoryState(categoryName);
+        var transition = GetTransitionFromCurrentState(categoryName, stateName);
+        if (transition is null) {
+            Logger.Warning("Transition from {0} to {1} not found in {2} {3}",
+                Logger.Args(currentState, newState, typeof(ObjStateCategory), category));
+        }
+
+        // The new state may force changes in the other categories.
+        foreach (var forceChange in newState.m_forcedStates) {
+            SetState(forceChange.m_category, forceChange.m_forcedState);
+        }
+
+        category.m_baseState = newState.m_stateName;
+    }
+
+    public string this[string categoryName] {
+        get {
+            var category = GetCategory(categoryName);
+            if (category == null) {
+                Logger.Error("Category {0} not found in {1} {2}", Logger.Args(categoryName, typeof(ObjStateSet), _stateSet));
+                return null;
+            }
+
+            return GetCategoryState(categoryName)?.m_stateName;
+        }
+        set => SetState(categoryName, value);
+    }
+
+    private void SetDefaultStates() {
+        foreach (var category in _stateSet.m_categories) {
+            category.m_baseState = category.m_startState;
+        }
+    }
+
+    private ObjStateCategory GetCategory(string categoryName)
+        => _stateSet.m_categories.FirstOrDefault(x => x.m_categoryName == categoryName);
+
+    private ObjState GetState(string categoryName, string stateName)
+        => GetCategory(categoryName)?.m_states.FirstOrDefault(x => x.m_stateName == stateName);
+
+    private ObjState GetCategoryState(string categoryName)
+        => GetCategory(categoryName)?.m_states.FirstOrDefault(x => x.m_stateName == GetCategory(categoryName)?.m_baseState);
+
+    private ObjStateTransition GetTransitionFromCurrentState(string categoryName, string stateName)
+        => GetCategoryState(categoryName)?.m_transitions.FirstOrDefault(x => x.m_targetState == stateName);
+}

--- a/src/CoreLib/Shared/Behaviors/ServerObjectStateBehavior.cs
+++ b/src/CoreLib/Shared/Behaviors/ServerObjectStateBehavior.cs
@@ -56,18 +56,29 @@ public sealed class ServerObjectStateBehavior : ServerBehaviorInstance {
     // This is a no transfer behavior !!
     public override BehaviorInstance GetClientBehaviorInstance() => throw new NotImplementedException();
 
-    public void SetState(string categoryName, string stateName) {
-        // Determine if the category and state given exist
+    public ObjState SetState(string stateName) {
+        // Find the category that the state belongs to.
+        var category = _stateSet.m_categories.FirstOrDefault(x => x.m_states.Any(y => y.m_stateName == stateName));
+        if (category == null) {
+            Logger.Error("State {0} not found in {1} {2}", Logger.Args(stateName, typeof(ObjStateSet), _stateSet));
+            return null;
+        }
+
+        return SetState(category.m_categoryName, stateName);
+    }
+
+    public ObjState SetState(string categoryName, string stateName) {
         var category = GetCategory(categoryName);
         if (category == null) {
-            Logger.Error("Category {0} not found in {1} {2}", Logger.Args(categoryName, typeof(ObjStateSet), _stateSet));
-            return;
+            Logger.Error("Category {0} not found in {1}", Logger.Args(categoryName, _stateSetName));
+            return null;
         }
 
         var newState = GetState(categoryName, stateName);
         if (newState == null) {
-            Logger.Error("State {0} not found in {1} {2}", Logger.Args(stateName, typeof(ObjStateCategory), category));
-            return;
+            Logger.Error("State {0} not found in category {1} in state set {2}",
+                Logger.Args(stateName, categoryName, _stateSetName));
+            return null;
         }
 
         // Determine if this transition is possible given the current state.
@@ -76,16 +87,17 @@ public sealed class ServerObjectStateBehavior : ServerBehaviorInstance {
         var currentState = GetCategoryState(categoryName);
         var transition = GetTransitionFromCurrentState(categoryName, stateName);
         if (transition is null) {
-            Logger.Warning("Transition from {0} to {1} not found in {2} {3}",
-                Logger.Args(currentState, newState, typeof(ObjStateCategory), category));
+            Logger.Warning("Transition from {0} to {1} not found in state set {2}",
+                Logger.Args(currentState.m_stateName, newState.m_stateName, _stateSetName));
         }
 
         // The new state may force changes in the other categories.
         foreach (var forceChange in newState.m_forcedStates) {
-            SetState(forceChange.m_category, forceChange.m_forcedState);
+            SetState(forceChange.m_forcedState);
         }
 
         category.m_baseState = newState.m_stateName;
+        return newState;
     }
 
     public string this[string categoryName] {

--- a/src/CoreLib/Shared/Behaviors/ServerObjectStateBehavior.cs
+++ b/src/CoreLib/Shared/Behaviors/ServerObjectStateBehavior.cs
@@ -67,27 +67,32 @@ public sealed class ServerObjectStateBehavior : ServerBehaviorInstance {
         return SetState(category.m_categoryName, stateName);
     }
 
-    public ObjState SetState(string categoryName, string stateName) {
+    public ObjState SetState(string categoryName, string newStateName) {
         var category = GetCategory(categoryName);
         if (category == null) {
             Logger.Error("Category {0} not found in {1}", Logger.Args(categoryName, _stateSetName));
             return null;
         }
 
-        var newState = GetState(categoryName, stateName);
+        var newState = GetState(categoryName, newStateName);
         if (newState == null) {
             Logger.Error("State {0} not found in category {1} in state set {2}",
-                Logger.Args(stateName, categoryName, _stateSetName));
+                Logger.Args(newStateName, categoryName, _stateSetName));
             return null;
+        }
+
+        // If the new state is the same as the current state, we don't need to do anything.
+        var currentState = GetCategoryState(categoryName);
+        if (currentState.m_stateName == newStateName) {
+            return currentState;
         }
 
         // Determine if this transition is possible given the current state.
         // We'll throw a warning if the state is not allowed to transition to the new state, but continue regardless
         // because we are the server and we can do whatever we want.
-        var currentState = GetCategoryState(categoryName);
-        var transition = GetTransitionFromCurrentState(categoryName, stateName);
+        var transition = GetTransitionFromCurrentState(categoryName, newStateName);
         if (transition is null) {
-            Logger.Warning("Transition from {0} to {1} not found in state set {2}",
+            Logger.Warning("Transition from {0} to {1} is not possible in state set {2}. We did it anyways.",
                 Logger.Args(currentState.m_stateName, newState.m_stateName, _stateSetName));
         }
 

--- a/src/CoreLib/Shared/Packets/CHARACTER_103_PROTOCOL.cs
+++ b/src/CoreLib/Shared/Packets/CHARACTER_103_PROTOCOL.cs
@@ -46,4 +46,11 @@ public class CHARACTER_103_PROTOCOL : IServerProtocol {
         public byte MessageOrder { get; } = 5;
         public byte ServiceID { get; } = 103;
     }
+
+    public sealed class MSG_ENTERSTATE : IServerMessage {
+        public byte MessageOrder { get; } = 6;
+        public byte ServiceID { get; } = 103;
+
+        public string StateName;
+    }
 }

--- a/src/CoreLib/Shared/Packets/CHARACTER_103_PROTOCOL.cs
+++ b/src/CoreLib/Shared/Packets/CHARACTER_103_PROTOCOL.cs
@@ -3,9 +3,11 @@
  * Proprietary and confidential.
  */
 
+using Akka.Actor;
 using Imlight.Common.Caches;
 using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.WizardData.Models.Player;
+using static Imlight.Common.Caches.ServerTypeCache;
 
 namespace Imlight.CoreLib.Shared.Packets;
 
@@ -52,5 +54,13 @@ public class CHARACTER_103_PROTOCOL : IServerProtocol {
         public byte ServiceID { get; } = 103;
 
         public string StateName;
+    }
+
+    public sealed class MSG_ADDDYNAMOD : IServerMessage {
+        public byte MessageOrder { get; } = 7;
+        public byte ServiceID { get; } = 103;
+
+        public ResAddDynaMod DynaMod;
+        public IActorRef ContextActor;
     }
 }

--- a/src/CoreLib/Shared/Packets/CHARACTER_103_PROTOCOL.cs
+++ b/src/CoreLib/Shared/Packets/CHARACTER_103_PROTOCOL.cs
@@ -63,4 +63,12 @@ public class CHARACTER_103_PROTOCOL : IServerProtocol {
         public ResAddDynaMod DynaMod;
         public IActorRef ContextActor;
     }
+
+    public sealed class MSG_REMOVEDYNAMOD : IServerMessage {
+        public byte MessageOrder { get; } = 8;
+        public byte ServiceID { get; } = 103;
+
+        public ResRemoveDynaMod DynaMod;
+        public IActorRef ContextActor;
+    }
 }

--- a/src/CoreLib/WizardData/Collections/AccountCollection.cs
+++ b/src/CoreLib/WizardData/Collections/AccountCollection.cs
@@ -113,6 +113,12 @@ public static class AccountCollection {
             character.EquipmentBehavior.EquippedItems = inventory
                 .Where(i => character.EquipmentBehavior.EquippedItemIds.Any(e => i.m_globalID == e)).ToList();
 
+            // Load character dynamic modifications.
+            var dynamods = session.Query<DynamodSet>(collectionName: DynamodCollection.CollectionName)
+                .Where(d => d.CharId == character.CharId)
+                .ToList();
+            character.DynamodSet = dynamods.FirstOrDefault() ?? new DynamodSet(character.CharId);
+
             character.AfterDatabaseLoad();
         }
 
@@ -163,6 +169,12 @@ public static class AccountCollection {
             // Find any items in the inventory that match the equipped item IDs.
             character.EquipmentBehavior.EquippedItems = inventory
                 .Where(i => character.EquipmentBehavior.EquippedItemIds.Any(e => i.m_globalID == e)).ToList();
+
+            // Load character dynamic modifications.
+            var dynamods = session.Query<DynamodSet>(collectionName: DynamodCollection.CollectionName)
+                .Where(d => d.CharId == character.CharId)
+                .ToList();
+            character.DynamodSet = dynamods.FirstOrDefault() ?? new DynamodSet(character.CharId);
 
             character.AfterDatabaseLoad();
         }

--- a/src/CoreLib/WizardData/Collections/DynamodCollection.cs
+++ b/src/CoreLib/WizardData/Collections/DynamodCollection.cs
@@ -1,0 +1,102 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+using Imlight.CoreLib.WizardData.Databases;
+using Imlight.CoreLib.WizardData.Models.Player;
+using Raven.Client.Documents;
+using System.Linq;
+
+namespace Imlight.CoreLib.WizardData.Collections;
+
+public static class DynamodCollection {
+    public const string CollectionName = "DynamicMod";
+
+    private static readonly IDocumentStore s_store;
+
+    static DynamodCollection() {
+        s_store = PlayerDatabase.Instance.Store;
+    }
+
+    /// <summary>
+    /// Adds a DynamodSet to the collection.
+    /// </summary>
+    /// <param name="dynamodSet">The DynamodSet to add.</param>
+    /// <returns>
+    ///   <c>true</c> if the DynamodSet was added successfully;
+    ///   <c>false</c> if the DynamodSet already exists in the collection.
+    /// </returns>
+    public static bool AddDynamodSet(DynamodSet dynamodSet) {
+        using var session = s_store.OpenSession();
+
+        // Ensure that this dynamod set does not already exist
+        var dynamodSetExists = session.Query<DynamodSet>(collectionName: CollectionName)
+            .Any(ds => ds.CharId == dynamodSet.CharId);
+        if (dynamodSetExists) {
+            return false;
+        }
+
+        session.Store(dynamodSet);
+        var metaData = session.Advanced.GetMetadataFor(dynamodSet);
+        metaData[Raven.Client.Constants.Documents.Metadata.Collection] = CollectionName;
+
+        session.SaveChanges();
+        return true;
+    }
+
+    /// <summary>
+    /// Removes a DynamodSet from the collection based on the specified character ID.
+    /// </summary>
+    /// <param name="charId">The character ID of the DynamodSet to remove.</param>
+    /// <returns><c>true</c> if the DynamodSet was successfully removed; otherwise, <c>false</c>.</returns>
+    public static bool RemoveDynamodSet(ulong charId) {
+        using var session = s_store.OpenSession();
+
+        var dynamodSet = session.Query<DynamodSet>(collectionName: CollectionName)
+            .FirstOrDefault(ds => ds.CharId == charId);
+
+        if (dynamodSet == null) {
+            return false;
+        }
+
+        session.Delete(dynamodSet);
+        session.SaveChanges();
+        return true;
+    }
+
+    /// <summary>
+    /// Retrieves a DynamodSet from the collection based on the specified character ID.
+    /// </summary>
+    /// <param name="charId">The character ID of the DynamodSet to retrieve.</param>
+    /// <returns>The DynamodSet with the specified character ID, or <c>null</c> if not found.</returns>
+    public static DynamodSet GetDynamodSet(ulong charId) {
+        using var session = s_store.OpenSession();
+
+        return session.Query<DynamodSet>(collectionName: CollectionName)
+            .FirstOrDefault(ds => ds.CharId == charId);
+    }
+
+    /// <summary>
+    /// Updates a DynamodSet in the database.
+    /// </summary>
+    /// <param name="dynamodSet">The DynamodSet to update.</param>
+    /// <returns>True if the DynamodSet was successfully updated, false otherwise.</returns>
+    public static bool UpdateDynamodSet(DynamodSet dynamodSet) {
+        using var session = s_store.OpenSession();
+
+        // Ensure that this dynamod set exists. If not, we'll add it instead.
+        var dynamodSetExists = session.Query<DynamodSet>(collectionName: CollectionName)
+            .Any(ds => ds.CharId == dynamodSet.CharId);
+        if (!dynamodSetExists) {
+            AddDynamodSet(dynamodSet);
+        }
+
+        session.Store(dynamodSet);
+        var metaData = session.Advanced.GetMetadataFor(dynamodSet);
+        metaData[Raven.Client.Constants.Documents.Metadata.Collection] = CollectionName;
+
+        session.SaveChanges();
+        return true;
+    }
+}

--- a/src/CoreLib/WizardData/Collections/NpcInventoryCollection.cs
+++ b/src/CoreLib/WizardData/Collections/NpcInventoryCollection.cs
@@ -9,6 +9,7 @@ using Imlight.CoreLib.WizardData.Databases;
 using Imlight.CoreLib.WizardData.Models.World;
 
 namespace Imlight.CoreLib.WizardData.Collections;
+
 public static class NpcInventoryCollection {
     public const string CollectionName = "NpcInventory";
     private static readonly IDocumentStore s_store;

--- a/src/CoreLib/WizardData/Models/Player/Dynamod.cs
+++ b/src/CoreLib/WizardData/Models/Player/Dynamod.cs
@@ -1,0 +1,66 @@
+/* Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ */
+
+using Imlight.CoreLib.WizardData.Collections;
+using System;
+
+namespace Imlight.CoreLib.WizardData.Models.Player;
+
+public class DynamodSet {
+    internal ulong CharId { get; set; }
+    internal Dynamod[] Dynamods { get; set; }
+
+    // ctor
+    internal DynamodSet(ulong charId) {
+        CharId = charId;
+    }
+
+    internal bool AddDynamod(Dynamod dynamod) {
+        if (Dynamods == null) {
+            Dynamods = new Dynamod[1];
+            Dynamods[0] = dynamod;
+            return true;
+        }
+
+        for (int i = 0; i < Dynamods.Length; i++) {
+            if (Dynamods[i].ZoneName == dynamod.ZoneName) {
+                Dynamods[i] = dynamod;
+                return true;
+            }
+        }
+
+        Dynamod[] resizedArray = new Dynamod[Dynamods.Length + 1];
+        Array.Copy(Dynamods, resizedArray, Dynamods.Length);
+        resizedArray[Dynamods.Length] = dynamod;
+        Dynamods = resizedArray;
+
+        return true;
+    }
+
+    internal bool RemoveDynamod(string zoneName) {
+        if (Dynamods == null) {
+            return false;
+        }
+
+        for (int i = 0; i < Dynamods.Length; i++) {
+            if (Dynamods[i].ZoneName == zoneName) {
+                Dynamod[] resizedArray = new Dynamod[Dynamods.Length - 1];
+                Array.Copy(Dynamods, resizedArray, i);
+                Array.Copy(Dynamods, i + 1, resizedArray, i, Dynamods.Length - i - 1);
+                Dynamods = resizedArray;
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+[Serializable]
+public class Dynamod {
+    internal string ZoneName { get; set; }
+    internal string ClientTag { get; set; }
+    internal string ModState { get; set; }
+}

--- a/src/CoreLib/WizardData/Models/Player/Dynamod.cs
+++ b/src/CoreLib/WizardData/Models/Player/Dynamod.cs
@@ -50,17 +50,14 @@ public class DynamodSet {
         return true;
     }
 
-    internal bool RemoveDynamod(string zoneName) {
+    internal bool RemoveDynamod(string clientTag) {
         if (Dynamods == null) {
             return false;
         }
 
         for (int i = 0; i < Dynamods.Length; i++) {
-            if (Dynamods[i].ZoneName == zoneName) {
-                Dynamod[] resizedArray = new Dynamod[Dynamods.Length - 1];
-                Array.Copy(Dynamods, resizedArray, i);
-                Array.Copy(Dynamods, i + 1, resizedArray, i, Dynamods.Length - i - 1);
-                Dynamods = resizedArray;
+            if (Dynamods[i].ClientTag == clientTag) {
+                Dynamods[i] = null;
                 return true;
             }
         }

--- a/src/CoreLib/WizardData/Models/Player/Dynamod.cs
+++ b/src/CoreLib/WizardData/Models/Player/Dynamod.cs
@@ -5,6 +5,7 @@
 
 using Imlight.CoreLib.WizardData.Collections;
 using System;
+using System.Text.Json.Serialization;
 
 namespace Imlight.CoreLib.WizardData.Models.Player;
 
@@ -12,9 +13,19 @@ public class DynamodSet {
     internal ulong CharId { get; set; }
     internal Dynamod[] Dynamods { get; set; }
 
+    [JsonConstructor]
+    public DynamodSet() { }
+
     // ctor
     internal DynamodSet(ulong charId) {
         CharId = charId;
+
+        // todo: test; remove later!
+        AddDynamod(new Dynamod {
+            ZoneName = "WizardCity/WC_Hub",
+            ClientTag = "WC_GateCommons_ToUnicornWay",
+            ModState = "IdleOpen"
+        });
     }
 
     internal bool AddDynamod(Dynamod dynamod) {

--- a/src/CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/CoreLib/WizardData/Models/Player/Wizard.cs
@@ -556,7 +556,6 @@ public class Wizard : IDisposable {
         var removeSuccess = DynamodSet.RemoveDynamod(clientTag);
 
         if (!removeSuccess) {
-            Logger.Warning("Could not remove Dynamod from player {0}'s DynamodSet.", Logger.Args(PlayerNameBehavior.GetWizardName()));
             return false;
         }
 

--- a/src/CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/CoreLib/WizardData/Models/Player/Wizard.cs
@@ -28,8 +28,6 @@ namespace Imlight.CoreLib.WizardData.Models.Player;
 
 [Serializable]
 public class Wizard : IDisposable {
-    private const float OrientationCompressionFactor = CharacterHelper.OrientationCompressionFactor;
-
     public ulong AccountId { get; set; }
     public ulong CharId { get; set; }
     public string Zone { get; set; }
@@ -70,6 +68,7 @@ public class Wizard : IDisposable {
     public ServerMagicSchoolBehavior MagicSchoolBehavior { get; set; }
     public ServerWizSpellbookBehavior SpellbookBehavior { get; set; }
     public ServerMountOwnerBehavior MountOwnerBehavior { get; set; }
+    [JsonIgnore] public ServerObjectStateBehavior ObjectStateBehavior { get; set; }
     public ServerWizGameStats GameStats { get; set; }
 
     [JsonIgnore] public Account Account;
@@ -79,6 +78,7 @@ public class Wizard : IDisposable {
     [JsonIgnore] public ushort GameServerPort;
     [JsonIgnore] public string QueuedZoneName;
     [JsonIgnore] public string QueuedZoneLocation;
+    [JsonIgnore] internal DynamodSet DynamodSet { get; set; }
 
     [JsonIgnore] private Vector3 _location;
     [JsonIgnore] private Vector3 _orientation;
@@ -103,7 +103,6 @@ public class Wizard : IDisposable {
         284071, // Swift Gryphon (PERM)
         126983, // Starter Deck
     };
-    [JsonIgnore] private ServerObjectStateBehavior _objectStateBehavior;
 
     // Constructor: Used for deserialization. If this is not present, the default constructor will be used.
     [JsonConstructor]
@@ -124,6 +123,11 @@ public class Wizard : IDisposable {
         InitializeSpellbookBehavior();
         InitializeMountOwnerBehavior();
         InitializeWizardGameStats(wizardSchoolType, level);
+
+        ObjectStateBehavior = new ServerObjectStateBehavior("PlayerMobileStates");
+
+        DynamodSet = new DynamodSet(CharId);
+        DynamodCollection.AddDynamodSet(DynamodSet);
     }
 
     public void SetCachedLocation(Vector3 loc) => Location = loc;
@@ -520,13 +524,54 @@ public class Wizard : IDisposable {
         return true;
     }
 
-    public ObjState EnterState(string stateName) => _objectStateBehavior.SetState(stateName);
+    public ObjState EnterState(string stateName) => ObjectStateBehavior.SetState(stateName);
+
+    public bool AddDynamod(string zoneName, string clientTag, string modState) {
+        DynamodSet ??= new DynamodSet(CharId);
+
+        var dynamod = new Dynamod {
+            ZoneName = zoneName,
+            ClientTag = clientTag,
+            ModState = modState
+        };
+
+        var addSuccess = DynamodSet.AddDynamod(dynamod);
+
+        if (!addSuccess) {
+            Logger.Warning("Could not add Dynamod to player {0}'s DynamodSet.", Logger.Args(PlayerNameBehavior.GetWizardName()));
+            return false;
+        }
+
+        // Persistent save.
+        DynamodCollection.UpdateDynamodSet(DynamodSet);
+
+        return true;
+    }
+
+    public bool RemoveDynamod(string zoneName) {
+        if (DynamodSet is null) {
+            return false;
+        }
+
+        var removeSuccess = DynamodSet.RemoveDynamod(zoneName);
+
+        if (!removeSuccess) {
+            Logger.Warning("Could not remove Dynamod from player {0}'s DynamodSet.", Logger.Args(PlayerNameBehavior.GetWizardName()));
+            return false;
+        }
+
+        // Persistent save.
+        DynamodCollection.UpdateDynamodSet(DynamodSet);
+
+        return true;
+    }
 
     internal void AfterDatabaseLoad() {
         AfterDatabaseLoadWizardGameStats();
         AfterDatabaseLoadSpellbookBehavior();
         AfterDatabaseloadMountOwnerBehavior();
-        _objectStateBehavior = new ServerObjectStateBehavior("PlayerMobileStates");
+
+        ObjectStateBehavior ??= new ServerObjectStateBehavior("PlayerMobileStates");
     }
 
     private void EquipMount(WizItemTemplate template, WizClientObjectItem item) {

--- a/src/CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/CoreLib/WizardData/Models/Player/Wizard.cs
@@ -103,6 +103,7 @@ public class Wizard : IDisposable {
         284071, // Swift Gryphon (PERM)
         126983, // Starter Deck
     };
+    [JsonIgnore] private ServerObjectStateBehavior _objectStateBehavior;
 
     // Constructor: Used for deserialization. If this is not present, the default constructor will be used.
     [JsonConstructor]
@@ -519,10 +520,13 @@ public class Wizard : IDisposable {
         return true;
     }
 
+    public ObjState EnterState(string stateName) => _objectStateBehavior.SetState(stateName);
+
     internal void AfterDatabaseLoad() {
         AfterDatabaseLoadWizardGameStats();
         AfterDatabaseLoadSpellbookBehavior();
         AfterDatabaseloadMountOwnerBehavior();
+        _objectStateBehavior = new ServerObjectStateBehavior("PlayerMobileStates");
     }
 
     private void EquipMount(WizItemTemplate template, WizClientObjectItem item) {

--- a/src/CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/CoreLib/WizardData/Models/Player/Wizard.cs
@@ -548,12 +548,12 @@ public class Wizard : IDisposable {
         return true;
     }
 
-    public bool RemoveDynamod(string zoneName) {
+    public bool RemoveDynamod(string clientTag) {
         if (DynamodSet is null) {
             return false;
         }
 
-        var removeSuccess = DynamodSet.RemoveDynamod(zoneName);
+        var removeSuccess = DynamodSet.RemoveDynamod(clientTag);
 
         if (!removeSuccess) {
             Logger.Warning("Could not remove Dynamod from player {0}'s DynamodSet.", Logger.Args(PlayerNameBehavior.GetWizardName()));


### PR DESCRIPTION
## Changelog
* Added `StateFactory` as a root directory resource to load all files in a `StateData/` directory
* Added `ServerObjectStateBehavior` as a behavior instance for both `Wizard`s and `WizardZoneObject`s. Handles the logic for state changes and transitions.
* Added `DynamodCollection` in the player database
* Added `Dynamod` and `DynamodSet` classes
* Added a `DynamodSet` field for the `Wizard` class, with methods `AddDynamod` and `RemoveDynamod`
* Added dispatch handlers for both `ResAddDynaMod` and `ResRemoveDynaMod`

## Writings
### States
A "state" is a specific phase that an object is in. There are states for dead/alive, walking/running/idle, and interacting with objects. Being in a state may change the object's behavior, like blocking movement or disallowing certain actions. Every time a state changes, the server will update the client with the new state, so long as the state is not private (_privateState).

There are also state transitions. Each state will declare which states it is capable of transforming into. Some state changes may have an intermediate state known as a "transition state." Transition states are explicitly declared with the `m_autoTransition` field, and have a `m_transitionTime` field.

When a state is changed to a state that has a transition state, the object will first enter the transition state, then the final state.

Entering a state may also play an animation.

### DynaMods
This is guessed to be shorthand for "dynamic modification." In some instance that a quest is completed, the world may change. This may be an object changing state, or being spawned/despawned entirely. The *dynamic* action of the world changing are known as dynamic modifications.