### PR TITLE
`Fix/zonestuffs` -> `quality-assurance`

### DIFF
--- a/src/CoreLib/Game/Zone/Components/CombatDuelComponent.cs
+++ b/src/CoreLib/Game/Zone/Components/CombatDuelComponent.cs
@@ -72,6 +72,7 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
     private CombatSigilTemplate _sigilTemplate;
     private bool _isActive;
     private bool _awaitingCombatMoves;
+
     public static bool ShouldAttachToEntity(CoreTemplate template)
         => template is GameObjectTemplate gameObjectTemplate
         && gameObjectTemplate.m_behaviors.Any(x => x is not null && x.m_behaviorName == "DuelBehavior");
@@ -283,6 +284,10 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
 
     [MessageHandler(typeof(COMBAT_106_PROTOCOL.MSG_PLANNINGPHASEOVER))]
     private void ReceivePlanningPhaseOver(COMBAT_106_PROTOCOL.MSG_PLANNINGPHASEOVER message) {
+        if (!_isActive) {
+            return;
+        }
+
         Logger.Debug("Duel {0} | Round {1} over at {2}",
             Logger.Args(Duel.m_duelID, Duel.m_roundNum, DateTime.Now.ToString("HH:mm:ss")));
 
@@ -855,8 +860,7 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
         ZoneBroadcast(duelEndedMsg);
 
         DespawnDuel();
-
-        Context.Stop(Self);
+        _isActive = false;
     }
 
     private void PlayerWin() {
@@ -934,4 +938,5 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
 
         return slotAvailable;
     }
+
 }

--- a/src/CoreLib/Game/Zone/Components/PathMovementComponent.cs
+++ b/src/CoreLib/Game/Zone/Components/PathMovementComponent.cs
@@ -302,6 +302,8 @@ internal sealed class PathMovementComponent(ZoneEntity entity) : ZoneEntityCompo
                     )
                 );
 
+                Entity.DeleteObject();
+
                 return false;
             }
 

--- a/src/CoreLib/Game/Zone/Core/ZoneEntity.cs
+++ b/src/CoreLib/Game/Zone/Core/ZoneEntity.cs
@@ -79,6 +79,11 @@ public class ZoneEntity(
             m_despawnEffect = StringHash.Compute(effectName),
         };
 
+        // Send kill-pill to all components.
+        foreach (var (_, actor) in Components) {
+            actor.Tell(PoisonPill.Instance);
+        }
+
         var serializedData = _serializer.Serialize(despawnEffects);
         var despawnMsg = new GAME_5_PROTOCOL.MSG_DELETEOBJECT {
             GameObjectID = ActiveGameObject.m_globalID,

--- a/src/CoreLib/Game/Zone/Core/ZonePath.cs
+++ b/src/CoreLib/Game/Zone/Core/ZonePath.cs
@@ -222,8 +222,12 @@ public sealed class ZonePath : ZoneEntity, IWithTimers {
             var result = objectActor.Ask<ZONE_102_PROTOCOL.MSG_ZONEOBJECTLOADRESULTS>(msg, timeout).WaitAndUnwrapException();
         }
         catch (Exception ex) {
+            var goTemplate = template as GameObjectTemplate;
             Logger.Error("Failed to create entity actor for {0} {1} ({2}).",
-                Logger.Args(nameof(CoreTemplate), template.GetType().Name, ex.Message));
+                Logger.Args(nameof(CoreTemplate), goTemplate.m_objectName, ex.Message));
+
+            // Kill the actor.
+            objectActor.Tell(PoisonPill.Instance);
 
             return null;
         }

--- a/src/CoreLib/Game/Zone/Supervisors/ZoneEntitySupervisor.cs
+++ b/src/CoreLib/Game/Zone/Supervisors/ZoneEntitySupervisor.cs
@@ -99,8 +99,12 @@ internal abstract class ZoneEntitySupervisor(Core.Zone zone) : ReceiveProtocolDi
             EntityActors.Add(objectActor);
         }
         catch (Exception ex) {
-            Logger.Error("Failed to create entity actor for {0} {1} ({2}).", 
-                Logger.Args(nameof(CoreTemplate), template.GetType().Name, ex.Message));
+            var goTemplate = template as GameObjectTemplate;
+            Logger.Error("Failed to create entity actor for {0} {1} ({2}).",
+                Logger.Args(nameof(CoreTemplate), goTemplate.m_objectName, ex.Message));
+
+            // Kill the actor.
+            objectActor.Tell(PoisonPill.Instance);
 
             return null;
         }

--- a/src/CoreLib/Game/Zone/Supervisors/ZoneObjectSupervisor.cs
+++ b/src/CoreLib/Game/Zone/Supervisors/ZoneObjectSupervisor.cs
@@ -39,7 +39,21 @@ internal sealed class ZoneObjectSupervisor(Core.Zone zone) : ZoneEntitySuperviso
             }
 
             var template = (GameObjectTemplate) CoreObjectFactory.GetCoreTemplate(objectInfo.m_templateID);
+            if (template is null) {
+                Logger.Warning("Could not create {0} because template ID {1} was not found.",
+                    Logger.Args(objectInfo.m_zoneTag, objectInfo.m_templateID));
+                
+                continue;
+            }
+
             var coreObject = CoreObjectFactory.FinalizeCoreObject(objectInfo, template);
+            if (coreObject is null) {
+                Logger.Warning("Could not finalize CoreObject {0} with template ID {1}.",
+                    Logger.Args(objectInfo.m_zoneTag, objectInfo.m_templateID));
+
+                continue;
+            }
+
             var objectActor = CreateEntityActor(coreObject, template);
         }
 


### PR DESCRIPTION
## Changelog
* Fixed Revive101/imlight-issues#78
* Fixed `ZoneEntity` not being deleted upon `PathMovementComponent` failing to get path data
* Fixed `ZoneEntitySupervisor` not deleting entities if their template couldn't be found within the timespan
* Fixed `CombatDuelComponent` accidently calling `Context.Stop(Self)` once a duel ended
* Fixed `ZoneEntity` not echoing kill-pill to all components