### PR TITLE
`Feat/progression` -> `quality-assurance`

### DIFF
--- a/src/Imlight.CoreLib/AntiAmbrose/UserAuthenticator.cs
+++ b/src/Imlight.CoreLib/AntiAmbrose/UserAuthenticator.cs
@@ -28,6 +28,7 @@
 
 using System;
 using Imcodec.IO;
+using Imlight.Common;
 using Imlight.CoreLib.Shared.Cryptography;
 using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.WizardData.Collections;
@@ -60,6 +61,11 @@ internal enum UserAuthenResult {
 /// </remarks>
 internal static class UserAuthenticator {
 
+    private static readonly bool s_enforceRevision 
+        = ConfigurationManager.Settings["Global Settings.EnforceRevision"].AsBool();
+    private static readonly string s_serverRevision 
+        = ConfigurationManager.Settings["Global Settings.GameRevision"].AsString();
+
     internal class AuthenticationDetails {
         
         internal Account _account;
@@ -87,6 +93,19 @@ internal static class UserAuthenticator {
             details._result = UserAuthenResult.AuthenFailed;
 
             return details;
+        }
+
+        // If the revision is enforced, check if the client revision matches the server revision.
+        if (s_enforceRevision) {
+            var clientRevision = authMessage.Revision;
+            if (clientRevision != s_serverRevision) {
+                Logger.Warning("SessionActor {0} was rejected due to revision mismatch. (Given: {1}, Expected: {2})",
+                    Logger.Args(sessionActor.SessionID, clientRevision, s_serverRevision));
+
+                details._result = UserAuthenResult.ErrorNoLock;
+
+                return details;
+            }
         }
 
         // Check if we can find the account.

--- a/src/Imlight.CoreLib/Game/Combat/CombatDuelSubCircle.cs
+++ b/src/Imlight.CoreLib/Game/Combat/CombatDuelSubCircle.cs
@@ -120,6 +120,7 @@ public class CombatDuelSubCircle {
     internal CombatDeck _combatDeck;
     internal readonly CombatDuelComponent _duelActor;
     internal Wizard _wizard;
+    internal int _usedPipsForExperienceGain = 0;
 
     private readonly float _radius;
     private readonly float _rotation;

--- a/src/Imlight.CoreLib/Game/Combat/CombatResolver.cs
+++ b/src/Imlight.CoreLib/Game/Combat/CombatResolver.cs
@@ -244,6 +244,9 @@ public class CombatResolver(Duel duel, CombatDuelSubCircle[] actorSubCircles) {
             var spellHits = SpellHits(action.SpellCaster, action.Spell);
             if (!spellHits) {
                 cinematicTime += HandleFizzleAction(action, combatActionList);
+
+                // Increase pips used counter by 1, even if the spell fizzled.
+                action.SpellCaster._usedPipsForExperienceGain++;
             }
             else {
                 cinematicTime += HandleSuccessfulAction(action, combatActionList);
@@ -448,9 +451,16 @@ public class CombatResolver(Duel duel, CombatDuelSubCircle[] actorSubCircles) {
 
         // Reduce pips.
         if (action.m_spell.m_pipCost.m_xPipSpell) {
+            var pipCount = caster.CombatParticipant.m_pipCount;
+            caster._usedPipsForExperienceGain += pipCount.m_genericPips;
+
             caster.DeductAllPips();
         }
         else {
+            // Increase the used pips for experience gain by the rank of the spell.
+            // Even 0-rank spells will give the caster 1 pip for experience gain.
+            caster._usedPipsForExperienceGain += Math.Max((byte) 1, action.m_spell.m_pipCost.m_spellRank);
+
             caster.DeductPips((MagicSchool) action.m_spell.m_magicSchoolID, action.m_spell.m_pipCost.m_spellRank);
         }
     }

--- a/src/Imlight.CoreLib/Game/Commands/Protocols/CommandModifyProtocol.cs
+++ b/src/Imlight.CoreLib/Game/Commands/Protocols/CommandModifyProtocol.cs
@@ -659,4 +659,22 @@ internal class CommandModifyProtocol : CommandProtocol {
         InformSenderClient($"Set training points to {trainingPointsInt}.");
     }
 
+    [Command("addxp")]
+    [AuthRequired(AuthLevel.QualityAssurance)]
+    private void AddXPCommand(string xp) {
+        // Try to parse the XP.
+        if (!int.TryParse(xp, out var xpInt)) {
+            InformSenderClient("Invalid XP amount.");
+
+            return;
+        }
+
+       var msg = new CHARACTER_103_PROTOCOL.MSG_GAINXP() {
+            XP = xpInt
+        };
+        Context.SessionActor.Tell(msg, null);
+
+        InformSenderClient($"Added {xpInt} XP.");
+    }
+
 }

--- a/src/Imlight.CoreLib/Game/Services/CombatService.cs
+++ b/src/Imlight.CoreLib/Game/Services/CombatService.cs
@@ -107,6 +107,15 @@ internal class CombatService(SessionActor sessionActor) : MessageService(session
             "NoAggroGraceOver",
             noAggroGraceOverMsg,
             TimeSpan.FromSeconds(NO_AGGRO_EFFECT_DURATION_IN_SECONDS));
+
+        // Gain 3 XP per pip used in the duel.
+        var usedPips = message.UsedPips;
+        var xpGained = usedPips * 3;
+
+        var msg = new CHARACTER_103_PROTOCOL.MSG_GAINXP {
+            XP = xpGained,
+        };
+        TellOtherServices(msg);
     }
 
     [MessageHandler(typeof(DOODLEDOUG_MESSAGES_51_PROTOCOL.MSG_COMBATMOVE))]

--- a/src/Imlight.CoreLib/Game/Services/WizardService.cs
+++ b/src/Imlight.CoreLib/Game/Services/WizardService.cs
@@ -37,6 +37,7 @@ using Imlight.CoreLib.Shared.Character;
 using Imcodec.MessageLayer.Generated;
 using Imcodec.ObjectProperty.TypeCache;
 using Imcodec.Math;
+using Microsoft.Extensions.ObjectPool;
 
 namespace Imlight.CoreLib.Game.Services;
 
@@ -118,6 +119,32 @@ internal class WizardService(SessionActor sessionActor) : MessageService(session
             MaxEnergy = baseStats.m_petEnergy
         };
         SendToSocket(petEnergyMessage);
+    }
+
+    [MessageHandler(typeof(CHARACTER_103_PROTOCOL.MSG_GAINXP))]
+    private void ReceiverGainXP(CHARACTER_103_PROTOCOL.MSG_GAINXP message) {
+        var beforeLevel = _activeWizard.MagicSchoolBehavior.Level;
+        var beforeXP = _activeWizard.MagicSchoolBehavior.ExperiencePoints;
+        var xpGained = message.XP;
+        
+        _activeWizard.AddExperiencePoints(xpGained);
+        var afterLevel = _activeWizard.MagicSchoolBehavior.Level;
+
+        if (beforeLevel != afterLevel) {
+            // The player leveled up.
+            var levelUpMsg = new CHARACTER_103_PROTOCOL.MSG_LEVELUP() {
+                NewLevel = (byte) afterLevel
+            };
+            Context.Self.Tell(levelUpMsg);
+        }
+
+        // Inform the client of the XP change.
+        var addXpMsg = new WIZARD_12_PROTOCOL.MSG_UPDATEXP {
+            GlobalID = _activeWizard.CharId,
+            XP = xpGained,
+            OldXP = beforeXP,
+        };
+        SendToSocket(addXpMsg);
     }
 
     #endregion

--- a/src/Imlight.CoreLib/Game/Zone/Components/CombatDuelComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/CombatDuelComponent.cs
@@ -976,7 +976,9 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
 
             circle.ParticipantActor.Tell(combatVictoryMsg);
 
-            var victoryMsg = new COMBAT_106_PROTOCOL.MSG_COMBATWIN();
+            var victoryMsg = new COMBAT_106_PROTOCOL.MSG_COMBATWIN() {
+                UsedPips = circle._usedPipsForExperienceGain
+            };
             circle.ParticipantActor.Tell(victoryMsg);
         });
     }

--- a/src/Imlight.CoreLib/Shared/Character/CharacterHelper.cs
+++ b/src/Imlight.CoreLib/Shared/Character/CharacterHelper.cs
@@ -67,6 +67,21 @@ internal static class CharacterHelper {
                 Logger.Args(wizard.PlayerNameBehavior.GetWizardName(), activatedEffects.Count, template.m_objectName));
         }
 
+        // Set the player's level based on how many experience points they have.
+        var xp = wizard.MagicSchoolBehavior.ExperiencePoints;
+        var matchedLevel = MagicLevelsConfig.GetPlayerLevelAtExperience(xp);
+        if (matchedLevel != wizard.MagicSchoolBehavior.Level) {
+            var newXp = MagicLevelsConfig.GetExperiencePointsAtLevel(matchedLevel);
+            wizard.MagicSchoolBehavior.ExperiencePoints = newXp;
+            wizard.SetLevel(matchedLevel);
+            
+            Logger.Warning("Player {0} had a level mismatch. XP: {1}, Level: {2}, New Level: {3}.",
+                Logger.Args(wizard.PlayerNameBehavior.GetWizardName(), 
+                            xp, 
+                            wizard.MagicSchoolBehavior.Level, 
+                            matchedLevel));
+        }
+
         Logger.Debug("Game stats recalculated for {0}.", Logger.Args(wizard.PlayerNameBehavior.GetWizardName()));
     }
 

--- a/src/Imlight.CoreLib/Shared/Character/MagicLevelsConfig.cs
+++ b/src/Imlight.CoreLib/Shared/Character/MagicLevelsConfig.cs
@@ -34,6 +34,7 @@ using Imlight.CoreLib.Shared.Resources;
 using Imlight.CoreLib.Shared.Behaviors;
 using Imcodec.ObjectProperty.TypeCache;
 using Imcodec.ObjectProperty;
+using System.Linq;
 
 namespace Imlight.CoreLib.Shared.Character;
 
@@ -115,7 +116,50 @@ internal class MagicLevelsConfig : RootSingleResourceSingleton<MagicLevelsConfig
         return null;
     }
 
-    private void LoadMaxLevel(MagicXPConfig magicXPConfig) {
+    /// <summary>
+    /// Gets the level of a player based on the experience points.
+    /// </summary>
+    /// <param name="xp">The experience points.</param>
+    /// <returns>The level of the player based on the experience points.</returns>
+    internal static byte GetPlayerLevelAtExperience(int xp) {
+        if (s_playerLevelConfig is null || s_playerLevelConfig.Count == 0) {
+            return 0;
+        }
+
+        // All classes need the same amount of XP to level up.
+        // We will use the first class to determine the level.
+        var levelInfo = s_playerLevelConfig.Values.First();
+        for (int i = 0; i < levelInfo.Count; i++) {
+            var level = levelInfo[i];
+            if (xp < level.m_xpToLevel) {
+                return (byte) i;
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Gets the experience points required to reach a specific level.
+    /// </summary>
+    /// <param name="level">The level.</param>
+    /// <returns>The experience points required to reach the specified level.</returns>
+    internal static int GetExperiencePointsAtLevel(int level) {
+        if (s_playerLevelConfig is null || s_playerLevelConfig.Count == 0) {
+            return 0;
+        }
+
+        // All classes need the same amount of XP to level up.
+        // We will use the first class to determine the level.
+        var levelInfo = s_playerLevelConfig.Values.First();
+        if (level < levelInfo.Count) {
+            return levelInfo[level].m_xpToLevel;
+        }
+
+        return 0;
+    }
+
+    private static void LoadMaxLevel(MagicXPConfig magicXPConfig) {
         // If the configuration deems the max level to be lower than the one recorded here,
         // we will use the configuration's max level instead.
         MaxLevel = magicXPConfig.m_maxSchoolLevel;
@@ -126,7 +170,7 @@ internal class MagicLevelsConfig : RootSingleResourceSingleton<MagicLevelsConfig
         Logger.Information("Imlight max level set to {0}", Logger.Args(MaxLevel));
     }
 
-    private void LoadMobLevelConfig(MagicXPConfig magicXPConfig) {
+    private static void LoadMobLevelConfig(MagicXPConfig magicXPConfig) {
         s_mobLevelConfig = [];
         var counter = 0;
 
@@ -138,7 +182,7 @@ internal class MagicLevelsConfig : RootSingleResourceSingleton<MagicLevelsConfig
         Logger.Information("Loaded {0} mob level configurations", Logger.Args(counter));
     }
 
-    private void LoadPlayerLevelConfig(MagicXPConfig magicXPConfig) {
+    private static void LoadPlayerLevelConfig(MagicXPConfig magicXPConfig) {
         // There are two lists of data here. One is the `m_levelInfo` which is non-unique and shared
         // between all schools. It details how much mana, power pip chance, and xp is required to level up.
         // However, the `m_classInfo` is the same as `m_levelInfo` but is unique to each school, and details

--- a/src/Imlight.CoreLib/Shared/Character/MagicLevelsConfig.cs
+++ b/src/Imlight.CoreLib/Shared/Character/MagicLevelsConfig.cs
@@ -152,8 +152,8 @@ internal class MagicLevelsConfig : RootSingleResourceSingleton<MagicLevelsConfig
         // All classes need the same amount of XP to level up.
         // We will use the first class to determine the level.
         var levelInfo = s_playerLevelConfig.Values.First();
-        if (level < levelInfo.Count) {
-            return levelInfo[level].m_xpToLevel;
+        if (level > 0 && level < levelInfo.Count) {
+            return levelInfo[level - 1].m_xpToLevel;
         }
 
         return 0;

--- a/src/Imlight.CoreLib/Shared/Packets/CHARACTER_103_PROTOCOL.cs
+++ b/src/Imlight.CoreLib/Shared/Packets/CHARACTER_103_PROTOCOL.cs
@@ -133,4 +133,13 @@ public class CHARACTER_103_PROTOCOL : IServerProtocol {
         
     }
 
+    public sealed class MSG_GAINXP : IServerMessage {
+        
+        public byte MessageOrder { get; } = 12;
+        public byte ServiceID { get; } = 103;
+
+        public int XP;
+        
+    }
+
 }

--- a/src/Imlight.CoreLib/Shared/Packets/COMBAT_106_PROTOCOL.cs
+++ b/src/Imlight.CoreLib/Shared/Packets/COMBAT_106_PROTOCOL.cs
@@ -156,6 +156,8 @@ public sealed class COMBAT_106_PROTOCOL : IServerProtocol {
         public byte MessageOrder => 16;
         public byte ServiceID => 106;
 
+        public int UsedPips;
+
     }
 
     public sealed class MSG_COMBATEFFECT : IServerMessage {

--- a/src/Imlight.CoreLib/Shared/Resources/Locale.cs
+++ b/src/Imlight.CoreLib/Shared/Resources/Locale.cs
@@ -23,7 +23,7 @@
  * 
  * Created by: Jooty
  * Version: KALI 1.0
- * Last Updated: 3/18/2025
+ * Last Updated: 07/26/2025
  */
 
 using System;
@@ -161,6 +161,14 @@ internal class Locale : RootDirectoryResourceSingleton<Locale>, IMemoryStreamDis
             // Remove the '/r' that may exist at the end of the value.
             if (value.EndsWith("\r")) {
                 value = value[..^1];
+            }
+
+            // Log warnings for duplicate keys.
+            if (data.ContainsKey(key)) {
+                Logger.Warning("Duplicate key {0} in {1}.",
+                    Logger.Args(key, record.FileName));
+
+                continue;
             }
 
             data.Add(key, value);

--- a/src/Imlight.CoreLib/WizardData/Collections/WizardCollection.cs
+++ b/src/Imlight.CoreLib/WizardData/Collections/WizardCollection.cs
@@ -242,6 +242,7 @@ public static class WizardCollection {
         }
 
         existingCharacter.MagicSchoolBehavior.Level = wizard.MagicSchoolBehavior.Level;
+        existingCharacter.MagicSchoolBehavior.ExperiencePoints = wizard.MagicSchoolBehavior.ExperiencePoints;
         session.SaveChanges();
     }
 

--- a/src/Imlight.CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/Imlight.CoreLib/WizardData/Models/Player/Wizard.cs
@@ -182,10 +182,51 @@ public class Wizard : IDisposable {
         GameStats.m_baseMana += manaDifference;
         GameStats.m_powerPipBase += powerPipDifference;
 
+        var xpAtLevel = MagicLevelsConfig.GetExperiencePointsAtLevel(level);
+        MagicSchoolBehavior.ExperiencePoints = xpAtLevel;
+
         // Persistent save.
         WizardCollection.UpdateCharacterLevel(this);
 
         return true;
+    }
+
+    public void AddExperiencePoints(int xp) {
+        MagicSchoolBehavior.ExperiencePoints += xp;
+
+        // If the level at XP is greater than the current level, we need to level up.
+        var levelAtXp = MagicLevelsConfig.GetPlayerLevelAtExperience(xp);
+        if (levelAtXp > MagicSchoolBehavior.Level) {
+            var levelUpSuccess = SetLevel(levelAtXp);
+            if (!levelUpSuccess) {
+                Logger.Warning("Could not level up player {0} to level {1}.", 
+                    Logger.Args(PlayerNameBehavior.GetWizardName(), levelAtXp));
+
+                return;
+            }
+        }
+
+        // Persistent save.
+        WizardCollection.UpdateCharacterLevel(this);
+    }
+
+    public void RemoveExperiencePoints(int xp) {
+        MagicSchoolBehavior.ExperiencePoints -= xp;
+
+        // If the level at XP is less than the current level, we need to level down.
+        var levelAtXp = MagicLevelsConfig.GetPlayerLevelAtExperience(xp);
+        if (levelAtXp < MagicSchoolBehavior.Level) {
+            var levelDownSuccess = SetLevel(levelAtXp);
+            if (!levelDownSuccess) {
+                Logger.Warning("Could not level down player {0} to level {1}.", 
+                    Logger.Args(PlayerNameBehavior.GetWizardName(), levelAtXp));
+
+                return;
+            }
+        }
+
+        // Persistent save.
+        WizardCollection.UpdateCharacterLevel(this);
     }
 
     public void SetMarkedLocation(Vector3 loc, Vector3 orientation, string zone, string zoneDisplayName) {

--- a/src/Imlight.CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/Imlight.CoreLib/WizardData/Models/Player/Wizard.cs
@@ -195,7 +195,7 @@ public class Wizard : IDisposable {
         MagicSchoolBehavior.ExperiencePoints += xp;
 
         // If the level at XP is greater than the current level, we need to level up.
-        var levelAtXp = MagicLevelsConfig.GetPlayerLevelAtExperience(xp);
+        var levelAtXp = MagicLevelsConfig.GetPlayerLevelAtExperience(MagicSchoolBehavior.ExperiencePoints);
         if (levelAtXp > MagicSchoolBehavior.Level) {
             var levelUpSuccess = SetLevel(levelAtXp);
             if (!levelUpSuccess) {
@@ -214,7 +214,7 @@ public class Wizard : IDisposable {
         MagicSchoolBehavior.ExperiencePoints -= xp;
 
         // If the level at XP is less than the current level, we need to level down.
-        var levelAtXp = MagicLevelsConfig.GetPlayerLevelAtExperience(xp);
+        var levelAtXp = MagicLevelsConfig.GetPlayerLevelAtExperience(MagicSchoolBehavior.ExperiencePoints);
         if (levelAtXp < MagicSchoolBehavior.Level) {
             var levelDownSuccess = SetLevel(levelAtXp);
             if (!levelDownSuccess) {

--- a/src/Imlight.Director/Config/Imlight.ini
+++ b/src/Imlight.Director/Config/Imlight.ini
@@ -1,5 +1,7 @@
 [Global Settings]
 GameRevision = r774526.Wizard_1_570
+; If true, the servers will refuse connections if the game revision does not match.
+EnforceRevision = false
 
 [Logging]
 LogPath = ./logs/log.txt


### PR DESCRIPTION
## Changelog
* Added experience points
* Added experience point gain after combat
* Added `mod addxp <xp>` command
* Added internal message `CHARACTER_103_PROTOCOL.MSG_GAINXP`
* Added check on character stat recalculation for appropriate level
* Added `MagicLevelsConfig.GetPlayerLevelAtExperience(int xp)`
* Added `MagicLevelsConfig.GetExperiencePointsAtLevel(int level)`
* Added `Wizard.AddExperiencePoints(int xp)`
* Added `Wizard.RemoveExperiencePoints(int xp)`
* Fixed exception on locale IDs with duplicate keys