### PR TITLE
`feat/treasure-chests` -> `quality-assurance`

### DIFF
--- a/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
@@ -1,0 +1,139 @@
+using Akka.Actor;
+using Imcodec.Cryptography;
+using Imcodec.IO;
+using Imcodec.MessageLayer.Generated;
+using Imcodec.ObjectProperty;
+using Imcodec.ObjectProperty.TypeCache;
+using Imlight.Common;
+using Imlight.CoreLib.Game.WizBang;
+using Imlight.CoreLib.Game.Zone.Core;
+using Imlight.CoreLib.Shared.Packets;
+using Imlight.CoreLib.WizardData.Models.Player;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Imlight.CoreLib.Game.Zone.Components;
+internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityComponent(entity), IServiceComponent, IComponentFactory {
+
+    private const uint TREASURE_CHEST_TEMPLATE_ID = 77823;
+
+    public string ServiceName => "Interact";
+
+    public string NpcIcon => "GUI/QuestButtons/Art_Quest_Chest_Wood.dds";
+
+    public string NpcNameKey => "WizardGameObjects_00000054";
+
+    public string NpcTextKey => "GUI_ChestInteract";
+
+    public WizBangs WizBang => WizBangs.None;
+
+    public string StateName => "Open";
+
+    public string InteractWizBang => "";
+
+    public string DisplayKey => "";
+
+    public static bool ShouldAttachToEntity(CoreTemplate template) =>
+        template is GameObjectTemplate goTemplate
+        && goTemplate.m_templateID == TREASURE_CHEST_TEMPLATE_ID;
+    public IEnumerable<ServiceOptionBase> GetServiceOptions(Wizard _)
+        => [
+            new ServiceOptionBase() {
+                m_displayKey = DisplayKey,
+                m_forceInteract = false,
+                m_iconKey = NpcIcon,
+                m_serviceName = ServiceName,
+                m_serviceIndex = 0
+            }
+         ];
+    public void OnServiceInteraction(IActorRef playerActor, Wizard playerCharacter, CoreObject playerObject, uint serviceOptionIndex) {
+        TriggerChestAnimation();
+        SendLoot(playerActor);
+        UpdateGold(playerActor);
+        PlaySound(playerActor);
+        RemoveObject();
+    }
+
+    private void TriggerChestAnimation() {
+        var animation = new GAME_5_PROTOCOL.MSG_ENTERSTATE {
+            State = StringHash.Compute(StateName),
+            Data = "",
+            IgnoreIfCurrentStateIsOff = 0,
+            GameObjectID = Entity.ActiveGameObject.m_globalID
+        };
+
+        var broadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
+            Message = animation,
+            Selfless = false,
+        };
+
+        Entity.ZoneRef.Tell(broadcastMsg);
+    }
+
+    private void SendLoot(IActorRef playerActor) {
+        var lootInfoList = new LootInfoList {
+            m_loot = [],
+            m_goldInfo = new GoldLootInfo {
+                m_goldAmount = 0,
+                m_lootType = LOOT_TYPE.LOOT_TYPE_GOLD,
+            },
+            m_lootRarityList = new LootRarityList {
+                m_loot = []
+            }
+        };
+
+        var serializer = new ObjectSerializer(
+            false,
+            Behaviors: SerializerFlags.None
+        );
+
+        if (!serializer.Serialize(lootInfoList, 4, out var data)) {
+            Logger.Error("Failed to serialize LootInfoList.");
+            return;
+        }
+
+        var loot = new WIZARD_12_PROTOCOL.MSG_LOOT {
+            GlobalID = Entity.ActiveGameObject.m_globalID,
+            LootList = data
+        };
+
+        playerActor.Tell(loot);
+    }
+
+    private void UpdateGold(IActorRef playerActor) {
+        var updateGold = new WIZARD_12_PROTOCOL.MSG_UPDATEGOLD {
+            Gold = Random.Shared.Next(10, 101),
+            MaxGold = 300_000 // 300.000 for non premium users ?
+        };
+
+        playerActor.Tell(updateGold);
+    }
+
+    private void PlaySound(IActorRef playerActor) {
+        var playSound = new GAME_5_PROTOCOL.MSG_PLAYSOUND {
+            SoundID = 89061816524770,
+            ReinteractTime = 0,
+            SoundFilename = "",
+            StartDelay = 0,
+            PlayAtMusicVolume = 0,
+        };
+
+        playerActor.Tell(playSound);
+    }
+
+    private void RemoveObject() {
+        var removeObject = new GAME_5_PROTOCOL.MSG_REMOVEOBJECT {
+            GameObjectID = Entity.ActiveGameObject.m_globalID,
+        };
+
+        var broadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
+            Message = removeObject,
+            Selfless = false,
+        };
+
+        Entity.ZoneRef.Tell(broadcastMsg);
+    }
+}

--- a/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
@@ -81,7 +81,8 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
         UpdateGold(playerActor, playerCharacter, goldAmount);
         PlaySound(playerActor);
         TriggerChestAnimation();
-        RemoveObject();
+
+        Timers.StartSingleTimer("deletechestobject", null, _chestOpenAnimationTimeSpan);
     }
 
     private void TriggerChestAnimation() {
@@ -157,23 +158,6 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
         playerActor.Tell(playSound);
     }
 
-    private void RemoveObject() {
-        var removeObject = new GAME_5_PROTOCOL.MSG_REMOVEOBJECT {
-            GameObjectID = Entity.ActiveGameObject.m_globalID,
-        };
-
-        var broadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
-            Message = removeObject,
-            Selfless = false,
-        };
-
-        Timers.StartSingleTimer("chestopen", broadcastMsg, _chestOpenAnimationTimeSpan);
-    }
-
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST))]
-    private void ReceiveZoneBroadcast(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST message) {
-        Entity.ZoneRef.Forward(message);
-        Entity.DeleteObject(); // Please correct me if I'm wrong
-    }
-
+    private void ReceiveZoneBroadcast(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST _) => Entity.DeleteObject();
 }

--- a/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
@@ -121,6 +121,7 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
         };
 
         playerActor.Tell(updateGold);
+        playerCharacter.AddGold(goldAmount);
     }
 
     private void PlaySound(IActorRef playerActor) {

--- a/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
@@ -1,6 +1,32 @@
+/* 
+ * Copyright (C) Revive101 Development Team - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential.
+ * 
+ * ========================================================================
+ * WOODEN CHEST COMPONENT
+ * ========================================================================
+ * 
+ * PURPOSE:
+ * This component handles the interaction logic for wooden chests in the game.
+ * The gold value is randomly generated between 10 and 100.
+ * 
+ * USAGE EXAMPLE:
+ * 
+ * NOTE:
+ * 
+ * TODO:
+ * 
+ * Created by: Phill
+ * Version: KALI 1.0
+ * Last Updated: 10/09/2025
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Akka.Actor;
 using Imcodec.Cryptography;
-using Imcodec.IO;
 using Imcodec.MessageLayer.Generated;
 using Imcodec.ObjectProperty;
 using Imcodec.ObjectProperty.TypeCache;
@@ -10,42 +36,31 @@ using Imlight.CoreLib.Game.Zone.Core;
 using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.Shared.Packets;
 using Imlight.CoreLib.WizardData.Models.Player;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Imlight.CoreLib.Game.Zone.Components;
-internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityComponent(entity), IServiceComponent, IComponentFactory, IWithTimers {
 
-    private static readonly uint[] TREASURE_CHEST_TEMPLATE_IDS = [1233729, 77825, 77884, 77826, 77827, 1562742, 77823, 470099];
+internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityComponent(entity), IServiceComponent, IComponentFactory, IWithTimers {
 
     private const int ANIMATION_TIME = 1;
 
+    private static readonly uint[] s_treasureChestTemplateIDs = [1233729, 77825, 77884, 77826, 77827, 1562742, 77823, 470099];
     private readonly TimeSpan _chestOpenAnimationTimeSpan = TimeSpan.FromSeconds(ANIMATION_TIME);
 
     public string ServiceName => "Interact";
-
     public string NpcIcon => "GUI/QuestButtons/Art_Quest_Chest_Wood.dds";
-
     public string NpcNameKey => "WizardGameObjects_00000054";
-
     public string NpcTextKey => "GUI_ChestInteract";
-
     public WizBangs WizBang => WizBangs.None;
-
     public string StateName => "Open";
-
     public string InteractWizBang => "";
-
     public string DisplayKey => "";
 
     public ITimerScheduler Timers { get; set; }
 
     public static bool ShouldAttachToEntity(CoreTemplate template) =>
         template is GameObjectTemplate goTemplate
-        && TREASURE_CHEST_TEMPLATE_IDS.Contains(goTemplate.m_templateID);
+        && s_treasureChestTemplateIDs.Contains(goTemplate.m_templateID);
+
     public IEnumerable<ServiceOptionBase> GetServiceOptions(Wizard _)
         => [
             new ServiceOptionBase() {
@@ -56,6 +71,7 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
                 m_serviceIndex = 0
             }
          ];
+
     public void OnServiceInteraction(IActorRef playerActor, Wizard playerCharacter, CoreObject playerObject, uint serviceOptionIndex) {
         var goldAmount = Random.Shared.Next(10, 101);
 
@@ -104,6 +120,7 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
 
         if (!serializer.Serialize(lootInfoList, 4, out var data)) {
             Logger.Error("Failed to serialize LootInfoList.");
+
             return;
         }
 
@@ -155,4 +172,5 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
         Entity.ZoneRef.Forward(message);
         Entity.DeleteObject(); // Please correct me if I'm wrong
     }
+
 }

--- a/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
@@ -30,6 +30,7 @@ using Imcodec.Cryptography;
 using Imcodec.MessageLayer.Generated;
 using Imcodec.ObjectProperty;
 using Imcodec.ObjectProperty.TypeCache;
+using Imcodec.Types;
 using Imlight.Common;
 using Imlight.CoreLib.Game.WizBang;
 using Imlight.CoreLib.Game.Zone.Core;
@@ -44,6 +45,7 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
     private const int ANIMATION_TIME = 1;
 
     private static readonly uint[] s_treasureChestTemplateIDs = [1233729, 77825, 77884, 77826, 77827, 1562742, 77823, 470099];
+    private static readonly uint s_openSoundTemplateID = 1374674914;
     private readonly TimeSpan _chestOpenAnimationTimeSpan = TimeSpan.FromSeconds(ANIMATION_TIME);
 
     public string ServiceName => "Interact";
@@ -143,8 +145,9 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
     }
 
     private void PlaySound(IActorRef playerActor) {
+        var soundId = new GID(s_openSoundTemplateID);
         var playSound = new GAME_5_PROTOCOL.MSG_PLAYSOUND {
-            SoundID = 89061816524770,
+            SoundID = soundId,
             ReinteractTime = 0,
             SoundFilename = "",
             StartDelay = 0,

--- a/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
@@ -52,7 +52,7 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
     public void OnServiceInteraction(IActorRef playerActor, Wizard playerCharacter, CoreObject playerObject, uint serviceOptionIndex) {
         TriggerChestAnimation();
         SendLoot(playerActor);
-        UpdateGold(playerActor);
+        UpdateGold(playerActor, playerCharacter);
         PlaySound(playerActor);
         RemoveObject();
     }
@@ -103,10 +103,10 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
         playerActor.Tell(loot);
     }
 
-    private void UpdateGold(IActorRef playerActor) {
+    private void UpdateGold(IActorRef playerActor, Wizard playerCharacter) {
         var updateGold = new WIZARD_12_PROTOCOL.MSG_UPDATEGOLD {
             Gold = Random.Shared.Next(10, 101),
-            MaxGold = 300_000 // 300.000 for non premium users ?
+            MaxGold = playerCharacter.GameStats.m_baseGoldPouch
         };
 
         playerActor.Tell(updateGold);

--- a/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
@@ -50,10 +50,12 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
             }
          ];
     public void OnServiceInteraction(IActorRef playerActor, Wizard playerCharacter, CoreObject playerObject, uint serviceOptionIndex) {
-        TriggerChestAnimation();
-        SendLoot(playerActor);
-        UpdateGold(playerActor, playerCharacter);
+        var goldAmount = Random.Shared.Next(10, 101);
+
+        SendLoot(playerActor, goldAmount);
+        UpdateGold(playerActor, playerCharacter, goldAmount);
         PlaySound(playerActor);
+        TriggerChestAnimation();
         RemoveObject();
     }
 
@@ -73,11 +75,11 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
         Entity.ZoneRef.Tell(broadcastMsg);
     }
 
-    private void SendLoot(IActorRef playerActor) {
+    private void SendLoot(IActorRef playerActor, int goldAmount) {
         var lootInfoList = new LootInfoList {
             m_loot = [],
             m_goldInfo = new GoldLootInfo {
-                m_goldAmount = 0,
+                m_goldAmount = goldAmount,
                 m_lootType = LOOT_TYPE.LOOT_TYPE_GOLD,
             },
             m_lootRarityList = new LootRarityList {
@@ -103,9 +105,9 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
         playerActor.Tell(loot);
     }
 
-    private void UpdateGold(IActorRef playerActor, Wizard playerCharacter) {
+    private void UpdateGold(IActorRef playerActor, Wizard playerCharacter, int goldAmount) {
         var updateGold = new WIZARD_12_PROTOCOL.MSG_UPDATEGOLD {
-            Gold = Random.Shared.Next(10, 101),
+            Gold = goldAmount,
             MaxGold = playerCharacter.GameStats.m_baseGoldPouch
         };
 

--- a/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
@@ -55,24 +55,27 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
         SendLoot(playerActor, goldAmount);
         UpdateGold(playerActor, playerCharacter, goldAmount);
         PlaySound(playerActor);
-        TriggerChestAnimation();
+        TriggerChestAnimation(); // Rename (doesn't actually trigger any animation)
         RemoveObject();
     }
 
     private void TriggerChestAnimation() {
-        var animation = new GAME_5_PROTOCOL.MSG_ENTERSTATE {
-            State = StringHash.Compute(StateName),
-            Data = "",
-            IgnoreIfCurrentStateIsOff = 0,
-            GameObjectID = Entity.ActiveGameObject.m_globalID
-        };
+        var chestStates = new uint[] { StringHash.Compute(StateName), StringHash.Compute("NotInteracting") };
+        for (int i = 0; i < chestStates.Length; i++) {
+            var enterState = new GAME_5_PROTOCOL.MSG_ENTERSTATE {
+                Data = "",
+                GameObjectID = Entity.ActiveGameObject.m_globalID,
+                IgnoreIfCurrentStateIsOff = 0,
+                State = chestStates[i]
+            };
 
-        var broadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
-            Message = animation,
-            Selfless = false,
-        };
+            var broadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
+                Message = enterState,
+                Selfless = false,
+            };
 
-        Entity.ZoneRef.Tell(broadcastMsg);
+            Entity.ZoneRef.Tell(broadcastMsg);
+        }
     }
 
     private void SendLoot(IActorRef playerActor, int goldAmount) {

--- a/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
@@ -153,5 +153,6 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST))]
     private void ReceiveZoneBroadcast(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST message) {
         Entity.ZoneRef.Forward(message);
+        Entity.DeleteObject(); // Please correct me if I'm wrong
     }
 }

--- a/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
@@ -19,7 +19,8 @@ using System.Threading.Tasks;
 namespace Imlight.CoreLib.Game.Zone.Components;
 internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityComponent(entity), IServiceComponent, IComponentFactory, IWithTimers {
 
-    private const uint TREASURE_CHEST_TEMPLATE_ID = 77823;
+    private static readonly uint[] TREASURE_CHEST_TEMPLATE_IDS = [1233729, 77825, 77884, 77826, 77827, 1562742, 77823, 470099];
+
     private const int ANIMATION_TIME = 1;
 
     private readonly TimeSpan _chestOpenAnimationTimeSpan = TimeSpan.FromSeconds(ANIMATION_TIME);
@@ -44,7 +45,7 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
 
     public static bool ShouldAttachToEntity(CoreTemplate template) =>
         template is GameObjectTemplate goTemplate
-        && goTemplate.m_templateID == TREASURE_CHEST_TEMPLATE_ID;
+        && TREASURE_CHEST_TEMPLATE_IDS.Contains(goTemplate.m_templateID);
     public IEnumerable<ServiceOptionBase> GetServiceOptions(Wizard _)
         => [
             new ServiceOptionBase() {

--- a/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/WoodenChestComponent.cs
@@ -7,6 +7,7 @@ using Imcodec.ObjectProperty.TypeCache;
 using Imlight.Common;
 using Imlight.CoreLib.Game.WizBang;
 using Imlight.CoreLib.Game.Zone.Core;
+using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.Shared.Packets;
 using Imlight.CoreLib.WizardData.Models.Player;
 using System;
@@ -16,9 +17,12 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace Imlight.CoreLib.Game.Zone.Components;
-internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityComponent(entity), IServiceComponent, IComponentFactory {
+internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityComponent(entity), IServiceComponent, IComponentFactory, IWithTimers {
 
     private const uint TREASURE_CHEST_TEMPLATE_ID = 77823;
+    private const int ANIMATION_TIME = 1;
+
+    private readonly TimeSpan _chestOpenAnimationTimeSpan = TimeSpan.FromSeconds(ANIMATION_TIME);
 
     public string ServiceName => "Interact";
 
@@ -35,6 +39,8 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
     public string InteractWizBang => "";
 
     public string DisplayKey => "";
+
+    public ITimerScheduler Timers { get; set; }
 
     public static bool ShouldAttachToEntity(CoreTemplate template) =>
         template is GameObjectTemplate goTemplate
@@ -55,7 +61,7 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
         SendLoot(playerActor, goldAmount);
         UpdateGold(playerActor, playerCharacter, goldAmount);
         PlaySound(playerActor);
-        TriggerChestAnimation(); // Rename (doesn't actually trigger any animation)
+        TriggerChestAnimation();
         RemoveObject();
     }
 
@@ -139,6 +145,11 @@ internal sealed class WoodenChestComponent(ZoneEntity entity) : ZoneEntityCompon
             Selfless = false,
         };
 
-        Entity.ZoneRef.Tell(broadcastMsg);
+        Timers.StartSingleTimer("chestopen", broadcastMsg, _chestOpenAnimationTimeSpan);
+    }
+
+    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST))]
+    private void ReceiveZoneBroadcast(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST message) {
+        Entity.ZoneRef.Forward(message);
     }
 }


### PR DESCRIPTION
## Changelog:
- Added `WoodenChestComponent`
- Players can now interact with any wooden chests to gain between `10` and `100`  gold
- The wooden chests are removed (temporarily) after an interaction
- Gold is added to the players character and Database

## Todo:
- ~Chests must be *permanently* removed after interacting with them~ should be fixed with https://github.com/Revive101/Imlight/pull/112/commits/fa2f55e9f50317ff78eb0bc0997a96cdbc1b29e8