### PR TITLE
`Feat/realms` -> `quality-assurance`

### DIFF
--- a/src/Imlight.CoreLib/Game/GameServer.cs
+++ b/src/Imlight.CoreLib/Game/GameServer.cs
@@ -66,9 +66,10 @@ public class GameServer : Server {
     private readonly Cache<ByteString, ulong> _sessionKeys;
     private readonly ListQueue<SessionActor> _playerQueue;
 
-    public GameServer(string serverName, ushort serverPort)
+    public GameServer(string serverName, ushort serverPort, string realmName = null)
         : base(serverName, serverPort, GameServiceFactory.Props(),
               ConfigurationManager.Settings["Game Server.GameServerIP"].AsString()) {
+        RealmName = realmName ?? serverName;
         this._playerQueue = new ListQueue<SessionActor>();
         this._sessionKeys = new Cache<ByteString, ulong>();
         this.ActiveSessions.CollectionChanged += ActiveSessionsChangedEvent;
@@ -96,8 +97,8 @@ public class GameServer : Server {
             Logger.Args(serverName, serverPort));
     }
 
-    public static Props Props(string serverName, ushort serverPort)
-        => Akka.Actor.Props.Create(() => new GameServer(serverName, serverPort));
+    public static Props Props(string serverName, ushort serverPort, string realmName = null)
+        => Akka.Actor.Props.Create(() => new GameServer(serverName, serverPort, realmName));
 
     [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_CREATEKEY))]
     private void ReceiveCreateKey(SERVER_100_PROTOCOL.MSG_CREATEKEY message) {
@@ -105,6 +106,39 @@ public class GameServer : Server {
 
         var rsp = new SERVER_100_PROTOCOL.MSG_CREATEKEYRSP() { Key = key };
         Sender.Tell(rsp);
+    }
+
+    [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_CREATEPLAYERKEY))]
+    private void ReceiveCreatePlayerKey(SERVER_100_PROTOCOL.MSG_CREATEPLAYERKEY message) {
+        // If this server is the target realm, create the key locally.
+        if (message.TargetRealmName == RealmName) {
+            var key = CreateKey(message.Account.AccountId);
+
+            Sender.Tell(new SERVER_100_PROTOCOL.MSG_CREATEPLAYERKEYRSP {
+                Key = key,
+                IP = Ip,
+                Port = (ushort) Port,
+                RealmName = RealmName,
+                Success = true
+            });
+
+            return;
+        }
+
+        // Otherwise, forward to the GameServerPool to route to the correct realm.
+        Context.Parent.Forward(message);
+    }
+
+    [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_REALMLIST))]
+    private void ReceiveRealmList(SERVER_100_PROTOCOL.MSG_REALMLIST message) {
+        // Forward to GameServerPool — it knows about all realms.
+        Context.Parent.Forward(message);
+    }
+
+    [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_QUERYREALMSERVER))]
+    private void ReceiveQueryRealmServer(SERVER_100_PROTOCOL.MSG_QUERYREALMSERVER message) {
+        // Forward to GameServerPool — it knows about all realms.
+        Context.Parent.Forward(message);
     }
 
     [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_VALIDATESESSIONKEY))]

--- a/src/Imlight.CoreLib/Game/Services/AttachService.cs
+++ b/src/Imlight.CoreLib/Game/Services/AttachService.cs
@@ -135,7 +135,7 @@ internal class AttachService(SessionActor sessionActor) : MessageService(session
         }
 
         var account = GetActiveAccount();
-        var realmName = "Centaur"; // todo
+        var realmName = gameServer.RealmName ?? "Imlight";
 
         _loginCompleteMessage = new GAME_5_PROTOCOL.MSG_LOGINCOMPLETE() {
             RealmName = realmName,

--- a/src/Imlight.CoreLib/Game/Services/ZoneService.cs
+++ b/src/Imlight.CoreLib/Game/Services/ZoneService.cs
@@ -37,9 +37,11 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Imcodec.Types;
 using Imcodec.CoreObject;
 using Imcodec.Cryptography;
 using Imcodec.MessageLayer.Generated;
@@ -454,6 +456,144 @@ internal class ZoneService(SessionActor sessionActor) : MessageService(sessionAc
             DisplayDiff = 1,
         };
         SendToSocket(networkMessage);
+    }
+
+    [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_REALM_INFO_QUERY))]
+    private void ReceiveRealmInfoQuery(GAME_5_PROTOCOL.MSG_REALM_INFO_QUERY message) {
+        // Query the LoginServer's GameServerPool for the realm list.
+        var realmListMsg = new SERVER_100_PROTOCOL.MSG_REALMLIST();
+        var realmList = AskServer<SERVER_100_PROTOCOL.MSG_REALMLIST>(realmListMsg);
+
+        var currentRealm = "Imlight";
+        var currentZone = GetActiveWizard()?.Zone ?? "";
+
+        // Query our own game server for the current realm name.
+        try {
+            var serverInfo = AskServer<SERVER_100_PROTOCOL.MSG_SERVERINFO>(
+                new SERVER_100_PROTOCOL.MSG_QUERYSERVER());
+            currentRealm = serverInfo.RealmName ?? currentRealm;
+        }
+        catch { }
+
+        // Serialize the realm list as a RealmInfoList PropertyClass blob.
+        // The client expects this exact type — we cannot fabricate the format.
+        var realmInfoList = new RealmInfoList {
+            m_infoList = []
+        };
+        for (int i = 0; i < realmList.RealmNames.Length; i++) {
+            realmInfoList.m_infoList.Add(new RealmInfo {
+                m_realmName = realmList.RealmNames[i],
+                m_displayName = realmList.RealmNames[i],
+                m_realmPopulation = realmList.PlayerCounts[i]
+            });
+        }
+
+        var serializer = new ObjectSerializer(
+            Versionable: false,
+            Behaviors: SerializerFlags.None
+        );
+        if (!serializer.Serialize(realmInfoList, (PropertyFlags) 31, out var realmInfoBlob)) {
+            Logger.Error("Failed to serialize RealmInfoList for MSG_REALM_INFO_QUERY.");
+
+            return;
+        }
+
+        // Serialize an empty instance list — the client requires a valid
+        // InstanceInfoList PropertyClass blob, not an empty string.
+        var instanceInfoList = new InstanceInfoList {
+            m_instanceList = new List<InstanceInfo>()
+        };
+        if (!serializer.Serialize(instanceInfoList, (PropertyFlags) 31, out var instanceInfoBlob)) {
+            Logger.Error("Failed to serialize InstanceInfoList for MSG_REALM_INFO_QUERY.");
+
+            return;
+        }
+
+        var rsp = new GAME_5_PROTOCOL.MSG_REALM_INFO_QUERY {
+            RealmInfoList = realmInfoBlob,
+            CurrentRealm = currentRealm,
+            InstanceInfoList = instanceInfoBlob,
+            CurrentZone = currentZone
+        };
+        SendToSocket(rsp);
+    }
+
+    [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_TRANSFER_REALMS))]
+    private void ReceiveTransferRealms(GAME_5_PROTOCOL.MSG_TRANSFER_REALMS message) {
+        var wizard = GetActiveWizard();
+        var account = GetActiveAccount();
+
+        if (wizard is null || account is null) {
+            return;
+        }
+
+        // Ask the LoginServer to create a session key on the target realm's game server.
+        var createKeyMsg = new SERVER_100_PROTOCOL.MSG_CREATEPLAYERKEY {
+            Account = account,
+            TargetRealmName = message.RealmName
+        };
+
+        SERVER_100_PROTOCOL.MSG_CREATEPLAYERKEYRSP keyRsp;
+        try {
+            keyRsp = AskServer<SERVER_100_PROTOCOL.MSG_CREATEPLAYERKEYRSP>(createKeyMsg);
+        }
+        catch {
+            Logger.Error("Failed to create player key for realm transfer to {Realm}.",
+                Logger.Args(message.RealmName));
+
+            return;
+        }
+
+        if (!keyRsp.Success) {
+            Logger.Warning("Realm transfer to {Realm} failed — realm not found.",
+                Logger.Args(message.RealmName));
+
+            return;
+        }
+
+        // Send MSG_SERVERTRANSFER to redirect the client to the new game server.
+        var serverTransfer = new GAME_5_PROTOCOL.MSG_SERVERTRANSFER {
+            IP = keyRsp.IP,
+            TCPPort = keyRsp.Port,
+            UDPPort = keyRsp.Port,
+            Key = 0, // Session key is already stored on the target server.
+            UserID = account.AccountId,
+            CharID = wizard.CharId,
+            ZoneName = wizard.Zone,
+            ZoneID = new Imcodec.Types.GID((ulong) keyRsp.Port),
+            Location = Util.GetCompactStringFromVector(wizard.Location, wizard.Orientation),
+            Slot = 0,
+            SessionSlot = 0,
+            SessionID = 0,
+            TargetPlayerID = wizard.CharId,
+            TransitionID = 1,
+            FallbackIP = keyRsp.IP,
+            FallbackTCPPort = keyRsp.Port,
+            FallbackUDPPort = keyRsp.Port,
+            FallbackZone = wizard.Zone,
+            FallbackZoneID = new Imcodec.Types.GID((ulong) keyRsp.Port)
+        };
+        SendToSocket(serverTransfer);
+    }
+
+    [MessageHandler(typeof(GAME2_55_PROTOCOL.MSG_CURRENTREALM))]
+    private void ReceiveCurrentRealm(GAME2_55_PROTOCOL.MSG_CURRENTREALM message) {
+        var wizard = GetActiveWizard();
+        var currentZone = wizard?.Zone ?? "";
+
+        var currentRealm = "Imlight";
+        try {
+            var serverInfo = AskServer<SERVER_100_PROTOCOL.MSG_SERVERINFO>(
+                new SERVER_100_PROTOCOL.MSG_QUERYSERVER());
+            currentRealm = serverInfo.RealmName ?? currentRealm;
+        }
+        catch { }
+
+        var rsp = new GAME2_55_PROTOCOL.MSG_CURRENTREALM {
+            CurrentRealm = currentRealm,
+            CurrentZone = currentZone
+        };
+        SendToSocket(rsp);
     }
 
     private void SetZone(IActorRef actorRef) {

--- a/src/Imlight.CoreLib/Login/GameServerPool.cs
+++ b/src/Imlight.CoreLib/Login/GameServerPool.cs
@@ -58,6 +58,7 @@ internal class GameServerPool : ReceiveProtocolDispatcher {
     private readonly ushort _gameServerQueryTimeout = 10;
 
     private readonly Dictionary<ushort, IActorRef> _gameServers;
+    private readonly Dictionary<string, ushort> _realmToPort = [];
 
     public GameServerPool() {
         this._gameServers = [];
@@ -84,13 +85,17 @@ internal class GameServerPool : ReceiveProtocolDispatcher {
             return;
         }
 
-        var gameProps = GameServer.Props(message.Name, message.Port);
+        var gameProps = GameServer.Props(message.Name, message.Port, message.RealmName);
         var gameServerRef = Context.ActorOf(gameProps, $"{message.Name}.{message.Port}");
 
         _gameServers.Add(message.Port, gameServerRef);
 
-        Logger.Debug("Game server pool registered new game server {Name} created on port {Port}.",
-            Logger.Args(message.Name, message.Port));
+        if (!string.IsNullOrEmpty(message.RealmName)) {
+            _realmToPort[message.RealmName] = message.Port;
+        }
+
+        Logger.Debug("Game server pool registered new game server {Name} (realm: {Realm}) on port {Port}.",
+            Logger.Args(message.Name, message.RealmName, message.Port));
     }
 
     [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_GETBESTSERVER))]
@@ -156,6 +161,72 @@ internal class GameServerPool : ReceiveProtocolDispatcher {
             Found = false,
         };
         Sender.Tell(failureMsg);
+    }
+
+    [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_CREATEPLAYERKEY))]
+    private void ReceiveCreatePlayerKey(SERVER_100_PROTOCOL.MSG_CREATEPLAYERKEY message) {
+        if (!_realmToPort.TryGetValue(message.TargetRealmName, out var port)
+            || !_gameServers.TryGetValue(port, out var serverRef)) {
+            Sender.Tell(new SERVER_100_PROTOCOL.MSG_CREATEPLAYERKEYRSP { Success = false });
+
+            return;
+        }
+
+        // Forward the key creation request to the target game server.
+        // The game server handles MSG_CREATEPLAYERKEY and returns MSG_CREATEPLAYERKEYRSP.
+        serverRef.Forward(message);
+    }
+
+    [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_QUERYREALMSERVER))]
+    private void ReceiveQueryRealmServer(SERVER_100_PROTOCOL.MSG_QUERYREALMSERVER message) {
+        if (!_realmToPort.TryGetValue(message.RealmName, out var port)
+            || !_gameServers.TryGetValue(port, out var serverRef)) {
+            Sender.Tell(new SERVER_100_PROTOCOL.MSG_SERVERINFO { RealmName = null });
+
+            return;
+        }
+
+        try {
+            var msg = new SERVER_100_PROTOCOL.MSG_QUERYSERVER();
+            var timeout = TimeSpan.FromSeconds(_gameServerQueryTimeout);
+            var rsp = serverRef.Ask<SERVER_100_PROTOCOL.MSG_SERVERINFO>(msg, timeout).Result;
+            Sender.Tell(rsp);
+        }
+        catch {
+            Sender.Tell(new SERVER_100_PROTOCOL.MSG_SERVERINFO { RealmName = null });
+        }
+    }
+
+    [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_REALMLIST))]
+    private void ReceiveRealmList(SERVER_100_PROTOCOL.MSG_REALMLIST message) {
+        var realmNames = new List<string>();
+        var playerCounts = new List<ushort>();
+        var playerLimits = new List<ushort>();
+
+        foreach (var (realmName, port) in _realmToPort) {
+            if (!_gameServers.TryGetValue(port, out var serverRef)) {
+                continue;
+            }
+
+            try {
+                var msg = new SERVER_100_PROTOCOL.MSG_QUERYSERVER();
+                var timeout = TimeSpan.FromSeconds(_gameServerQueryTimeout);
+                var rsp = serverRef.Ask<SERVER_100_PROTOCOL.MSG_SERVERINFO>(msg, timeout).Result;
+
+                realmNames.Add(realmName);
+                playerCounts.Add(rsp.PlayerCount);
+                playerLimits.Add(_gameServerPlayerCount);
+            }
+            catch {
+                // Server unreachable — skip it.
+            }
+        }
+
+        Sender.Tell(new SERVER_100_PROTOCOL.MSG_REALMLIST {
+            RealmNames = [.. realmNames],
+            PlayerCounts = [.. playerCounts],
+            PlayerLimits = [.. playerLimits]
+        });
     }
 
 }

--- a/src/Imlight.CoreLib/Login/LoginServer.cs
+++ b/src/Imlight.CoreLib/Login/LoginServer.cs
@@ -64,6 +64,21 @@ public class LoginServer : Server {
         _gamePoolServer.Forward(message);
     }
 
+    [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_CREATEPLAYERKEY))]
+    private void ReceiveCreatePlayerKey(SERVER_100_PROTOCOL.MSG_CREATEPLAYERKEY message) {
+        _gamePoolServer.Forward(message);
+    }
+
+    [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_QUERYREALMSERVER))]
+    private void ReceiveQueryRealmServer(SERVER_100_PROTOCOL.MSG_QUERYREALMSERVER message) {
+        _gamePoolServer.Forward(message);
+    }
+
+    [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_REALMLIST))]
+    private void ReceiveRealmList(SERVER_100_PROTOCOL.MSG_REALMLIST message) {
+        _gamePoolServer.Forward(message);
+    }
+
     [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_PLAYERENQUEUED))]
     private void ReceivePlayerEnqueued(SERVER_100_PROTOCOL.MSG_PLAYERENQUEUED message) {
         var rsp = new SERVER_100_PROTOCOL.MSG_PLAYERENQUEUEDRSP();

--- a/src/Imlight.CoreLib/Login/Services/GameTransitionService.cs
+++ b/src/Imlight.CoreLib/Login/Services/GameTransitionService.cs
@@ -56,6 +56,13 @@ internal class GameTransitionService(SessionActor sessionActor) : MessageService
     protected static Props Props(SessionActor parentActor)
         => Akka.Actor.Props.Create(() => new GameTransitionService(parentActor));
 
+    [MessageHandler(typeof(LOGIN_7_PROTOCOL.MSG_REQUESTSERVERLIST))]
+    private void ReceiveRequestServerList(LOGIN_7_PROTOCOL.MSG_REQUESTSERVERLIST message) {
+        // Signal to the client that the server list is available.
+        // MSG_SERVERLIST has no payload — it's just a protocol acknowledgment.
+        SendToSocket(new LOGIN_7_PROTOCOL.MSG_SERVERLIST());
+    }
+
     [MessageHandler(typeof(LOGIN_7_PROTOCOL.MSG_SELECTCHARACTER))]
     private void ReceiveSelectCharacter(LOGIN_7_PROTOCOL.MSG_SELECTCHARACTER message) {
         // If the socket account cannot be found, send the client an error.

--- a/src/Imlight.CoreLib/Shared/Networking/Server.cs
+++ b/src/Imlight.CoreLib/Shared/Networking/Server.cs
@@ -57,6 +57,7 @@ public abstract class Server : ReceiveProtocolDispatcher {
     public string Name { get; }
     public string Ip { get; }
     public int Port { get; }
+    public virtual string RealmName { get; protected set; }
 
     protected readonly ObservableHashSet<SessionActor> ActiveSessions;
 
@@ -127,7 +128,8 @@ public abstract class Server : ReceiveProtocolDispatcher {
             Port = Port,
             PlayerCount = (ushort) ActiveSessions.Count,
             ActorRef = Context.Self,
-            ConnectedIps = ips
+            ConnectedIps = ips,
+            RealmName = RealmName
         };
 
         Sender.Tell(msg);

--- a/src/Imlight.CoreLib/Shared/Packets/SERVER_100_PROTOCOL.cs
+++ b/src/Imlight.CoreLib/Shared/Packets/SERVER_100_PROTOCOL.cs
@@ -40,6 +40,7 @@ public sealed class SERVER_100_PROTOCOL : IServerProtocol {
 
         public string Name;
         public ushort Port;
+        public string RealmName;
 
     }
 
@@ -115,6 +116,7 @@ public sealed class SERVER_100_PROTOCOL : IServerProtocol {
         public TcpListener TcpClient;
         public IActorRef ActorRef;
         public string[] ConnectedIps;
+        public string RealmName;
 
     }
 
@@ -259,6 +261,59 @@ public sealed class SERVER_100_PROTOCOL : IServerProtocol {
         public byte ServiceID { get; } = 100;
 
         public IMessage Packet;
+    }
+
+    /// <summary>
+    /// Sent to the GameServerPool to create a session key on a specific realm's game server.
+    /// Used for cross-server realm transfers.
+    /// </summary>
+    public class MSG_CREATEPLAYERKEY : IServerMessage {
+
+        public byte MessageOrder { get; } = 24;
+        public byte ServiceID { get; } = 100;
+
+        public Account Account;
+        public string TargetRealmName;
+
+    }
+
+    public class MSG_CREATEPLAYERKEYRSP : IServerMessage {
+
+        public byte MessageOrder { get; } = 25;
+        public byte ServiceID { get; } = 100;
+
+        public ByteString Key;
+        public string IP;
+        public ushort Port;
+        public string RealmName;
+        public bool Success;
+
+    }
+
+    /// <summary>
+    /// Query the GameServerPool for info about a specific realm's game server.
+    /// </summary>
+    public class MSG_QUERYREALMSERVER : IServerMessage {
+
+        public byte MessageOrder { get; } = 26;
+        public byte ServiceID { get; } = 100;
+
+        public string RealmName;
+
+    }
+
+    /// <summary>
+    /// Returns the list of all realm names with their player counts.
+    /// </summary>
+    public class MSG_REALMLIST : IServerMessage {
+
+        public byte MessageOrder { get; } = 27;
+        public byte ServiceID { get; } = 100;
+
+        public string[] RealmNames;
+        public ushort[] PlayerCounts;
+        public ushort[] PlayerLimits;
+
     }
     
 }

--- a/src/Imlight.Director/Config/Imlight.ini
+++ b/src/Imlight.Director/Config/Imlight.ini
@@ -27,8 +27,12 @@ GameServerName = Imlight.Game
 GameServerPort = 12333
 GameServerPlayerLimit = 1000
 GameServerIP = 127.0.0.1
+; The number of game servers (realms) the Director will create.
+GameServerCount = 3
 ; The number of game servers that can be created.
 MaxGameServersAllowed = 3
+; Comma-separated list of realm names. Must have at least GameServerCount entries.
+RealmNames = Centaur,Pegasus,Phoenix
 ; The time in seconds that a session key is valid.
 SessionKeyValidityTime = 28800
 

--- a/src/Imlight.Director/Program.cs
+++ b/src/Imlight.Director/Program.cs
@@ -84,6 +84,14 @@ internal static class Program {
         ConfigurationManager.Settings["Patch Server.PatchServerName"].AsString();
     private static readonly ushort s_patchServerPort = 
         ConfigurationManager.Settings["Patch Server.PatchServerPort"].AsUShort();
+    private static readonly byte s_gameServerCount = 
+        ConfigurationManager.Settings["Game Server.GameServerCount"].AsByte();
+    private static readonly string s_gameServerName = 
+        ConfigurationManager.Settings["Game Server.GameServerName"].AsString();
+    private static readonly ushort s_gameServerPort = 
+        ConfigurationManager.Settings["Game Server.GameServerPort"].AsUShort();
+    private static readonly string[] s_realmNames = 
+        ConfigurationManager.Settings["Game Server.RealmNames"].AsString().Split(',');
     private static readonly string s_adminAccountUsername = 
         ConfigurationManager.Settings["Database.AdminAccountUsername"].AsString();
     private static readonly string s_adminAccountPassword = 
@@ -137,7 +145,7 @@ internal static class Program {
         // SERVERS
         // =============================================================
         var loginServer = StartLoginServer();
-        StartGameServer(loginServer);
+        StartGameServers(loginServer);
 
         // Force load dragon database. Create a dud account if the database ends up using the embedded database.
         _ = PlayerDatabase.Instance.Store;
@@ -168,9 +176,27 @@ internal static class Program {
         return loginServerActor;
     }
 
-    private static void StartGameServer(IActorRef loginServerActorRef) {
-        var msg = new SERVER_100_PROTOCOL.MSG_CREATEGAMESERVER();
-        loginServerActorRef.Tell(msg);
+    private static void StartGameServers(IActorRef loginServerActorRef) {
+        var count = Math.Max(s_gameServerCount, (byte) 1);
+        var basePort = s_gameServerPort;
+
+        for (byte i = 0; i < count; i++) {
+            var realmName = i < s_realmNames.Length 
+                ? s_realmNames[i].Trim() 
+                : $"Realm-{i + 1}";
+            var serverName = $"{s_gameServerName}.{realmName}";
+            var port = (ushort) (basePort + i);
+
+            var msg = new SERVER_100_PROTOCOL.MSG_CREATEGAMESERVER {
+                Name = serverName,
+                Port = port,
+                RealmName = realmName
+            };
+            loginServerActorRef.Tell(msg);
+
+            Logger.Information("Director requested game server '{Name}' on port {Port} (realm: {Realm}).",
+                Logger.Args(serverName, port, realmName));
+        }
     }
 
     private static async Task StartPatchServer() {


### PR DESCRIPTION
## Changelog: 
* Added two new configuration options: `GameServerCount` & `RealmNames`:
```
; The number of game servers (realms) the Director will create.
GameServerCount = 3
; Comma-separated list of realm names. Must have at least GameServerCount entries.
RealmNames = Centaur,Pegasus,Phoenix
```
* The login server (master server) will now create these embedded game servers
* Added a number of handlers to allow the game client to swap between these game servers, which appear as realms ingame