### PR TITLE
`Fix/misc` -> `quality-assurance`

### DIFF
--- a/src/Imlight.Common/Imlight.Common.csproj
+++ b/src/Imlight.Common/Imlight.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Imlight.CoreLib/Game/Combat/CombatActionResolver.cs
+++ b/src/Imlight.CoreLib/Game/Combat/CombatActionResolver.cs
@@ -120,7 +120,7 @@ internal static class CombatActionResolver {
 
     private static SpellEffect ChooseRandomEffect(RandomSpellEffect randomSpellEffect, CombatEffectStack effectStack) {
         var count = randomSpellEffect.m_effectList.Count;
-        var randomEffectIndex = new Random().Next(0, count);
+        var randomEffectIndex = Random.Shared.Next(0, count);
         var chosenEffect = randomSpellEffect.m_effectList[randomEffectIndex];
 
         effectStack.PushRandomEffectChoice(randomEffectIndex);

--- a/src/Imlight.CoreLib/Game/Combat/CombatActionResolver.cs
+++ b/src/Imlight.CoreLib/Game/Combat/CombatActionResolver.cs
@@ -77,9 +77,11 @@ internal static class CombatActionResolver {
             // to the effect stack.
             chosenEffect = spellEffect switch {
                 RandomSpellEffect randomSpellEffect => ChooseRandomEffect(randomSpellEffect, effectStack),
-                VariableSpellEffect variableSpellEffect => ChooseVariableEffect(variableSpellEffect, combatAction.m_xPipCost, effectStack),
+                VariableSpellEffect variableSpellEffect => ChooseEffectByPipCount(variableSpellEffect.m_effectList, combatAction.m_xPipCost, effectStack),
+                EffectListSpellEffect effectListSpellEffect => ChooseFromEffectList(effectListSpellEffect, combatAction.m_xPipCost, effectStack),
                 _ => spellEffect,
             };
+
             allEffects.Add(chosenEffect);
 
             charmsAffectingThisSpell = CombatCharms.FindAppliedCharms(action.SpellCaster, [.. allEffects]);
@@ -126,22 +128,26 @@ internal static class CombatActionResolver {
         return chosenEffect;
     }
 
-    private static SpellEffect ChooseVariableEffect(VariableSpellEffect variableSpellEffect, int parameter, CombatEffectStack effectStack) {
-        // Variable spell effects are for x pip spells. There should be a total of 14 nested spell effects
-        // for each pip level of the spell.
-        if (variableSpellEffect.m_effectList.Count != 14) {
-            Logger.Error("Variable spell effect does not have 14 nested effects.");
-            
-            return variableSpellEffect;
+    private static SpellEffect ChooseEffectByPipCount(List<SpellEffect> effectList, int pipCost, CombatEffectStack effectStack) {
+        // Selects a nested effect from a VariableSpellEffect by pip count.
+        // VariableSpellEffect entries are 0-indexed: entry 0 = 0 pips, entry 5 = 5 pips.
+        var index = Math.Min(pipCost, effectList.Count - 1);
+        effectStack.PushRandomEffectChoice(index);
+
+        return effectList[index];
+    }
+
+    private static SpellEffect ChooseFromEffectList(EffectListSpellEffect effect, int pipCost, CombatEffectStack effectStack) {
+        // Selects a nested effect from an EffectListSpellEffect by pip count.
+        // EffectListSpellEffect entries are 1-indexed via m_pipNum: entry 0 = 1 pip, entry 4 = 5 pips.
+        var idx = Math.Max(0, pipCost - 1);
+        if (idx >= effect.m_effectList.Count) {
+            idx = effect.m_effectList.Count - 1;
         }
 
-        // Make sure we're not out of bounds.
-        parameter = Math.Min(parameter, 13);
+        effectStack.PushRandomEffectChoice(idx);
 
-        effectStack.PushRandomEffectChoice(parameter);
-        var chosenEffect = variableSpellEffect.m_effectList[parameter];
-
-        return chosenEffect;
+        return effect.m_effectList[idx];
     }
 
     private static byte GetXPipCost(Spell spell, CombatDuelSubCircle caster) {

--- a/src/Imlight.CoreLib/Game/Combat/CombatDeck.cs
+++ b/src/Imlight.CoreLib/Game/Combat/CombatDeck.cs
@@ -103,8 +103,6 @@ internal class CombatDeck {
     /// <exception cref="InvalidOperationException">Thrown when a spell cannot be created from the template id.</exception>
     internal Hand GetHand() {
         var newCards = new List<Spell>();
-        var random = new Random();
-
         // Discard the cards that were used up or discarded.
         foreach (var spell in _cardsDiscardedThisTurn) {
             LastGivenHand.Remove(spell);
@@ -132,7 +130,7 @@ internal class CombatDeck {
                 break; // No more spells available.
             }
 
-            var randomIndex = random.Next(0, _usedUpSpellData.Count);
+            var randomIndex = Random.Shared.Next(0, _usedUpSpellData.Count);
             var spellData = _usedUpSpellData[randomIndex];
             var spellTemplateId = spellData.TemplateId;
 
@@ -192,8 +190,7 @@ internal class CombatDeck {
             return null;
         }
 
-        var random = new Random();
-        var randomIndex = random.Next(0, _treasureVaultUsed.Count);
+        var randomIndex = Random.Shared.Next(0, _treasureVaultUsed.Count);
         var vaultData = _treasureVaultUsed[randomIndex];
 
         var spell = SpellFactory.GetSpell(vaultData.TemplateId);

--- a/src/Imlight.CoreLib/Game/Combat/CombatDuelSubCircle.cs
+++ b/src/Imlight.CoreLib/Game/Combat/CombatDuelSubCircle.cs
@@ -619,7 +619,7 @@ public class CombatDuelSubCircle {
         var stats = participant.m_pGameStats;
         var powerPipChance = 100 * (stats.m_powerPipBase + stats.m_powerPipBonusPercentAll);
 
-        var powerPipRoll = new Random().Next(0, 100);
+        var powerPipRoll = Random.Shared.Next(0, 100);
         return powerPipRoll <= powerPipChance;
     }
 

--- a/src/Imlight.CoreLib/Game/Combat/CombatDuelSubCircle.cs
+++ b/src/Imlight.CoreLib/Game/Combat/CombatDuelSubCircle.cs
@@ -452,9 +452,18 @@ public class CombatDuelSubCircle {
             }
         }
 
-        // Count temporary spells as 1 quantity.
+        // Count temporary spells as 1 quantity, skipping any that the player
+        // has excluded via the spell deck UI (MSG_UPDATEITEMSPELLEXCLUSIONLIST).
         var temporarySpells = new List<CombatDeckSpellData>();
+        var equippedDeckId = _wizard.EquipmentBehavior.SlotList
+            .FirstOrDefault(s => s.SlotType == EquipmentSlotType.Deck)?.ItemId;
         foreach (var tempSpell in _wizard.SpellbookBehavior.TemporarySpells) {
+            // Check if this item spell is excluded for the equipped deck.
+            if (equippedDeckId != null
+                && _wizard.SpellbookBehavior.IsItemSpellExcluded(equippedDeckId.Value, tempSpell.m_templateID)) {
+                continue;
+            }
+
             // If the spell data already exists, increase the quantity.. otherwise add it.
             var existingSpell = temporarySpells.Find(s => s.TemplateId == tempSpell.m_templateID);
             if (existingSpell is not null) {

--- a/src/Imlight.CoreLib/Game/Combat/CombatEffectApplicator.cs
+++ b/src/Imlight.CoreLib/Game/Combat/CombatEffectApplicator.cs
@@ -80,6 +80,9 @@ internal static class CombatEffectApplicator {
             case kSpellEffects.kDamage:
                 cinematicTime += ApplyFlatDamageEffect(effect, charms, caster, targets);
                 break;
+            case kSpellEffects.kDamagePerTotalPipPower:
+                cinematicTime += ApplyFlatDamageEffect(effect, charms, caster, targets);
+                break;
             case kSpellEffects.kDamageOverTime:
                 cinematicTime += ApplyDamageOverTime(effect, charms, caster, targets);
                 break;
@@ -186,8 +189,6 @@ internal static class CombatEffectApplicator {
             };
             target._hangingEffects.Add(effectClone);
         }
-
-        effect.m_paramPerRound = damageFromCaster / effect.m_numRounds;
 
         return cinematicTime;
     }

--- a/src/Imlight.CoreLib/Game/Combat/CombatResolver.cs
+++ b/src/Imlight.CoreLib/Game/Combat/CombatResolver.cs
@@ -450,7 +450,7 @@ public class CombatResolver(Duel duel, CombatDuelSubCircle[] actorSubCircles) {
         // Apply any hanging accuracy effects
         spellAccuracy = ConsumeHangingAccuracyEffects(spellAccuracy, caster, spell.m_magicSchoolID);
 
-        var hitChance = new Random().Next(0, 100);
+        var hitChance = Random.Shared.Next(0, 100);
         
         return hitChance <= spellAccuracy;
     }

--- a/src/Imlight.CoreLib/Game/Commands/CommandUtilities.cs
+++ b/src/Imlight.CoreLib/Game/Commands/CommandUtilities.cs
@@ -24,31 +24,40 @@ internal static class CommandUtilities {
     internal static bool TryParseDuration(string durationString, out TimeSpan result) {
         result = TimeSpan.Zero;
 
-        // Use regular expression to match and extract components
-        var match = Regex.Match(durationString, @"(\d+d)?(\d+h)?(\d+m)?(\d+s)?");
+        // Use regular expression to match and extract components.
+        // Anchor with ^...$ so the whole string must be a valid duration (no "abc123d" partials).
+        var match = Regex.Match(durationString, @"^(\d+d)?(\d+h)?(\d+m)?(\d+s)?$");
 
-        if (match.Success) {
-            // Try to extract and convert each component
-            if (match.Groups[1].Success && int.TryParse(match.Groups[1].Value.TrimEnd('d'), out int days)) {
-                result += TimeSpan.FromDays(days);
-            }
-
-            if (match.Groups[2].Success && int.TryParse(match.Groups[2].Value.TrimEnd('h'), out int hours)) {
-                result += TimeSpan.FromHours(hours);
-            }
-
-            if (match.Groups[3].Success && int.TryParse(match.Groups[3].Value.TrimEnd('m'), out int minutes)) {
-                result += TimeSpan.FromMinutes(minutes);
-            }
-
-            if (match.Groups[4].Success && int.TryParse(match.Groups[4].Value.TrimEnd('s'), out int seconds)) {
-                result += TimeSpan.FromSeconds(seconds);
-            }
-
-            return true;
+        if (!match.Success) {
+            return false;
         }
 
-        return false;
+        var parsedAny = false;
+
+        if (match.Groups[1].Success && int.TryParse(match.Groups[1].Value.TrimEnd('d'), out int days)) {
+            result += TimeSpan.FromDays(days);
+            parsedAny = true;
+        }
+
+        if (match.Groups[2].Success && int.TryParse(match.Groups[2].Value.TrimEnd('h'), out int hours)) {
+            result += TimeSpan.FromHours(hours);
+            parsedAny = true;
+        }
+
+        if (match.Groups[3].Success && int.TryParse(match.Groups[3].Value.TrimEnd('m'), out int minutes)) {
+            result += TimeSpan.FromMinutes(minutes);
+            parsedAny = true;
+        }
+
+        if (match.Groups[4].Success && int.TryParse(match.Groups[4].Value.TrimEnd('s'), out int seconds)) {
+            result += TimeSpan.FromSeconds(seconds);
+            parsedAny = true;
+        }
+
+        // All groups are optional in the regex, so match.Success alone isn't enough —
+        // we must have parsed at least one component. Otherwise overflow values like
+        // "10000000000000m" would silently produce TimeSpan.Zero and return true.
+        return parsedAny;
     }
     
 }

--- a/src/Imlight.CoreLib/Game/Commands/Protocols/CommandDebugProtocol.cs
+++ b/src/Imlight.CoreLib/Game/Commands/Protocols/CommandDebugProtocol.cs
@@ -53,9 +53,10 @@ internal class CommandDebugProtocol : CommandProtocol {
             Sender = Context.SessionActor
         };
 
-        var message = new ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST {
+        var message = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
             Messages = [stateChangeMsg],
-            Sender = Context.SessionActor
+            Sender = Context.SessionActor,
+            Targets = ZoneBroadcastTarget.Objects,
         };
 
         Context.ZoneActor.Tell(message, Context.SessionActor);
@@ -71,9 +72,10 @@ internal class CommandDebugProtocol : CommandProtocol {
             Sender = Context.SessionActor
         };
 
-        var message = new ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST {
+        var message = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
             Messages = [stateChangeMsg],
-            Sender = Context.SessionActor
+            Sender = Context.SessionActor,
+            Targets = ZoneBroadcastTarget.Objects,
         };
 
         Context.ZoneActor.Tell(message, Context.SessionActor);

--- a/src/Imlight.CoreLib/Game/Commands/Protocols/CommandModifyProtocol.cs
+++ b/src/Imlight.CoreLib/Game/Commands/Protocols/CommandModifyProtocol.cs
@@ -99,7 +99,7 @@ internal class CommandModifyProtocol : CommandProtocol {
         // Create the network message and send it.
         var networkMessage = new GAME_5_PROTOCOL.MSG_ADDEFFECT() {
             GameObjectID = Context.Character.CharId,
-            EffectData = serializedEffect.ToString()
+            EffectData = serializedEffect
         };
         Context.SessionActor.Tell(networkMessage, null);
 

--- a/src/Imlight.CoreLib/Game/Madlibs/QuestMadlibs.cs
+++ b/src/Imlight.CoreLib/Game/Madlibs/QuestMadlibs.cs
@@ -94,26 +94,24 @@ internal static class QuestMadlibs {
         };
 
     private static MadlibBlock GetMadlibBlockForPersonaGoal(GoalTemplate gTemplate) {
-        // Grab the completion dialog for this goal. It will determine the dialog that
-        // players see when they complete the goal. This dialog should always be from the NPC.
-        if (gTemplate.m_dialogList is not ActorDialogList dialogList) {
-            throw new System.Exception("Persona goals must have an ActorDialogList assigned to m_dialogList.");
+        string firstName = string.Empty;
+        string lastName = string.Empty;
+
+        // Try to resolve the NPC's display name from the Completion dialog entry.
+        if (gTemplate.m_dialogList is ActorDialogList dialogList) {
+            var completionDialogEntry = dialogList.m_dialogs
+                .FirstOrDefault(de => de.m_dialogTag == "Completion");
+            var templateId = completionDialogEntry?.m_dialogEntries
+                ?.FirstOrDefault()?.m_actorTemplateID ?? 0;
+
+            if (templateId != 0) {
+                var npcTemplate = CoreObjectFactory.GetCoreTemplate(templateId);
+                if (npcTemplate is GameObjectTemplate npcGameObjectTemplate) {
+                    var npcFullname = npcGameObjectTemplate.m_displayName;
+                    (firstName, lastName) = Locale.GetEnglishNameKeys(npcFullname);
+                }
+            }
         }
-
-        var completionDialogEntry = dialogList.m_dialogs.FirstOrDefault(de => de.m_dialogTag == "Completion") 
-            ?? throw new System.Exception("Persona goals must have a Completion dialog entry in their ActorDialogList.");
-        var templateId = (completionDialogEntry?.m_dialogEntries?.FirstOrDefault()?.m_actorTemplateID)
-            ?? throw new System.Exception("Persona goals must have an ActorTemplateID assigned in their Completion dialog entry.");
-
-        // Grab the actual template from the template ID.
-        var npcTemplate = CoreObjectFactory.GetCoreTemplate(templateId);
-        if (npcTemplate is not GameObjectTemplate npcGameObjectTemplate) {
-            throw new System.Exception("Persona goals must have a valid GameObjectTemplate assigned to their Completion dialog entry.");
-        }
-
-        // Resolve the fullname display locale ID into a FIRSTNAME/LASTNAME format.
-        var npcFullname = npcGameObjectTemplate.m_displayName;
-        (string firstName, string lastName) = Locale.GetEnglishNameKeys(npcFullname);
 
         var madLibs = new MadlibBlock() {
             m_madlibs = [

--- a/src/Imlight.CoreLib/Game/Requirements/Handlers/ReqHasEntryHandler.cs
+++ b/src/Imlight.CoreLib/Game/Requirements/Handlers/ReqHasEntryHandler.cs
@@ -30,7 +30,7 @@ internal sealed class ReqHasEntryHandler : BaseRequirementHandler<ReqHasEntry> {
         }
 
         var questName = Requirement.m_questName;
-        if (string.IsNullOrEmpty(questName)) {
+        if (Requirement.m_isQuestRegistry && string.IsNullOrEmpty(questName)) {
             return false;
         }
 

--- a/src/Imlight.CoreLib/Game/Requirements/Handlers/ReqHasGoalHandler.cs
+++ b/src/Imlight.CoreLib/Game/Requirements/Handlers/ReqHasGoalHandler.cs
@@ -1,0 +1,62 @@
+/*
+ * Imlight
+ * Copyright (C) 2025 Revive101
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System.Linq;
+using Imcodec.ObjectProperty.TypeCache;
+
+namespace Imlight.CoreLib.Game.Requirements.Handlers;
+
+internal sealed class ReqHasGoalHandler : BaseRequirementHandler<ReqHasGoal> {
+
+    public override bool Evaluate(IRequirementContext context) {
+        var wizard = context.GetWizard();
+        if (wizard == null) {
+            return false;
+        }
+
+        var questName = Requirement.m_questName;
+        if (string.IsNullOrEmpty(questName)) {
+            return false;
+        }
+
+        var goalName = Requirement.m_goalName;
+        if (string.IsNullOrEmpty(goalName)) {
+            return false;
+        }
+
+        var quest = wizard.QuestBehavior.CurrentQuestInstances
+            .FirstOrDefault(q => q.QuestName == questName);
+        if (quest == null) {
+            return false;
+        }
+
+        var goal = quest.GoalProgress
+            .FirstOrDefault(g => g.GoalName == goalName);
+        if (goal == null) {
+            return false;
+        }
+
+        return Requirement.m_requiredStatus switch {
+            GoalStatusRequirement.DontCare => true,
+            GoalStatusRequirement.Complete => goal.IsGoalCompleted(),
+            GoalStatusRequirement.Incomplete => goal.DoesPlayerHaveGoal() && !goal.IsGoalCompleted(),
+            _ => false
+        };
+    }
+
+}

--- a/src/Imlight.CoreLib/Game/Results/BaseResultHandler.cs
+++ b/src/Imlight.CoreLib/Game/Results/BaseResultHandler.cs
@@ -91,7 +91,11 @@ public abstract class BaseResultHandler<T> : ReceiveProtocolDispatcher, IResultH
         var rsp = new CHARACTER_103_PROTOCOL.MSG_RESULTEXECUTED {
             Success = executeSuccess
         };
-        Sender.Tell(rsp);   
+        Sender.Tell(rsp);
+
+        // Self-destruct after replying so handler actors don't accumulate
+        // as orphan children of the ResultExecutorActor.
+        Context.Stop(Self);
     }
 
 }

--- a/src/Imlight.CoreLib/Game/Results/Handlers/ResModifyEntryHandler.cs
+++ b/src/Imlight.CoreLib/Game/Results/Handlers/ResModifyEntryHandler.cs
@@ -1,0 +1,75 @@
+/*
+ * Imlight
+ * Copyright (C) 2025 Revive101
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System;
+using Akka.Actor;
+using Imcodec.ObjectProperty.TypeCache;
+using Imlight.Common;
+using Imlight.CoreLib.Shared.Packets;
+
+namespace Imlight.CoreLib.Game.Results.Handlers;
+
+internal sealed class ResModifyEntryHandler : BaseResultHandler<ResModifyEntry> {
+
+    private const float QUERY_WIZARD_TIMEOUT_SECONDS = 5.0f;
+
+    public override bool Execute(IResultContext context) {
+        var playerObj = context.GetPlayerObj();
+        if (playerObj is null) {
+            return false;
+        }
+
+        if (Result is null) {
+            return false;
+        }
+
+        var entryName = Result.m_entryName;
+        if (string.IsNullOrEmpty(entryName)) {
+            return false;
+        }
+
+        // Context does not ship with a wizard reference, so we need to query for it.
+        var queryWizardMsg = new CHARACTER_103_PROTOCOL.MSG_QUERYACTIVEWIZARD();
+        var queryTimeout = TimeSpan.FromSeconds(QUERY_WIZARD_TIMEOUT_SECONDS);
+        var queryResponse = context
+            .GetPlayerRef()
+            .Ask<CHARACTER_103_PROTOCOL.MSG_CHARACTER>(queryWizardMsg, queryTimeout).Result;
+        if (queryResponse == null) {
+            Logger.Error("ResModifyEntry handler failed to retrieve character data within {0} seconds.",
+                Logger.Args(QUERY_WIZARD_TIMEOUT_SECONDS));
+
+            return false;
+        }
+
+        var wizard = queryResponse.Wizard;
+        var value = (ulong) Result.m_value;
+
+        if (Result.m_isQuestRegistry) {
+            var questName = Result.m_questName;
+            if (string.IsNullOrEmpty(questName)) {
+                return false;
+            }
+            
+            return wizard.SetQuestRegistryValue(questName, entryName, value);
+        }
+        else {
+            return wizard.SetRegistryValue(entryName, value);
+        }
+    }
+
+}

--- a/src/Imlight.CoreLib/Game/Results/Handlers/ResSpawnHandler.cs
+++ b/src/Imlight.CoreLib/Game/Results/Handlers/ResSpawnHandler.cs
@@ -34,10 +34,11 @@ internal sealed class ResSpawnHandler : BaseResultHandler<ResSpawn> {
             return false;
         }
 
-        var broadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST {
+        var broadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
             Messages = [new ZONE_102_PROTOCOL.MSG_ZONEPATHSPAWN {
                 SpawnObjectID = (uint) Result.m_spawnID
             }],
+            Targets = ZoneBroadcastTarget.Paths,
         };
 
         zoneActor.Tell(broadcastMsg);
@@ -59,10 +60,11 @@ internal sealed class ResDespawnHandler : BaseResultHandler<ResDespawn> {
             return false;
         }
 
-        var broadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST {
+        var broadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
             Messages = [new ZONE_102_PROTOCOL.MSG_REMOVEOBJECT {
                 TemplateID = Result.m_templateID,
             }],
+            Targets = ZoneBroadcastTarget.Objects,
         };
 
         zoneActor.Tell(broadcastMsg);

--- a/src/Imlight.CoreLib/Game/Services/AttachService.cs
+++ b/src/Imlight.CoreLib/Game/Services/AttachService.cs
@@ -59,11 +59,9 @@ using Imlight.CoreLib.WizardData.Models.Player;
 
 namespace Imlight.CoreLib.Game.Services;
 
-internal class AttachService(SessionActor sessionActor) : MessageService(sessionActor), IWithTimers {
+internal class AttachService(SessionActor sessionActor) : MessageService(sessionActor) {
 
     private const float PRELOGIN_DELAY_MS = 500.0f;
-
-    public ITimerScheduler Timers { get; set; }
 
     private Account _account;
     private Wizard _wizard;

--- a/src/Imlight.CoreLib/Game/Services/AuctionHouseService.cs
+++ b/src/Imlight.CoreLib/Game/Services/AuctionHouseService.cs
@@ -50,6 +50,8 @@ using Imcodec.MessageLayer.Generated;
 using Imcodec.ObjectProperty.TypeCache;
 using Imcodec.CoreObject;
 using Imcodec.ObjectProperty;
+using Imcodec.IO;
+using Imcodec.Cryptography;
 using Imlight.Common;
 using Imcodec.Types;
 
@@ -60,9 +62,36 @@ internal class AuctionHouseService(SessionActor sessionActor) : MessageService(s
     private readonly CoreObjectSerializer _itemSerializer = new(
         behaviors: SerializerFlags.None
     );
-    private readonly ObjectSerializer _serializer = new(
-        Behaviors: SerializerFlags.None
-    );
+
+    private static ByteString WriteAuctionBlob(uint categoryHash, IReadOnlyCollection<AuctionHouseEntry> entries) {
+        // Writes auction house entries as binary. This is very similar to PropertyClass serialization.
+        //
+        // Format:
+        //   [0-3]  Category hash (uint32) — StringHash of category name (hat, robe, boots), or 0 for empty
+        //   [4-7]  Entry count (uint32)
+        //   [8..]  Array of entries, each 20 bytes:
+        //          [0-7]  GID / template ID (uint64, little-endian)
+        //          [8-11] Stock quantity (int32)
+        //          [12-15] Buy price (int32)
+        //          [16-19] Sell price (int32)
+        var writer = new BitWriter();
+        writer.WriteUInt32(categoryHash);
+        writer.WriteUInt32((uint) entries.Count);
+
+        foreach (var entry in entries) {
+            // Ensure the GID has Type=9
+            // Live bazaar entries use Type=9; our database entries may
+            // have Type=0 from direct ulong→GID casts.
+            var gid = new GID(entry.m_templateID.Full | (9UL << 40));
+
+            writer.WriteUInt64(gid);
+            writer.WriteInt32(entry.m_numForSale);
+            writer.WriteInt32(entry.m_buyPrice);
+            writer.WriteInt32(entry.m_sellPrice);
+        }
+
+        return writer.GetData();
+    }
 
     protected static Props Props(SessionActor parentActor)
         => Akka.Actor.Props.Create(() => new AuctionHouseService(parentActor));
@@ -71,7 +100,7 @@ internal class AuctionHouseService(SessionActor sessionActor) : MessageService(s
     private void ReceiveAuctionHouseRequest(WIZARD_12_PROTOCOL.MSG_AUCTIONHOUSEREQUEST message) {
         switch (message.Command) {
             case 0:
-                SendAuctionHouseContents(message.npcGlobalID, message.key);
+                SendAuctionHouseContents(message.npcGlobalID, message.category, message.key);
                 break;
             case 1:
                 ConfirmBuyFromAuctionHouse(message.itemTemplateID, message.key);
@@ -99,46 +128,24 @@ internal class AuctionHouseService(SessionActor sessionActor) : MessageService(s
         }
     }
 
-    private void SendAuctionHouseContents(ulong npcId, uint key) {
+    private void SendAuctionHouseContents(ulong npcId, uint category, uint key) {
         // Retrieve all Auction House entries.
         var houseEntries = AuctionHouseCollection.GetAllAuctionHouseEntries();
 
-        if (houseEntries is null) {
-            return;
-        }
+        var entryList = houseEntries is null
+            ? new List<AuctionHouseEntry>()
+            : [.. houseEntries];
 
-        var houseEntryList = new List<AuctionHouseEntry>(houseEntries);
+        // Serialize in the compact binary format the client expects.
+        // category=0 is reserved for empty/update signals per the live capture.
+        var contentsData = WriteAuctionBlob(category, entryList);
 
-        while (houseEntryList.Count > 0) {
-            // Contents sent in blocks of up to 50 entries.
-            var houseEntryBlock = (houseEntryList.Count >= 50)
-                ? houseEntryList.GetRange(0, 50) : houseEntryList.GetRange(0, houseEntryList.Count);
-
-            var auctionHouseEntries = new AuctionHouseOffering {
-                m_auctionHousePurchaseKey = key,
-                m_auctionList = houseEntryBlock
-            };
-
-            if (!_serializer.Serialize(auctionHouseEntries, 1, out var auctionHouseEntriesData)) {
-                Logger.Error("Failed to serialize auction house entries.");
-
-                return;
-            }
-
-            var auctionHouseContentsMsg = new WIZARD_12_PROTOCOL.MSG_AUCTIONHOUSECONTENTS {
-                Contents = auctionHouseEntriesData,
-                GlobalID = npcId
-            };
-            SendToSocket(auctionHouseContentsMsg);
-
-            // Remove first 50 entries from list.
-            if (houseEntryList.Count >= 50) {
-                houseEntryList.RemoveRange(0, 50);
-            }
-            else {
-                houseEntryList.RemoveRange(0, houseEntryList.Count);
-            }
-        }
+        var auctionHouseContentsMsg = new WIZARD_12_PROTOCOL.MSG_AUCTIONHOUSECONTENTS {
+            Contents = contentsData,
+            GlobalID = npcId,
+            LastSegment = 0
+        };
+        SendToSocket(auctionHouseContentsMsg);
     }
 
     private void ConfirmBuyFromAuctionHouse(ulong templateId, uint key) {
@@ -190,11 +197,7 @@ internal class AuctionHouseService(SessionActor sessionActor) : MessageService(s
         }
 
         // Inform of update.
-        if (!_serializer.Serialize(entry, 1, out var houseEntryData)) {
-            Logger.Error("Failed to serialize auction house entry.");
-
-            return;
-        }
+        var houseEntryData = WriteAuctionBlob(0, [entry]);
         var auctionUpdateMsg = new GAME_5_PROTOCOL.MSG_AUCTIONHOUSEUPDATE {
             UpdateInfo = houseEntryData,
             CharacterID = wizard.CharId
@@ -288,7 +291,7 @@ internal class AuctionHouseService(SessionActor sessionActor) : MessageService(s
         if (entry is null) {
             entry = new AuctionHouseEntry {
                 m_templateID = (GID) item.m_templateID,
-                m_buyPrice = (int) template.m_baseCost * 2, // Bazaar sells items at 200% of their value.
+                m_buyPrice = (int)(template.m_baseCost * 2), // Bazaar sells items at 200% of their value.
                 m_numForSale = 1,
                 m_sellPrice = gold
             };
@@ -305,11 +308,7 @@ internal class AuctionHouseService(SessionActor sessionActor) : MessageService(s
         var removedItemSuccess = wizard.RemoveItemFromInventory(itemGlobalId);
 
         // Inform of update.
-        if (!_serializer.Serialize(entry, 1, out var houseEntryData)) {
-            Logger.Error("Failed to serialize auction house entry.");
-
-            return;
-        }
+        var houseEntryData = WriteAuctionBlob(0, [entry]);
         var auctionUpdateMsg = new GAME_5_PROTOCOL.MSG_AUCTIONHOUSEUPDATE {
             UpdateInfo = houseEntryData,
             CharacterID = wizard.CharId

--- a/src/Imlight.CoreLib/Game/Services/CantripService.cs
+++ b/src/Imlight.CoreLib/Game/Services/CantripService.cs
@@ -56,11 +56,9 @@ using Imlight.CoreLib.WizardData.Models.Player;
 
 namespace Imlight.CoreLib.Game.Services;
 
-internal class CantripService(SessionActor sessionActor) : MessageService(sessionActor), IWithTimers {
+internal class CantripService(SessionActor sessionActor) : MessageService(sessionActor) {
 
     private const int CANTRIP_CAST_TIME = 3;
-
-    public ITimerScheduler Timers { get; set; }
 
     private readonly TimeSpan _cantripCastTimeSpan = TimeSpan.FromSeconds(CANTRIP_CAST_TIME);
     private readonly CoreObjectSerializer _effectSerializer = new(

--- a/src/Imlight.CoreLib/Game/Services/CombatService.cs
+++ b/src/Imlight.CoreLib/Game/Services/CombatService.cs
@@ -56,12 +56,10 @@ using Imlight.CoreLib.WizardData.Models.Player;
 
 namespace Imlight.CoreLib.Game.Services;
 
-internal class CombatService(SessionActor sessionActor) : MessageService(sessionActor), IWithTimers {
+internal class CombatService(SessionActor sessionActor) : MessageService(sessionActor) {
 
     private const uint NO_AGGRO_EFFECT_STRINGID = 1618528611;
     private const uint NO_AGGRO_EFFECT_DURATION_IN_SECONDS = 3;
-
-    public ITimerScheduler Timers { get; set; }
 
     private readonly CoreObjectSerializer _effectSerializer = new(
         behaviors: SerializerFlags.None

--- a/src/Imlight.CoreLib/Game/Services/MoveService.cs
+++ b/src/Imlight.CoreLib/Game/Services/MoveService.cs
@@ -50,15 +50,13 @@ using Imlight.CoreLib.WizardData.Models.Player;
 
 namespace Imlight.CoreLib.Game.Services;
 
-internal class MoveService : MessageService, IWithTimers {
+internal class MoveService : MessageService {
 
     private const uint MARK_MANA_COST_LESS_THAN_50_MANA = 1;
     private const uint MARK_MANA_COST_LESS_THAN_100_MANA = 5;
     private const uint MARK_MANA_COST_ELSE = 10; 
     private const int FISH_INTERACTION_INTERVAL_IN_MILLI = 250;
     private const int MOVE_THRESHOLD_IN_MILLI = FISH_INTERACTION_INTERVAL_IN_MILLI * 2;
-
-    public ITimerScheduler Timers { get; set; }
 
     private readonly TimeSpan _fishInteractionInterval
         = TimeSpan.FromMilliseconds(FISH_INTERACTION_INTERVAL_IN_MILLI);
@@ -206,13 +204,17 @@ internal class MoveService : MessageService, IWithTimers {
 
     [MessageHandler(typeof(GAME_5_PROTOCOL.MSG_RECALL_LOCATION))]
     private void ReceiveRecallLocation(GAME_5_PROTOCOL.MSG_RECALL_LOCATION message) {
-        var wizard = GetActiveWizard();
-
         var teleportEffectsMsg = new CHARACTER_103_PROTOCOL.MSG_DOTELEPORTEFFECTS();
         TellOtherServices(teleportEffectsMsg);
 
-        // Wait 2 seconds.
-        Task.Delay(2000).Wait();
+        // Defer the actual recall by 2s so the client can play teleport effects.
+        Timers.StartSingleTimer("recall-delay", new SERVICE_101_PROTOCOL.MSG_RECALL_DELAY(),
+                                TimeSpan.FromSeconds(2));
+    }
+
+    [MessageHandler(typeof(SERVICE_101_PROTOCOL.MSG_RECALL_DELAY))]
+    private void OnRecallDelay(SERVICE_101_PROTOCOL.MSG_RECALL_DELAY _) {
+        var wizard = GetActiveWizard();
 
         // If we are in the same zone as the marked location, teleport to it.
         if (wizard.MarkedZone == wizard.Zone) {
@@ -220,7 +222,6 @@ internal class MoveService : MessageService, IWithTimers {
             var deflatedDir = CompressDirection(wizard.MarkedOrientation.Z);
 
             var serverTeleportRsp = new GAME_5_PROTOCOL.MSG_SERVERTELEPORT {
-                // Compress the location by a factor of 4 and convert to unsigned.
                 Direction = deflatedDir,
                 LocationX = (ushort) deflatedPos.X,
                 LocationY = (ushort) deflatedPos.Y,
@@ -232,7 +233,6 @@ internal class MoveService : MessageService, IWithTimers {
                 MarkType = "1"
             };
 
-            // Broadcast the server teleport.
             var broadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST() {
                 Sender = SessionActor.ActorRef,
                 Message = serverTeleportRsp,
@@ -240,14 +240,13 @@ internal class MoveService : MessageService, IWithTimers {
             };
             TellOtherServices(broadcastMsg);
 
-            // Send the recall response to the client.
             SendToSocket(recallRsp);
         }
-        // If we're not in the same zone, send a zone transfer prior to the server teleport.
         else {
             var ml = wizard.MarkedLocation;
+            // doTeleportEffects: false — effects already played during the 2s delay above.
             Teleport(
-                doTeleportEffects: true,
+                doTeleportEffects: false,
                 destinationZone: wizard.MarkedZone,
                 destinationLocation: $"{ml.X},{ml.Y},{ml.Z},{ml.Z}"
             );

--- a/src/Imlight.CoreLib/Game/Services/PetService.cs
+++ b/src/Imlight.CoreLib/Game/Services/PetService.cs
@@ -53,14 +53,12 @@ using Imlight.CoreLib.WizardData.Models.Player;
 
 namespace Imlight.CoreLib.Game.Services;
 
-internal class PetService(SessionActor sessionActor) : MessageService(sessionActor), IWithTimers {
+internal class PetService(SessionActor sessionActor) : MessageService(sessionActor) {
 
     private static readonly int s_petEnergyTickIntervalInSeconds 
         = ConfigurationManager.Settings["Character.PetEnergyTickInSeconds"].AsInt();
     private const int PET_ENERGY_TICK_DELAY = 2;
     private const int DEFAULT_PET_OVERALL_RATING = 30;
-
-    public ITimerScheduler Timers { get; set; }
 
     protected static Props Props(SessionActor parentActor)
         => Akka.Actor.Props.Create(() => new PetService(parentActor));

--- a/src/Imlight.CoreLib/Game/Services/ShopService.cs
+++ b/src/Imlight.CoreLib/Game/Services/ShopService.cs
@@ -33,7 +33,7 @@
  * 
  * Created by: Jooty, Joji
  * Version: KALI 1.0
- * Last Updated: 3/18/2025
+ * Last Updated: 06/27/2026
  */
 
 using System;
@@ -179,45 +179,38 @@ internal class ShopService(SessionActor sessionActor) : MessageService(sessionAc
         var decal2 = (DyeColor) message.decal2;
         DyeMapper.ApplyAllDye(item, texture, decal, decal2);
 
-        // If the item was equipped, tell the client to re-equip it
+        // If the item is equipped, update the client's local item cache with the
+        // new colors IN PLACE using MSG_EQUIPMENTBEHAVIOR_EQUIPITEM. 
         if (isEquipped) {
-            var slotIndex = wizard.EquipmentBehavior.GetSlotOfItem(item.m_globalID);
             var slotName = ItemHelper.GetItemSlot(template).ToString();
 
-            // Unequip newly dyed item
-            var unequipMsg = new GAME_5_PROTOCOL.MSG_EQUIPITEM() {
-                ItemID = item.m_globalID,
-                SlotName = slotName,
-                IsEquip = 0
-            };
-            SendToSocket(unequipMsg);
-
-            var publicUnequipMsg = new GAME_5_PROTOCOL.MSG_EQUIPMENTBEHAVIOR_PUBLICUNEQUIPITEM() {
-                GlobalID = wizard.CharId,
-                IndexToRemove = slotIndex
-            };
-            ZoneBroadcast(publicUnequipMsg, false);
-
-            // Reequip item
-            var equipMsg = new GAME_5_PROTOCOL.MSG_EQUIPITEM() {
-                ItemID = item.m_globalID,
-                SlotName = slotName,
-                IsEquip = 1
-            };
-            SendToSocket(equipMsg);
-
-            // Serialize the public item and send it to the client.
-            var pubItem = ItemHelper.GetPublicItem(item);
-            if (!s_itemSerializer.Serialize(pubItem, 1, out var data)) {
-                Logger.Error("Failed to serialize item {0} for dyeing", 
+            // Serialize the item with new colors for the local player's cache.
+            if (!s_itemSerializer.Serialize(item, 1, out var localData)) {
+                Logger.Error("Failed to serialize dyed item {0} for local update",
                     Logger.Args(item.m_globalID));
 
                 return;
             }
 
-            ZoneBroadcast(new GAME_5_PROTOCOL.MSG_EQUIPMENTBEHAVIOR_PUBLICEQUIPITEM() {
+            SendToSocket(new GAME_5_PROTOCOL.MSG_EQUIPMENTBEHAVIOR_EQUIPITEM {
                 GlobalID = wizard.CharId,
-                SerializedInfo = data
+                SlotName = slotName,
+                IsValid = 1,
+                SerializedItem = localData
+            });
+
+            // Broadcast updated public appearance so other players see the new colors.
+            var pubItem = ItemHelper.GetPublicItem(item);
+            if (!s_itemSerializer.Serialize(pubItem, 1, out var pubData)) {
+                Logger.Error("Failed to serialize item {0} for dye broadcast",
+                    Logger.Args(item.m_globalID));
+                    
+                return;
+            }
+
+            ZoneBroadcast(new GAME_5_PROTOCOL.MSG_EQUIPMENTBEHAVIOR_PUBLICEQUIPITEM {
+                GlobalID = wizard.CharId,
+                SerializedInfo = pubData
             }, false);
         }
 

--- a/src/Imlight.CoreLib/Game/Services/SpellBookService.cs
+++ b/src/Imlight.CoreLib/Game/Services/SpellBookService.cs
@@ -173,6 +173,42 @@ internal class SpellbookService(SessionActor sessionActor) : MessageService(sess
         });
     }
 
+    [MessageHandler(typeof(WIZARD2_53_PROTOCOL.MSG_UPDATEITEMSPELLEXCLUSIONLIST))]
+    private void ReceiveUpdateItemSpellExclusionList(WIZARD2_53_PROTOCOL.MSG_UPDATEITEMSPELLEXCLUSIONLIST message) {
+        var wizard = GetActiveWizard();
+        var exclude = message.Exclude != 0;
+
+        // Resolve the spell hash (SpellID) to a template ID.
+        var spellTemplateId = SpellFactory.GetTemplateIdByHash((uint) message.SpellID);
+        if (spellTemplateId == 0) {
+            Logger.Warning("Could not resolve item spell exclusion hash {0} to a template ID.",
+                Logger.Args(message.SpellID));
+
+            SendToSocket(new WIZARD2_53_PROTOCOL.MSG_UPDATEITEMSPELLEXCLUSIONLIST {
+                SpellID = message.SpellID,
+                DeckID = message.DeckID,
+                Exclude = message.Exclude,
+                Success = 0
+            });
+
+            return;
+        }
+
+        // Update the in-memory exclusion list.
+        wizard.SpellbookBehavior.SetItemSpellExclusion(message.DeckID, spellTemplateId, exclude);
+
+        // Persist the change.
+        WizardData.Collections.WizardCollection.UpdateCharacterSpellbookBehavior(wizard);
+
+        // Echo success back to the client.
+        SendToSocket(new WIZARD2_53_PROTOCOL.MSG_UPDATEITEMSPELLEXCLUSIONLIST {
+            SpellID = message.SpellID,
+            DeckID = message.DeckID,
+            Exclude = message.Exclude,
+            Success = 1
+        });
+    }
+
     [MessageHandler(typeof(SERVICE_101_PROTOCOL.MSG_ATTACHCOMPLETE))]
     private void ReceiveAttachComplete(SERVICE_101_PROTOCOL.MSG_ATTACHCOMPLETE message) {
         var wizard = GetActiveWizard();
@@ -194,7 +230,26 @@ internal class SpellbookService(SessionActor sessionActor) : MessageService(sess
             return;
         }
 
+        // Send MSG_UPDATEITEMSPELLEXCLUSIONLIST for each excluded item spell so the
+        // client restores the X'd-out state of item cards on login.
+        foreach (var (excludedDeckId, excludedTemplateIds) in wizard.SpellbookBehavior.ExcludedItemSpellIds) {
+            foreach (var templateId in excludedTemplateIds) {
+                var spell = SpellFactory.GetSpell(templateId);
+                if (spell == null) {
+                    continue;
+                }
+
+                SendToSocket(new WIZARD2_53_PROTOCOL.MSG_UPDATEITEMSPELLEXCLUSIONLIST {
+                    SpellID = (int) spell.m_spellID,
+                    DeckID = excludedDeckId,
+                    Exclude = 1,
+                    Success = 1
+                });
+            }
+        }
+
         var spellList = deckBehavior.m_spellList;
+
         if (spellList is null) {
             return;
         }

--- a/src/Imlight.CoreLib/Game/Services/TutorialService.cs
+++ b/src/Imlight.CoreLib/Game/Services/TutorialService.cs
@@ -30,7 +30,7 @@ using Imlight.CoreLib.WizardData.Models.Player;
 
 namespace Imlight.CoreLib.Game.Services;
 
-internal sealed class TutorialService(SessionActor sessionActor) : MessageService(sessionActor), IWithTimers {
+internal sealed class TutorialService(SessionActor sessionActor) : MessageService(sessionActor) {
 
     private const string TUTORIAL_QUEST_NAME = "WC-TUT-C05-001";
     private const uint TUTORIAL_NAME_STRING_ID = 600062081;
@@ -45,8 +45,6 @@ internal sealed class TutorialService(SessionActor sessionActor) : MessageServic
         m_tutorialNameID = TUTORIAL_NAME_STRING_ID,
         m_tutorialStage = 0,
     };
-
-    public ITimerScheduler Timers { get; set; }
 
     internal static Props Props(SessionActor parentActor)
         => Akka.Actor.Props.Create(() => new TutorialService(parentActor));

--- a/src/Imlight.CoreLib/Game/Services/WizardService.cs
+++ b/src/Imlight.CoreLib/Game/Services/WizardService.cs
@@ -105,7 +105,8 @@ internal class WizardService(SessionActor sessionActor) : MessageService(session
         var magicSchool = _activeWizard.MagicSchoolBehavior.MagicSchool;
         var baseStats = MagicLevelsConfig.GetPlayerLevelInfo(magicSchool, message.NewLevel);
 
-        // Update health.
+        // Update health — heal to full and sync server state with what the client was told.
+        _activeWizard.UpdateHealth(_activeWizard.GameStats.m_baseHitpoints);
         var healthMessage = new WIZARD_12_PROTOCOL.MSG_UPDATEHEALTH() {
             CharacterID = _activeWizardGameObject.m_globalID,
             NewHealth = baseStats.m_hitpoints,
@@ -115,6 +116,7 @@ internal class WizardService(SessionActor sessionActor) : MessageService(session
         SendToSocket(healthMessage);
 
         // Update mana.
+        _activeWizard.UpdateMana(_activeWizard.GameStats.m_baseMana);
         var manaMessage = new WIZARD_12_PROTOCOL.MSG_UPDATEMANA() {
             Mana = baseStats.m_mana,
             MaxMana = baseStats.m_mana,
@@ -127,6 +129,7 @@ internal class WizardService(SessionActor sessionActor) : MessageService(session
         SendToSocket(powerPipsMessage);
 
         // Update energy.
+        _activeWizard.UpdateEnergy(baseStats.m_petEnergy);
         var petEnergyMessage = new PET_9_PROTOCOL.MSG_PETENERGYMAX() {
             MaxEnergy = baseStats.m_petEnergy
         };
@@ -156,6 +159,8 @@ internal class WizardService(SessionActor sessionActor) : MessageService(session
             var magicSchool = _activeWizard.MagicSchoolBehavior.MagicSchool;
             var baseStats = MagicLevelsConfig.GetPlayerLevelInfo(magicSchool, afterLevel);
 
+            // Heal to full and sync server state with what the client was told.
+            _activeWizard.UpdateHealth(_activeWizard.GameStats.m_baseHitpoints);
             var healthMessage = new WIZARD_12_PROTOCOL.MSG_UPDATEHEALTH() {
                 CharacterID = _activeWizardGameObject.m_globalID,
                 NewHealth = baseStats.m_hitpoints,
@@ -164,6 +169,7 @@ internal class WizardService(SessionActor sessionActor) : MessageService(session
             };
             SendToSocket(healthMessage);
 
+            _activeWizard.UpdateMana(_activeWizard.GameStats.m_baseMana);
             var manaMessage = new WIZARD_12_PROTOCOL.MSG_UPDATEMANA() {
                 Mana = baseStats.m_mana,
                 MaxMana = baseStats.m_mana,
@@ -176,6 +182,7 @@ internal class WizardService(SessionActor sessionActor) : MessageService(session
             };
             SendToSocket(powerPipsMessage);
 
+            _activeWizard.UpdateEnergy(baseStats.m_petEnergy);
             var petEnergyMessage = new PET_9_PROTOCOL.MSG_PETENERGYMAX() {
                 MaxEnergy = baseStats.m_petEnergy
             };

--- a/src/Imlight.CoreLib/Game/Services/ZoneService.cs
+++ b/src/Imlight.CoreLib/Game/Services/ZoneService.cs
@@ -365,15 +365,6 @@ internal class ZoneService(SessionActor sessionActor) : MessageService(sessionAc
         ZoneActor.Tell(message);
     }
 
-    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST))]
-    private void ReceiveZoneSupervisorBroadcast(ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST message) {
-        if (ZoneActor is null) {
-            throw new Exception("Zone Reference was null.");
-        }
-
-        ZoneActor.Tell(message);
-    }
-
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_PLAYERMOVE))]
     private void ReceiveZoneInteraction(ZONE_102_PROTOCOL.MSG_PLAYERMOVE message) {
         // This is an exception. Sometimes the MoveService interval happens as we zone transfer.

--- a/src/Imlight.CoreLib/Game/Services/ZoneService.cs
+++ b/src/Imlight.CoreLib/Game/Services/ZoneService.cs
@@ -58,7 +58,7 @@ using Imlight.CoreLib.WizardData.Collections;
 
 namespace Imlight.CoreLib.Game.Services;
 
-internal class ZoneService(SessionActor sessionActor) : MessageService(sessionActor), IWithTimers {
+internal class ZoneService(SessionActor sessionActor) : MessageService(sessionActor) {
 
     private const int ZONE_REMOVAL_WAIT_TIME_IN_SECONDS = 8;
     private const int ZONE_TRANSFER_CLEANUP_WAIT_TIME_IN_SECONDS = 1;
@@ -67,7 +67,6 @@ internal class ZoneService(SessionActor sessionActor) : MessageService(sessionAc
     private const string ENTER_ZONE_EVENT_NAME = "EnterZone";
 
     public IActorRef ZoneActor;
-    public ITimerScheduler Timers { get; set; }
 
     private readonly TimeSpan _zoneRemovalWaitTime = TimeSpan.FromSeconds(ZONE_REMOVAL_WAIT_TIME_IN_SECONDS);
     private readonly bool _randomBackflips
@@ -616,9 +615,6 @@ internal class ZoneService(SessionActor sessionActor) : MessageService(sessionAc
     }
 
     private void DoZoneTransfer() {
-        var account = GetSocketAccount();
-        var character = GetActiveWizard();
-
         // Remove the player from their current zone. We're awaiting a reply so the zone can properly clean up
         // before we continue on potentially a different thread.
         try {
@@ -636,34 +632,37 @@ internal class ZoneService(SessionActor sessionActor) : MessageService(sessionAc
         catch {
             Logger.Warning("Zone removal timeout of {0} seconds exceeded.", Logger.Args(ZONE_REMOVAL_WAIT_TIME_IN_SECONDS));
         }
-        finally {
-            // The zone has removed the player, but the client may not have had time to clean up
-            // all the zone items. We'll wait a short time here before we send zone transfer.
-            var delay = TimeSpan.FromSeconds(ZONE_TRANSFER_CLEANUP_WAIT_TIME_IN_SECONDS);
-            Task.Run(async () => await Task.Delay(delay)).Wait();
 
-            // When we send this message, the client will disconnect from the current zone and reconnect to the next.
-            // This means attach will happen again, so this is all we need to do here.
-            var serverTransfer = new GAME_5_PROTOCOL.MSG_SERVERTRANSFER() {
-                IP = character.GameServerIp,
-                TCPPort = character.GameServerPort,
-                UDPPort = character.GameServerPort,
-                UserID = account.AccountId,
-                CharID = character.CharId,
-                ZoneName = character.QueuedZoneName,
-                Location = character.QueuedZoneLocation,
-                Slot = 0,
-                SessionSlot = 0,
-                SessionID = 0,
-                TargetPlayerID = character.CharId,
-                TransitionID = 1,
-                FallbackIP = character.GameServerIp,
-                FallbackTCPPort = character.GameServerPort,
-                FallbackUDPPort = character.GameServerPort,
-                FallbackZone = character.Zone
-            };
-            SendToSocket(serverTransfer);
-        }
+        // Defer the server transfer by the cleanup wait time so the client can
+        // finish tearing down zone objects.
+        Timers.StartSingleTimer("zone-transfer-delay", new SERVICE_101_PROTOCOL.MSG_ZONETRANSFER_DELAY(),
+                                TimeSpan.FromSeconds(ZONE_TRANSFER_CLEANUP_WAIT_TIME_IN_SECONDS));
+    }
+
+    [MessageHandler(typeof(SERVICE_101_PROTOCOL.MSG_ZONETRANSFER_DELAY))]
+    private void OnZoneTransferDelay(SERVICE_101_PROTOCOL.MSG_ZONETRANSFER_DELAY _) {
+        var account = GetSocketAccount();
+        var character = GetActiveWizard();
+
+        var serverTransfer = new GAME_5_PROTOCOL.MSG_SERVERTRANSFER() {
+            IP = character.GameServerIp,
+            TCPPort = character.GameServerPort,
+            UDPPort = character.GameServerPort,
+            UserID = account.AccountId,
+            CharID = character.CharId,
+            ZoneName = character.QueuedZoneName,
+            Location = character.QueuedZoneLocation,
+            Slot = 0,
+            SessionSlot = 0,
+            SessionID = 0,
+            TargetPlayerID = character.CharId,
+            TransitionID = 1,
+            FallbackIP = character.GameServerIp,
+            FallbackTCPPort = character.GameServerPort,
+            FallbackUDPPort = character.GameServerPort,
+            FallbackZone = character.Zone
+        };
+        SendToSocket(serverTransfer);
     }
 
     private void DoTeleport(string location) {

--- a/src/Imlight.CoreLib/Game/World/GameWorld.cs
+++ b/src/Imlight.CoreLib/Game/World/GameWorld.cs
@@ -42,6 +42,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Util.Internal;
 using Imcodec.Cryptography;
@@ -209,32 +210,38 @@ public class GameWorld : ReceiveProtocolDispatcher, IWithTimers {
             return;
         }
 
-        // Ask the instance container if it has the zone loaded.
+        // Capture sender before async work — Akka Sender is context-bound.
+        var originalSender = Sender;
+
         var hasZoneMsg = new ZONE_102_PROTOCOL.MSG_INSTANCECONTAINERHASZONE {
             ZoneName = message.DestinationZone
         };
         var timeOut = TimeSpan.FromSeconds(5);
-        var response = _instanceContainers[message.OwnerCharId]
+
+        _instanceContainers[message.OwnerCharId]
             .Ask<ZONE_102_PROTOCOL.MSG_INSTANCECONTAINERHASZONERSP>(hasZoneMsg, timeOut)
-            .Result;
+            .ContinueWith(t => new ZONE_102_PROTOCOL.MSG_INSTANCECONTAINER_QUERY_RESULT {
+                OriginalSender = originalSender,
+                OriginalTransfer = message,
+                Response = t.IsFaulted || t.IsCanceled ? null : t.Result
+            })
+            .PipeTo(Self);
+    }
 
-        // If the instance container does not have the zone loaded, we need to create it.
-        if (!response.HasZone) {
-            // Create the zone loader.
+    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_INSTANCECONTAINER_QUERY_RESULT))]
+    private void ReceiveInstanceContainerQueryResult(ZONE_102_PROTOCOL.MSG_INSTANCECONTAINER_QUERY_RESULT result) {
+        var message = result.OriginalTransfer;
+
+        if (result.Response == null || !result.Response.HasZone) {
             CreateZoneLoader(message.DestinationZone);
-
-            // We want to wait until the zone is fully loaded before transferring the player.
-            _awaitingTransfers.Add(message, Sender);
-
-            // Add the owner ID to the map so we know who called for the creation of this zone.
+            _awaitingTransfers.Add(message, result.OriginalSender);
             _instanceCreationCalledByMap.Add(message.DestinationZone, message.OwnerCharId);
 
             return;
         }
-        else {
-            // If the instance container already exists, we can transfer the player immediately.
-            _instanceContainers[message.OwnerCharId].Forward(message);
-        }
+
+        // Instance container has the zone — forward the transfer to it.
+        _instanceContainers[message.OwnerCharId].Tell(message, result.OriginalSender);
     }
 
     public void HandleOtherZoneTransfer(ZONE_102_PROTOCOL.MSG_ZONETRANSFER message) {

--- a/src/Imlight.CoreLib/Game/Zone/Components/CombatCreatureAIComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/CombatCreatureAIComponent.cs
@@ -321,7 +321,6 @@ internal sealed class CombatCreatureAIComponent(ZoneEntity entity) : ZoneEntityC
     }
 
     private COMBAT_106_PROTOCOL.MSG_ACTORCOMBATMOVE DetermineDefensiveBehavior() {
-        // We want to prepare.
         var msg = new COMBAT_106_PROTOCOL.MSG_ACTORCOMBATMOVE {
             Actor = Entity.SelfRef,
             MoveType = (byte) CombatMoveType.Attack,
@@ -335,9 +334,11 @@ internal sealed class CombatCreatureAIComponent(ZoneEntity entity) : ZoneEntityC
                 Logger.Args(_currentDuelComponent.SigilId, _currentSubCircle.SlotIndex));
 
             msg.MoveType = (byte) CombatMoveType.Pass;
+            
             return msg;
         }
 
+        // Healing is the highest priority defensive action.
         if (_isHealingViable && _random.NextDouble() < _healingPercentChance) {
             var healingSpells = GetCastableHealingSpells(_roundHand.m_spellList);
             if (healingSpells.Count > 0) {
@@ -345,10 +346,21 @@ internal sealed class CombatCreatureAIComponent(ZoneEntity entity) : ZoneEntityC
             }
         }
 
+        // Check what we have available to "prepare" with.
         var buffSpells = GetCastableBuffSpells(_roundHand.m_spellList);
         var debuffSpells = GetCastableDebuffSpells(_roundHand.m_spellList);
+
+        // If we have nothing to prepare with, fall back to attacking.
+        // Otherwise damage-only creatures pass every time the aggressiveness RNG fails.
         if (buffSpells.Count == 0 && debuffSpells.Count == 0) {
-            // If we have no buff or debuff spells, we'll just pass.
+            return DetermineAggressiveBehavior();
+        }
+
+        // We have buffs or debuffs available. There's a small chance we pass anyway.
+        if (_random.NextDouble() < _preparePassChance) {
+            Logger.Debug("Duel {0} | Slot {1} | Preparing, but passing.",
+                Logger.Args(_currentDuelComponent.SigilId, _currentSubCircle.SlotIndex));
+
             msg.MoveType = (byte) CombatMoveType.Pass;
             return msg;
         }
@@ -356,12 +368,12 @@ internal sealed class CombatCreatureAIComponent(ZoneEntity entity) : ZoneEntityC
         // Flip a coin to either cast a buff or a debuff.
         var coinFlip = _random.NextDouble();
         if (coinFlip < 0.5 && buffSpells.Count > 0) {
-            // cast a buff.
+            // Cast a buff.
             var randomIdx = _random.Next(buffSpells.Count);
             var selectedSpell = buffSpells[randomIdx];
             msg.SpellSelection = (byte) _roundHand.m_spellList.IndexOf(selectedSpell);
 
-            // Are we selfish? If so, cast it on ourselves. Otherwise, cast it on a teammate.
+            // Are we selfish? If so, cast it on ourselves.
             if (_determinedSelfishThisTurn) {
                 msg.SpellTarget = (uint) _currentSubCircle.SlotIndex;
             }
@@ -372,12 +384,11 @@ internal sealed class CombatCreatureAIComponent(ZoneEntity entity) : ZoneEntityC
             }
         }
         else if (debuffSpells.Count > 0) {
-            // cast a debuff.
+            // Cast a debuff on our most hated enemy.
             var randomIdx = _random.Next(debuffSpells.Count);
             var selectedSpell = debuffSpells[randomIdx];
             msg.SpellSelection = (byte) _roundHand.m_spellList.IndexOf(selectedSpell);
 
-            // Select our most hated enemy.
             var targetIdx = GetMostHatedTarget();
             msg.SpellTarget = (byte) targetIdx;
         }

--- a/src/Imlight.CoreLib/Game/Zone/Components/CombatCreatureDeckComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/CombatCreatureDeckComponent.cs
@@ -39,6 +39,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Imcodec.IO;
 using Imcodec.ObjectProperty.TypeCache;
 using Imlight.Common;
 using Imlight.CoreLib.Game.Spells;
@@ -60,30 +61,41 @@ internal sealed class CombatCreatureDeckComponent : ZoneEntityComponent, ICompon
 
     // ctor
     public CombatCreatureDeckComponent(ZoneEntity entity) : base(entity) { 
-        var DeckBehaviorTemplate = entity.Template.m_behaviors
+        // Collect every behavior from the creature's equipment items.
+        var equipmentItemBehaviors = entity.Template.m_behaviors
             .OfType<EquipmentBehaviorTemplate>()
             .SelectMany(x => x.m_itemList)
             .Select(x => CoreObjectFactory.GetCoreTemplate(x))
-            .OfType<WizItemTemplate>()
-            .SelectMany(x => x.m_behaviors)
-            .OfType<DeckBehaviorTemplate>()
-            .FirstOrDefault();
+            .Where(x => x != null)
+            .SelectMany(x => x.m_behaviors ?? []);
 
-        if (DeckBehaviorTemplate == null) {
-            Logger.Error(
-                "{0} {1} is missing {2}",
-                Logger.Args(nameof(ZoneEntity), 
-                            entity.ActiveGameObject.m_debugName, 
-                            nameof(DeckBehaviorTemplate) 
-                )
-            );
+        // Combine equipment item behaviors with the entity's own behaviors.
+        // MobDeckBehaviorTemplate can appear in either location.
+        var allBehaviors = entity.Template.m_behaviors
+            .Concat(equipmentItemBehaviors);
 
+        // MobDeckBehaviorTemplate stores spell names directly, if it exists.
+        var mobDeck = allBehaviors.OfType<MobDeckBehaviorTemplate>().FirstOrDefault();
+        if (mobDeck != null) {
+            InitializeSpellbookFromNames(mobDeck.m_spellList);
             return;
         }
 
-        var deckName = DeckBehaviorTemplate.m_defaultDeck;
-        var creatureSpellbook = GetCreatureSpellbook(deckName);
-        InitializeSpellbook(creatureSpellbook);
+        // DeckBehaviorTemplate stores a deck name that maps to a SpiralDB spellbook.
+        var deckBehavior = allBehaviors.OfType<DeckBehaviorTemplate>().FirstOrDefault();
+        if (deckBehavior != null) {
+            var creatureSpellbook = GetCreatureSpellbook(deckBehavior.m_defaultDeck);
+            InitializeSpellbook(creatureSpellbook);
+            return;
+        }
+
+        // Neither deck type found — fall back to the default spellbook so the
+        // creature can at least cast basic spells instead of passing all the time.
+        Logger.Warning(
+            "{0} {1} has no deck behavior — falling back to default spellbook.",
+            Logger.Args(nameof(ZoneEntity), entity.ActiveGameObject.m_debugName)
+        );
+        InitializeSpellbook(GetCreatureSpellbook(null));
     }
 
     private void InitializeSpellbook(CreatureSpellbook spellbook) {
@@ -109,6 +121,30 @@ internal sealed class CombatCreatureDeckComponent : ZoneEntityComponent, ICompon
                 m_quantity = 9999,
             };
             Spells.Add(spellData);
+        }
+    }
+
+    private void InitializeSpellbookFromNames(List<ByteString> spellNames) {
+        foreach (var spellName in spellNames) {
+            if (spellName.ToString().Length == 0) {
+                continue;
+            }
+
+            var spell = SpellFactory.GetSpell(spellName.ToString());
+            if (spell == null) {
+                Logger.Error(
+                    "{0} {1} has unknown spell \"{2}\" in MobDeckBehaviorTemplate.",
+                    Logger.Args(nameof(ZoneEntity),
+                                Entity.ActiveGameObject.m_debugName,
+                                spellName)
+                );
+                continue;
+            }
+
+            Spells.Add(new SpellData {
+                m_templateID = spell.m_templateID,
+                m_quantity = 9999,
+            });
         }
     }
 

--- a/src/Imlight.CoreLib/Game/Zone/Components/InteractServiceMementoComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/InteractServiceMementoComponent.cs
@@ -39,6 +39,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Imcodec.MessageLayer.Generated;
 using Imcodec.ObjectProperty;
@@ -191,19 +192,42 @@ internal sealed class InteractServiceMementoComponent(ZoneEntity entity)
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_WIZBANGUPDATEINTERVAL))]
     private void HandleWizBangUpdateInterval(ZONE_102_PROTOCOL.MSG_WIZBANGUPDATEINTERVAL message) {
-        if (_serviceComponents.Count <= 0) {
+        if (_serviceComponents.Count <= 0 || _playersInRenderRange.Count == 0) {
             return;
         }
 
-        // Update wizbangs for all players in render range.
-        foreach (var playerActor in _playersInRenderRange.Values.ToList()) {
-            var queryCharacterMsg = new CHARACTER_103_PROTOCOL.MSG_QUERYACTIVEWIZARD();
-            var wizard = playerActor
-                .Ask<CHARACTER_103_PROTOCOL.MSG_CHARACTER>(queryCharacterMsg)
-                .Result
-                .Wizard;
+        // Query every nearby player's wizard concurrently instead of
+        // blocking on each one sequentially.
+        var playerActors = _playersInRenderRange.Values.ToArray();
+        var queryTasks = playerActors.Select(async playerActor => {
+            try {
+                var msg = new CHARACTER_103_PROTOCOL.MSG_QUERYACTIVEWIZARD();
+                var rsp = await playerActor.Ask<CHARACTER_103_PROTOCOL.MSG_CHARACTER>(msg);
+                return rsp.Wizard;
+            }
+            catch {
+                return null;
+            }
+        });
 
-            SendWizBang(playerActor, wizard);
+        Task.WhenAll(queryTasks)
+            .ContinueWith(t => {
+                var wizards = t.Result.ToArray();
+                return new ZONE_102_PROTOCOL.MSG_WIZBANG_UPDATE_RESULT {
+                    PlayerActors = playerActors,
+                    Wizards = wizards
+                };
+            })
+            .PipeTo(Self);
+    }
+
+    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_WIZBANG_UPDATE_RESULT))]
+    private void HandleWizBangUpdateResult(ZONE_102_PROTOCOL.MSG_WIZBANG_UPDATE_RESULT result) {
+        for (int i = 0; i < result.PlayerActors.Length; i++) {
+            var wizard = result.Wizards[i];
+            if (wizard != null) {
+                SendWizBang(result.PlayerActors[i], wizard);
+            }
         }
     }
 

--- a/src/Imlight.CoreLib/Game/Zone/Components/PathMovementComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/PathMovementComponent.cs
@@ -279,7 +279,8 @@ internal sealed class PathMovementComponent(ZoneEntity entity) : ZoneEntityCompo
             NewState = 0
         };
         var movestateMsgBroadcast = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
-            Message = movestateMsg
+            Message = movestateMsg,
+            Targets = ZoneBroadcastTarget.Players,
         };
         Entity.ZoneRef.Tell(movestateMsgBroadcast);
 
@@ -293,7 +294,8 @@ internal sealed class PathMovementComponent(ZoneEntity entity) : ZoneEntityCompo
             MobileID = Entity.MobileID
         };
         var movementMsgBroadcast = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
-            Message = movementMsg
+            Message = movementMsg,
+            Targets = ZoneBroadcastTarget.Players,
         };
         Entity.ZoneRef.Tell(movementMsgBroadcast);
     }

--- a/src/Imlight.CoreLib/Game/Zone/Components/WorldTeleportDoorComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/WorldTeleportDoorComponent.cs
@@ -95,6 +95,7 @@ internal sealed class WorldTeleportDoorComponent(ZoneEntity entity) : ZoneEntity
 
         // Serialize the teleport door options and send it to the player.
         var serializer = new ObjectSerializer(
+            Versionable: false,
             Behaviors: SerializerFlags.None
         );
         if (!serializer.Serialize(teleportDoorOptions, 4, out var data)) {

--- a/src/Imlight.CoreLib/Game/Zone/Core/Zone.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Core/Zone.cs
@@ -96,6 +96,8 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
     private readonly List<IActorRef> _supervisors = [];
     private IActorRef _sigilSupervisor;
     private IActorRef _playerSupervisor;
+    private IActorRef _objectSupervisor;
+    private IActorRef _volumeSupervisor;
     private readonly Stopwatch _zoneLoadTimer;
     private readonly Dictionary<IActorRef, IServerMessage> _pendingPlayerEvents = [];
     private readonly List<ushort> _mobileIdMap = [];
@@ -114,8 +116,10 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
         this._isLoading = true;
         this._zoneLoadTimer = new Stopwatch();
 
-        _supervisors.Add(CreateSupervisor<ZoneObjectSupervisor>());
-        _supervisors.Add(CreateSupervisor<ZoneVolumeSupervisor>());
+        _objectSupervisor = CreateSupervisor<ZoneObjectSupervisor>();
+        _supervisors.Add(_objectSupervisor);
+        _volumeSupervisor = CreateSupervisor<ZoneVolumeSupervisor>();
+        _supervisors.Add(_volumeSupervisor);
         _supervisors.Add(CreateSupervisor<ZoneTriggerSupervisor>());
         _playerSupervisor = CreateSupervisor<ZonePlayerSupervisor>();
         _supervisors.Add(_playerSupervisor);
@@ -223,7 +227,13 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
             return;
         }
 
-        InformZoneSupervisors(message.PlayerActor, message);
+        var broadcast = new ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST {
+            Sender = message.PlayerActor,
+            Messages = [message]
+        };
+        _objectSupervisor.Forward(broadcast);
+        _volumeSupervisor.Forward(broadcast);
+        _sigilSupervisor.Forward(broadcast);
     }
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_CREATUREMOVE))]

--- a/src/Imlight.CoreLib/Game/Zone/Core/Zone.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Core/Zone.cs
@@ -93,6 +93,7 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
     private readonly uint _dynamicZoneId;
     private readonly Lock _mobileIdLock = new();
     private readonly List<IActorRef> _supervisors = [];
+    private IActorRef _sigilSupervisor;
     private readonly Stopwatch _zoneLoadTimer;
     private readonly Dictionary<IActorRef, IServerMessage> _pendingPlayerEvents = [];
     private readonly List<ushort> _mobileIdMap = [];
@@ -116,7 +117,8 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
         _supervisors.Add(CreateSupervisor<ZoneTriggerSupervisor>());
         _supervisors.Add(CreateSupervisor<ZonePlayerSupervisor>());
         _supervisors.Add(CreateSupervisor<ZonePathSupervisor>());
-        _supervisors.Add(CreateSupervisor<ZoneSigilSupervisor>());
+        _sigilSupervisor = CreateSupervisor<ZoneSigilSupervisor>();
+        _supervisors.Add(_sigilSupervisor);
         
         _zoneLoadTimer.Restart();
         _isLoading = true;
@@ -228,7 +230,11 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
             return;
         }
 
-        InformZoneSupervisors(message.CreatureActor, message);
+        var broadcast = new ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST {
+            Sender = message.CreatureActor,
+            Messages = [message]
+        };
+        _sigilSupervisor.Forward(broadcast);
     }
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONELOADRESULTS))]

--- a/src/Imlight.CoreLib/Game/Zone/Core/Zone.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Core/Zone.cs
@@ -98,6 +98,8 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
     private readonly IActorRef _playerSupervisor;
     private readonly IActorRef _objectSupervisor;
     private readonly IActorRef _volumeSupervisor;
+    private readonly IActorRef _triggerSupervisor;
+    private readonly IActorRef _pathSupervisor;
     private readonly Stopwatch _zoneLoadTimer;
     private readonly Dictionary<IActorRef, IServerMessage> _pendingPlayerEvents = [];
     private readonly List<ushort> _mobileIdMap = [];
@@ -121,10 +123,12 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
         _supervisors.Add(_objectSupervisor);
         _volumeSupervisor = CreateSupervisor<ZoneVolumeSupervisor>();
         _supervisors.Add(_volumeSupervisor);
-        _supervisors.Add(CreateSupervisor<ZoneTriggerSupervisor>());
+        _triggerSupervisor = CreateSupervisor<ZoneTriggerSupervisor>();
+        _supervisors.Add(_triggerSupervisor);
         _playerSupervisor = CreateSupervisor<ZonePlayerSupervisor>();
         _supervisors.Add(_playerSupervisor);
-        _supervisors.Add(CreateSupervisor<ZonePathSupervisor>());
+        _pathSupervisor = CreateSupervisor<ZonePathSupervisor>();
+        _supervisors.Add(_pathSupervisor);
         _sigilSupervisor = CreateSupervisor<ZoneSigilSupervisor>();
         _supervisors.Add(_sigilSupervisor);
         
@@ -233,13 +237,13 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
             return;
         }
 
-        var broadcast = new ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST {
+        DispatchBroadcast(new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
             Sender = message.PlayerActor,
-            Messages = [message]
-        };
-        _objectSupervisor.Forward(broadcast);
-        _volumeSupervisor.Forward(broadcast);
-        _sigilSupervisor.Forward(broadcast);
+            Messages = [message],
+            Targets = ZoneBroadcastTarget.Objects
+                    | ZoneBroadcastTarget.Volumes
+                    | ZoneBroadcastTarget.Sigils,
+        });
     }
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_CREATUREMOVE))]
@@ -254,11 +258,11 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
             return;
         }
 
-        var broadcast = new ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST {
+        DispatchBroadcast(new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
             Sender = message.CreatureActor,
-            Messages = [message]
-        };
-        _sigilSupervisor.Forward(broadcast);
+            Messages = [message],
+            Targets = ZoneBroadcastTarget.Sigils,
+        });
     }
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONELOADRESULTS))]
@@ -347,28 +351,25 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST))]
     private void ReceiveZoneBroadcast(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST message) {
-        // MSG_SERVERMOVE and MSG_MOVESTATE are client-render messages —
-        // when the zone is empty there is nobody to see them.
-        if (message.Message is GAME_5_PROTOCOL.MSG_SERVERMOVE
-                            or GAME_5_PROTOCOL.MSG_MOVESTATE) {
-            if (_playerCount > 0) {
-                _playerSupervisor.Forward(message);
-            }
-            return;
-        }
-
-        _supervisors.ForEach(supervisor => supervisor.Forward(message));
+        DispatchBroadcast(message);
     }
-
-    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST))]
-    private void ReceiveZoneSupervisorBroadcast(ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST message) 
-        => _supervisors.ForEach(supervisor => supervisor.Forward(message));
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_REQUESTCOMBATSIGIL))]
     private void ReceiveRequestCombatSigil(ZONE_102_PROTOCOL.MSG_REQUESTCOMBATSIGIL message)
         => _supervisors.ForEach(supervisor => supervisor.Forward(message));
 
     #endregion
+
+    private void DispatchBroadcast(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST message) {
+        if ((message.Targets & ZoneBroadcastTarget.Players) != 0) {
+            if (_playerCount > 0) _playerSupervisor.Forward(message);
+        }
+        if ((message.Targets & ZoneBroadcastTarget.Objects)  != 0) _objectSupervisor.Forward(message);
+        if ((message.Targets & ZoneBroadcastTarget.Volumes)  != 0) _volumeSupervisor.Forward(message);
+        if ((message.Targets & ZoneBroadcastTarget.Triggers) != 0) _triggerSupervisor.Forward(message);
+        if ((message.Targets & ZoneBroadcastTarget.Paths)    != 0) _pathSupervisor.Forward(message);
+        if ((message.Targets & ZoneBroadcastTarget.Sigils)   != 0) _sigilSupervisor.Forward(message);
+    }
 
     private IActorRef CreateSupervisor<T>() where T : ActorBase {
         var props = Akka.Actor.Props.Create(() => (T) Activator.CreateInstance(typeof(T), this));
@@ -377,14 +378,11 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
     }
 
     private void InformZoneSupervisors(IActorRef player, IServerMessage message) {
-        var broadcast = new ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST {
+        DispatchBroadcast(new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
             Sender = player,
-            Messages = [message]
-        };
-
-        foreach (var supervisor in _supervisors) {
-            supervisor.Forward(broadcast);
-        }
+            Messages = [message],
+            Targets = ZoneBroadcastTarget.All,
+        });
     }
 
     private Vector4 GetLocationFromString(ByteString location) {

--- a/src/Imlight.CoreLib/Game/Zone/Core/Zone.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Core/Zone.cs
@@ -94,16 +94,17 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
     private readonly uint _dynamicZoneId;
     private readonly Lock _mobileIdLock = new();
     private readonly List<IActorRef> _supervisors = [];
-    private IActorRef _sigilSupervisor;
-    private IActorRef _playerSupervisor;
-    private IActorRef _objectSupervisor;
-    private IActorRef _volumeSupervisor;
+    private readonly IActorRef _sigilSupervisor;
+    private readonly IActorRef _playerSupervisor;
+    private readonly IActorRef _objectSupervisor;
+    private readonly IActorRef _volumeSupervisor;
     private readonly Stopwatch _zoneLoadTimer;
     private readonly Dictionary<IActorRef, IServerMessage> _pendingPlayerEvents = [];
     private readonly List<ushort> _mobileIdMap = [];
     private readonly Dictionary<IActorRef, bool> _supervisorLoadResults = [];
     private readonly HashSet<GID> _criticalObjectIds = [];
     private bool _isLoading;
+    private int _playerCount;
 
     /// <summary>
     /// Creates a new zone from the path of the zone, formatted as it would be in the access pass.
@@ -193,6 +194,7 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
             return;
         }
 
+        _playerCount++;
         InformZoneSupervisors(message.PlayerActor, message);
         
         // Send response to confirm player was added
@@ -208,6 +210,10 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
             _pendingPlayerEvents.Remove(message.PlayerActor);
 
             return;
+        }
+
+        if (_playerCount > 0) {
+            _playerCount--;
         }
 
         InformZoneSupervisors(message.PlayerActor, message);
@@ -238,6 +244,11 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_CREATUREMOVE))]
     protected virtual void ReceiveCreatureMove(ZONE_102_PROTOCOL.MSG_CREATUREMOVE message) {
+        // Nobody to interact with — drop early.
+        if (_playerCount <= 0) {
+            return;
+        }
+
         // If the actor is not a part of this zone, do not bother processing.
         if (!_mobileIdMap.Contains(message.CreatureObject.m_nMobileID)) {
             return;
@@ -336,11 +347,13 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST))]
     private void ReceiveZoneBroadcast(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST message) {
-        // MSG_SERVERMOVE and MSG_MOVESTATE are client-render messages.
+        // MSG_SERVERMOVE and MSG_MOVESTATE are client-render messages —
+        // when the zone is empty there is nobody to see them.
         if (message.Message is GAME_5_PROTOCOL.MSG_SERVERMOVE
                             or GAME_5_PROTOCOL.MSG_MOVESTATE) {
-            _playerSupervisor.Forward(message);
-
+            if (_playerCount > 0) {
+                _playerSupervisor.Forward(message);
+            }
             return;
         }
 
@@ -425,6 +438,7 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
                 ProcessZoneTransfer(transfer, playerActor);
             }
             else if (pendingEvent is ZONE_102_PROTOCOL.MSG_ADDPLAYER addPlayer) {
+                _playerCount++;
                 InformZoneSupervisors(playerActor, addPlayer);
                 
                 // Send response to confirm player was added

--- a/src/Imlight.CoreLib/Game/Zone/Core/Zone.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Core/Zone.cs
@@ -46,6 +46,7 @@ using System.Threading;
 using Akka.Actor;
 using Imcodec.IO;
 using Imcodec.Math;
+using Imcodec.MessageLayer.Generated;
 using Imcodec.ObjectProperty.TypeCache;
 using Imcodec.Types;
 using Imlight.Common;
@@ -94,6 +95,7 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
     private readonly Lock _mobileIdLock = new();
     private readonly List<IActorRef> _supervisors = [];
     private IActorRef _sigilSupervisor;
+    private IActorRef _playerSupervisor;
     private readonly Stopwatch _zoneLoadTimer;
     private readonly Dictionary<IActorRef, IServerMessage> _pendingPlayerEvents = [];
     private readonly List<ushort> _mobileIdMap = [];
@@ -115,7 +117,8 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
         _supervisors.Add(CreateSupervisor<ZoneObjectSupervisor>());
         _supervisors.Add(CreateSupervisor<ZoneVolumeSupervisor>());
         _supervisors.Add(CreateSupervisor<ZoneTriggerSupervisor>());
-        _supervisors.Add(CreateSupervisor<ZonePlayerSupervisor>());
+        _playerSupervisor = CreateSupervisor<ZonePlayerSupervisor>();
+        _supervisors.Add(_playerSupervisor);
         _supervisors.Add(CreateSupervisor<ZonePathSupervisor>());
         _sigilSupervisor = CreateSupervisor<ZoneSigilSupervisor>();
         _supervisors.Add(_sigilSupervisor);
@@ -322,8 +325,17 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
     }
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST))]
-    private void ReceiveZoneBroadcast(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST message) 
-        => _supervisors.ForEach(supervisor => supervisor.Forward(message));
+    private void ReceiveZoneBroadcast(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST message) {
+        // MSG_SERVERMOVE and MSG_MOVESTATE are client-render messages.
+        if (message.Message is GAME_5_PROTOCOL.MSG_SERVERMOVE
+                            or GAME_5_PROTOCOL.MSG_MOVESTATE) {
+            _playerSupervisor.Forward(message);
+
+            return;
+        }
+
+        _supervisors.ForEach(supervisor => supervisor.Forward(message));
+    }
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST))]
     private void ReceiveZoneSupervisorBroadcast(ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST message) 

--- a/src/Imlight.CoreLib/Game/Zone/Core/Zone.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Core/Zone.cs
@@ -35,7 +35,7 @@
  * 
  * Created by: Jooty
  * Version: KALI 1.0
- * Last Updated: 3/18/2025
+ * Last Updated: 06/28/2026
  */
 
 using System;
@@ -107,6 +107,8 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
     private readonly HashSet<GID> _criticalObjectIds = [];
     private bool _isLoading;
     private int _playerCount;
+    private readonly List<ZONE_102_PROTOCOL.MSG_PLAYERMOVE> _pendingPlayerMoves = [];
+    private readonly List<ZONE_102_PROTOCOL.MSG_CREATUREMOVE> _pendingCreatureMoves = [];
 
     /// <summary>
     /// Creates a new zone from the path of the zone, formatted as it would be in the access pass.
@@ -131,7 +133,10 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
         _supervisors.Add(_pathSupervisor);
         _sigilSupervisor = CreateSupervisor<ZoneSigilSupervisor>();
         _supervisors.Add(_sigilSupervisor);
-        
+
+        Timers.StartPeriodicTimer("flush-moves", new ZONE_102_PROTOCOL.MSG_FLUSHMOVES(),
+            TimeSpan.FromMilliseconds(250), TimeSpan.FromMilliseconds(250));
+
         _zoneLoadTimer.Restart();
         _isLoading = true;
 
@@ -140,7 +145,8 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
 
     // Props
     public static Props Props(string zonePath, uint dynamicZoneId)
-        => Akka.Actor.Props.Create(() => new Zone(zonePath, dynamicZoneId));
+        => Akka.Actor.Props.Create(() => new Zone(zonePath, dynamicZoneId))
+            .WithMailbox("zone-priority");
 
     protected override void PreRestart(Exception reason, object message) {
         Logger.Error("Zone {ZoneName} restarts for: {Exception}", Logger.Args(ZoneName, reason));
@@ -228,41 +234,50 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
     protected virtual void ReceivePlayerMove(ZONE_102_PROTOCOL.MSG_PLAYERMOVE message) {
         if (_isLoading) {
             _pendingPlayerEvents[message.PlayerActor] = message;
-
             return;
         }
 
-        // If the actor is not a part of this zone, do not bother processing.
         if (!_mobileIdMap.Contains(message.PlayerObject.m_nMobileID)) {
             return;
         }
 
-        DispatchBroadcast(new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
-            Sender = message.PlayerActor,
-            Messages = [message],
-            Targets = ZoneBroadcastTarget.Objects
-                    | ZoneBroadcastTarget.Volumes
-                    | ZoneBroadcastTarget.Sigils,
-        });
+        _pendingPlayerMoves.Add(message);
     }
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_CREATUREMOVE))]
     protected virtual void ReceiveCreatureMove(ZONE_102_PROTOCOL.MSG_CREATUREMOVE message) {
-        // Nobody to interact with — drop early.
         if (_playerCount <= 0) {
             return;
         }
 
-        // If the actor is not a part of this zone, do not bother processing.
         if (!_mobileIdMap.Contains(message.CreatureObject.m_nMobileID)) {
             return;
         }
 
-        DispatchBroadcast(new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
-            Sender = message.CreatureActor,
-            Messages = [message],
-            Targets = ZoneBroadcastTarget.Sigils,
-        });
+        _pendingCreatureMoves.Add(message);
+    }
+
+    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_FLUSHMOVES))]
+    private void ReceiveFlushMoves(ZONE_102_PROTOCOL.MSG_FLUSHMOVES _) {
+        if (_pendingPlayerMoves.Count > 0) {
+            var moves = _pendingPlayerMoves.ToArray();
+            _pendingPlayerMoves.Clear();
+            DispatchBroadcast(new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
+                Messages = moves,
+                Targets = ZoneBroadcastTarget.Objects
+                        | ZoneBroadcastTarget.Volumes
+                        | ZoneBroadcastTarget.Sigils,
+            });
+        }
+
+        if (_pendingCreatureMoves.Count > 0) {
+            var moves = _pendingCreatureMoves.ToArray();
+            _pendingCreatureMoves.Clear();
+            DispatchBroadcast(new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
+                Messages = moves,
+                Targets = ZoneBroadcastTarget.Sigils,
+            });
+        }
     }
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONELOADRESULTS))]

--- a/src/Imlight.CoreLib/Game/Zone/Core/ZoneEntityComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Core/ZoneEntityComponent.cs
@@ -251,8 +251,10 @@ public abstract class ZoneEntityComponent(ZoneEntity entity) : ReceiveProtocolDi
     /// </summary>
     /// <param name="message">The message to broadcast.</param>
     protected void PlayerBroadcast(IMessage message) {
-        // Wrap the message in a zone broadcast message.
-        var broadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST { Message = message };
+        var broadcastMsg = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
+            Message = message,
+            Targets = ZoneBroadcastTarget.Players,
+        };
         ZoneActor.Tell(broadcastMsg);
     }
 

--- a/src/Imlight.CoreLib/Game/Zone/Supervisors/ZoneEntitySupervisor.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Supervisors/ZoneEntitySupervisor.cs
@@ -45,19 +45,6 @@ internal abstract class ZoneEntitySupervisor(Core.Zone zone) : ReceiveProtocolDi
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONELOADRESULTS))]
     public abstract void ReceiveZoneLoadResults(ZONE_102_PROTOCOL.MSG_ZONELOADRESULTS message);
 
-    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST))]
-    public virtual void ReceiveZoneSupervisorBroadcast(ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST message) {
-        foreach (var entity in EntityActors) {
-            if (entity is null) {
-                continue;
-            }
-
-            foreach (var internalMessage in message.Messages) {
-                entity.Forward(internalMessage);
-            }
-        }
-    }
-
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_QUERYZONEENTITY))]
     public virtual void ReceiveQueryEntityObject(ZONE_102_PROTOCOL.MSG_QUERYZONEENTITY message) {
         foreach (var entity in EntityActors) {
@@ -81,15 +68,28 @@ internal abstract class ZoneEntitySupervisor(Core.Zone zone) : ReceiveProtocolDi
     }
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST))]
-    public virtual void ReceiveZonePlayerBroadcast(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST message) {
+    public virtual void ReceiveZoneBroadcast(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST message) {
         foreach (var entity in EntityActors) {
-            if (   message.Selfless 
-                && message.Sender is not null 
-                && entity.Path.Name == message.Sender.Path.Name) {
+            if (entity is null) {
                 continue;
             }
 
-            entity.Forward(message.Message);
+            // Client-visible payload — forward to entities, respecting Selfless.
+            if (message.Message is not null) {
+                if (message.Selfless
+                    && message.Sender is not null
+                    && entity.Path.Name == message.Sender.Path.Name) {
+                    continue;
+                }
+                entity.Forward(message.Message);
+            }
+
+            // Server-internal payload — forward each message to entities.
+            if (message.Messages is not null) {
+                foreach (var internalMessage in message.Messages) {
+                    entity.Forward(internalMessage);
+                }
+            }
         }
     }
 

--- a/src/Imlight.CoreLib/Game/Zone/Supervisors/ZonePlayerSupervisor.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Supervisors/ZonePlayerSupervisor.cs
@@ -61,19 +61,22 @@ internal sealed class ZonePlayerSupervisor(Core.Zone zone) : ZoneEntitySuperviso
         }
     }
 
-    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST))]
-    public override void ReceiveZoneSupervisorBroadcast(ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST message) {
-        foreach (var internalMessage in message.Messages) {
-            // Check if this is the add player or remove player message.
-            switch (internalMessage) {
-                case ZONE_102_PROTOCOL.MSG_ADDPLAYER addPlayer:
-                    HandleAddPlayer(addPlayer);
-                    return;
-                case ZONE_102_PROTOCOL.MSG_REMOVEPLAYER removePlayer:
-                    HandleRemovePlayer(removePlayer);
-                    return;
+    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST))]
+    public override void ReceiveZoneBroadcast(ZONE_102_PROTOCOL.MSG_ZONEBROADCAST message) {
+        if (message.Messages is not null) {
+            foreach (var internalMessage in message.Messages) {
+                switch (internalMessage) {
+                    case ZONE_102_PROTOCOL.MSG_ADDPLAYER addPlayer:
+                        HandleAddPlayer(addPlayer);
+                        return;
+                    case ZONE_102_PROTOCOL.MSG_REMOVEPLAYER removePlayer:
+                        HandleRemovePlayer(removePlayer);
+                        return;
+                }
             }
         }
+
+        base.ReceiveZoneBroadcast(message);
     }
 
     // If this handler was left to the base class, it would cause a stack overflow.

--- a/src/Imlight.CoreLib/Game/Zone/Supervisors/ZoneSigilSupervisor.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Supervisors/ZoneSigilSupervisor.cs
@@ -51,7 +51,7 @@ internal sealed class ZoneSigilSupervisor(Core.Zone zone) : ZoneEntitySupervisor
 
             // Sometimes the sigil may spawn in the ground.
             var newLoc = coreObject.m_location;
-            newLoc.Y += 1.5f;
+            newLoc.Z += 5;
             coreObject.m_location = newLoc;
 
             // Create the sigil actor and inform it of the details.

--- a/src/Imlight.CoreLib/Imlight.CoreLib.csproj
+++ b/src/Imlight.CoreLib/Imlight.CoreLib.csproj
@@ -8,8 +8,8 @@
         <PackageReference Include="Akka" Version="1.5.33" />
         <PackageReference Include="Akka.Remote" Version="1.5.33" />
         <PackageReference Include="LiteDB" Version="5.0.16" />
-        <PackageReference Include="RavenDB.Client" Version="6.2.2" />
-        <PackageReference Include="RavenDB.Embedded" Version="6.2.2" />
+        <PackageReference Include="RavenDB.Client" Version="7.2.4" />
+        <PackageReference Include="RavenDB.Embedded" Version="7.2.4" />
         <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
         <PackageReference Include="Ionic.Zlib.Core" Version="1.0.0" />

--- a/src/Imlight.CoreLib/Imlight.CoreLib.csproj
+++ b/src/Imlight.CoreLib/Imlight.CoreLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Imlight.CoreLib/Login/GameServerPool.cs
+++ b/src/Imlight.CoreLib/Login/GameServerPool.cs
@@ -35,12 +35,13 @@
  * 
  * Created by: Jooty
  * Version: KALI 1.0
- * Last Updated: 3/18/2025
+ * Last Updated: 06/27/2026
  */
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.Shared.Packets;
@@ -100,67 +101,88 @@ internal class GameServerPool : ReceiveProtocolDispatcher {
 
     [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_GETBESTSERVER))]
     private void ReceiveQueryGameServer(SERVER_100_PROTOCOL.MSG_GETBESTSERVER message) {
-        // Iterate through the game servers we have registered and query them to check if they're still active.
-        var gameServerInfos = new List<SERVER_100_PROTOCOL.MSG_SERVERINFO>();
-        foreach (var gameServer in _gameServers.Values) {
+        // Capture the sender before any async work.
+        var originalSender = Sender;
+
+        var queryTasks = _gameServers.Values.Select(async gameServer => {
             try {
                 var msg = new SERVER_100_PROTOCOL.MSG_QUERYSERVER();
                 var timeout = TimeSpan.FromSeconds(_gameServerQueryTimeout);
-                var rsp = gameServer.Ask<SERVER_100_PROTOCOL.MSG_SERVERINFO>(msg, timeout).Result;
-                gameServerInfos.Add(rsp);
+                return await gameServer.Ask<SERVER_100_PROTOCOL.MSG_SERVERINFO>(msg, timeout);
             }
             catch {
                 // The server did not respond in time, so we'll just ignore it.
                 Logger.Error("Failed to query game server {Name}.", Logger.Args(gameServer.Path.Name));
-
-                continue;
+                return null;
             }
-        }
+        });
 
-        if (gameServerInfos.Count <= 0) {
-            throw new Exception("No game servers were available to query.");
+        // Aggregate results and pipe back to self for final processing.
+        Task.WhenAll(queryTasks)
+            .ContinueWith(t => new SERVER_100_PROTOCOL.MSG_QUERYGAMESERVER_AGGREGATE {
+                OriginalSender = originalSender,
+                ServerInfos = t.Result.Where(r => r != null).ToArray()
+            })
+            .PipeTo(Self);
+    }
+
+    [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_QUERYGAMESERVER_AGGREGATE))]
+    private void ReceiveQueryGameServerAggregate(SERVER_100_PROTOCOL.MSG_QUERYGAMESERVER_AGGREGATE result) {
+        var gameServerInfos = result.ServerInfos;
+
+        if (gameServerInfos.Length <= 0) {
+            Logger.Error("No game servers were available to query.");
+            return;
         }
 
         // Sort the servers by player count in descending order
-        gameServerInfos.Sort((s1, s2) => s2.PlayerCount.CompareTo(s1.PlayerCount));
+        Array.Sort(gameServerInfos, (s1, s2) => s2.PlayerCount.CompareTo(s1.PlayerCount));
 
         // Find the first non-full server or choose a random one if all servers are full
         var chosenServer = gameServerInfos
                                .FirstOrDefault(server => server.PlayerCount < _gameServerPlayerCount)
-                           ?? gameServerInfos[new Random().Next(0, gameServerInfos.Count)];
+                           ?? gameServerInfos[new Random().Next(0, gameServerInfos.Length)];
 
-        // Send the chosen server details back to the session actor
-        Sender.Tell(chosenServer);
+        // Send the chosen server details back to the original requester
+        result.OriginalSender.Tell(chosenServer);
     }
 
     [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_FINDPLAYER))]
     private void ReceiveFindPlayer(SERVER_100_PROTOCOL.MSG_FINDPLAYER message) {
-        var gameServers = _gameServers.Values
-            .Select(gameServer => {
-                var msg = new SERVER_100_PROTOCOL.MSG_QUERYSERVER();
-                var rsp = gameServer.Ask<SERVER_100_PROTOCOL.MSG_SERVERINFO>(msg).Result;
-                
-                return rsp;
-            })
-            .ToList();
+        var originalSender = Sender;
+        var targetIp = message.Ip;
 
-        foreach (var server in gameServers) {
-            var connectedPlayers = server.ConnectedIps;
-            if (server.ConnectedIps.Contains(message.Ip)) {
-                var foundMsg = new SERVER_100_PROTOCOL.MSG_PLAYERFOUND() {
-                    Found = true,
-                };
-                Sender.Tell(foundMsg);
-                
+        // Query all game servers concurrently for their connected IPs.
+        var queryTasks = _gameServers.Values.Select(async gameServer => {
+            try {
+                var msg = new SERVER_100_PROTOCOL.MSG_QUERYSERVER();
+                return await gameServer.Ask<SERVER_100_PROTOCOL.MSG_SERVERINFO>(msg);
+            }
+            catch {
+                return null;
+            }
+        });
+
+        Task.WhenAll(queryTasks)
+            .ContinueWith(t => new SERVER_100_PROTOCOL.MSG_FINDPLAYER_AGGREGATE {
+                OriginalSender = originalSender,
+                TargetIp = targetIp,
+                ServerInfos = t.Result.Where(r => r != null).ToArray()
+            })
+            .PipeTo(Self);
+    }
+
+    [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_FINDPLAYER_AGGREGATE))]
+    private void ReceiveFindPlayerAggregate(SERVER_100_PROTOCOL.MSG_FINDPLAYER_AGGREGATE result) {
+        foreach (var server in result.ServerInfos) {
+            if (server.ConnectedIps.Contains(result.TargetIp)) {
+                result.OriginalSender.Tell(new SERVER_100_PROTOCOL.MSG_PLAYERFOUND { Found = true });
                 return;
             }
         }
 
         // Inform the sender that this player was not found on any game servers.
-        var failureMsg = new SERVER_100_PROTOCOL.MSG_PLAYERFOUND() {
-            Found = false,
-        };
-        Sender.Tell(failureMsg);
+        result.OriginalSender.Tell(new SERVER_100_PROTOCOL.MSG_PLAYERFOUND { Found = false });
     }
 
     [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_CREATEPLAYERKEY))]
@@ -179,53 +201,72 @@ internal class GameServerPool : ReceiveProtocolDispatcher {
 
     [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_QUERYREALMSERVER))]
     private void ReceiveQueryRealmServer(SERVER_100_PROTOCOL.MSG_QUERYREALMSERVER message) {
+        var originalSender = Sender;
+
         if (!_realmToPort.TryGetValue(message.RealmName, out var port)
             || !_gameServers.TryGetValue(port, out var serverRef)) {
-            Sender.Tell(new SERVER_100_PROTOCOL.MSG_SERVERINFO { RealmName = null });
-
+            originalSender.Tell(new SERVER_100_PROTOCOL.MSG_SERVERINFO { RealmName = null });
             return;
         }
 
-        try {
-            var msg = new SERVER_100_PROTOCOL.MSG_QUERYSERVER();
-            var timeout = TimeSpan.FromSeconds(_gameServerQueryTimeout);
-            var rsp = serverRef.Ask<SERVER_100_PROTOCOL.MSG_SERVERINFO>(msg, timeout).Result;
-            Sender.Tell(rsp);
-        }
-        catch {
-            Sender.Tell(new SERVER_100_PROTOCOL.MSG_SERVERINFO { RealmName = null });
-        }
+        var msg = new SERVER_100_PROTOCOL.MSG_QUERYSERVER();
+        var timeout = TimeSpan.FromSeconds(_gameServerQueryTimeout);
+
+        serverRef.Ask<SERVER_100_PROTOCOL.MSG_SERVERINFO>(msg, timeout)
+            .ContinueWith(t => {
+                if (t.IsFaulted || t.IsCanceled) {
+                    return new SERVER_100_PROTOCOL.MSG_SERVERINFO { RealmName = null };
+                }
+                return t.Result;
+            })
+            .PipeTo(originalSender);
     }
 
     [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_REALMLIST))]
     private void ReceiveRealmList(SERVER_100_PROTOCOL.MSG_REALMLIST message) {
-        var realmNames = new List<string>();
-        var playerCounts = new List<ushort>();
-        var playerLimits = new List<ushort>();
+        var originalSender = Sender;
 
-        foreach (var (realmName, port) in _realmToPort) {
+        // Query every realm concurrently.
+        var realmQueries = _realmToPort.Select(async kvp => {
+            var (realmName, port) = kvp;
             if (!_gameServers.TryGetValue(port, out var serverRef)) {
-                continue;
+                return null;
             }
 
             try {
                 var msg = new SERVER_100_PROTOCOL.MSG_QUERYSERVER();
                 var timeout = TimeSpan.FromSeconds(_gameServerQueryTimeout);
-                var rsp = serverRef.Ask<SERVER_100_PROTOCOL.MSG_SERVERINFO>(msg, timeout).Result;
-
-                realmNames.Add(realmName);
-                playerCounts.Add(rsp.PlayerCount);
-                playerLimits.Add(_gameServerPlayerCount);
+                var rsp = await serverRef.Ask<SERVER_100_PROTOCOL.MSG_SERVERINFO>(msg, timeout);
+                return ((string realmName, ushort playerCount)?) (realmName, rsp.PlayerCount);
             }
             catch {
                 // Server unreachable — skip it.
+                return ((string realmName, ushort playerCount)?) null;
             }
-        }
+        });
 
-        Sender.Tell(new SERVER_100_PROTOCOL.MSG_REALMLIST {
-            RealmNames = [.. realmNames],
-            PlayerCounts = [.. playerCounts],
-            PlayerLimits = [.. playerLimits]
+        Task.WhenAll(realmQueries)
+            .ContinueWith(t => {
+                var entries = t.Result.Where(r => r.HasValue).Select(r => r.Value).ToList();
+                return new SERVER_100_PROTOCOL.MSG_REALMLIST_AGGREGATE {
+                    OriginalSender = originalSender,
+                    RealmNames = entries.Select(e => e.realmName).ToArray(),
+                    PlayerCounts = entries.Select(e => e.playerCount).ToArray()
+                };
+            })
+            .PipeTo(Self);
+    }
+
+    [MessageHandler(typeof(SERVER_100_PROTOCOL.MSG_REALMLIST_AGGREGATE))]
+    private void ReceiveRealmListAggregate(SERVER_100_PROTOCOL.MSG_REALMLIST_AGGREGATE result) {
+        var realmNames = result.RealmNames;
+        var playerCounts = result.PlayerCounts;
+        var playerLimits = realmNames.Select(_ => _gameServerPlayerCount).ToArray();
+
+        result.OriginalSender.Tell(new SERVER_100_PROTOCOL.MSG_REALMLIST {
+            RealmNames = realmNames,
+            PlayerCounts = playerCounts,
+            PlayerLimits = playerLimits
         });
     }
 

--- a/src/Imlight.CoreLib/Patch/LatestFileList.cs
+++ b/src/Imlight.CoreLib/Patch/LatestFileList.cs
@@ -51,5 +51,6 @@ public record PatchCacheProperties {
     public uint Version { get; init; }
     public uint Crc { get; init; }
     public uint Size { get; init; }
+    public uint FileTime { get; init; }
 
 }

--- a/src/Imlight.CoreLib/Patch/LatestFileList.cs
+++ b/src/Imlight.CoreLib/Patch/LatestFileList.cs
@@ -37,3 +37,19 @@ public record LatestFile {
     public uint HeaderCrc { get; init; }
     
 }
+
+/// <summary>
+/// Cached properties of the LatestFileList.bin download, used to serve
+/// <see cref="PATCH_8_PROTOCOL.MSG_LATEST_FILE_LIST_V2"/> responses to clients.
+/// </summary>
+public record PatchCacheProperties {
+
+    public string Name { get; init; }
+    public string Url { get; init; }
+    public string UrlPrefix { get; init; }
+    public string UrlSuffix { get; init; }
+    public uint Version { get; init; }
+    public uint Crc { get; init; }
+    public uint Size { get; init; }
+
+}

--- a/src/Imlight.CoreLib/Patch/PatchServer.cs
+++ b/src/Imlight.CoreLib/Patch/PatchServer.cs
@@ -21,7 +21,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Xml;
 using System.Threading.Tasks;
@@ -30,10 +29,19 @@ using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.Shared.Packets;
 using Imlight.Common;
 using Imlight.CoreLib.Shared.Cryptography;
-using Imcodec.IO;
 
 namespace Imlight.CoreLib.Patch;
 
+/// <summary>
+/// Akka.NET actor that manages communication with the remote patch server.
+/// Downloads and caches the LatestFileList, serves file-list metadata to connected
+/// clients, and downloads individual WAD archives on demand.
+/// </summary>
+/// <remarks>
+/// Only one instance may exist (singleton enforced via <see cref="Instance"/>).
+/// Initialization is triggered by <see cref="SERVER_100_PROTOCOL.MSG_INITIALIZE"/>
+/// and blocks the caller until the remote endpoint is checked and the file list is cached.
+/// </remarks>
 public class PatchServer : Server {
 
     private const string PatchServerWadUrlPrefix = "Data/GameData";
@@ -54,20 +62,20 @@ public class PatchServer : Server {
 
     public static IActorRef Instance { get; private set; }
     public static bool EndpointReached { get; set; }
-    // LatestFileList cached information.
-    private static uint s_latestVersion;
-    private static ByteString s_listFileName;
-    private static uint s_listFileSize;
-    private static uint s_listFileCrc;
-    private static ByteString s_listFileUrl;
-    private static ByteString s_urlPrefix;
-    private static ByteString s_urlSuffix;
+
+    /// <summary>
+    /// Cached properties of the LatestFileList.bin — populated during initialization
+    /// and served to clients via <see cref="ReceiveLatestFileCacheProperties"/>.
+    /// </summary>
+    private PatchCacheProperties _patchCacheProperties;
 
     private LatestFileList _latestFileList;
     private Stopwatch _diagnosticStopwatch;
     private string _patchServerWorkingUrl;
 
-    public PatchServer(string name, int port, Props factoryProps) : base(name, port, factoryProps) {
+    // ctor
+    public PatchServer(string name, int port, Props factoryProps)
+        : base(name, port, factoryProps) {
         if (Instance is not null) {
             throw new Exception("Attempted to create more than one patch server! This is not possible!");
         }
@@ -122,7 +130,7 @@ public class PatchServer : Server {
     }
 
     [MessageHandler(typeof(PATCH_105_PROTOCOL.MSG_DOWNLOAD_WAD_REQUEST))]
-    public void ReceiveDownloadRequest(PATCH_105_PROTOCOL.MSG_DOWNLOAD_WAD_REQUEST message) {
+    private void ReceiveDownloadRequest(PATCH_105_PROTOCOL.MSG_DOWNLOAD_WAD_REQUEST message) {
         var rsp = new PATCH_105_PROTOCOL.MSG_DOWNLOAD_FILE_RESULT {
             FileStream = DownloadWadStream(message.WadName).Result
         };
@@ -130,30 +138,31 @@ public class PatchServer : Server {
         Sender.Tell(rsp);
     }
 
+    [MessageHandler(typeof(PATCH_105_PROTOCOL.MSG_LATESTFILELIST))]
+    private void ReceiveLatestFileList(PATCH_105_PROTOCOL.MSG_LATESTFILELIST message) {
+        var rsp = new PATCH_105_PROTOCOL.MSG_LATESTFILELIST() { LatestFileList = this._latestFileList };
+        Sender.Tell(rsp);
+    }
+
     [MessageHandler(typeof(PATCH_105_PROTOCOL.MSG_LATEST_CACHE_PROPERTIES))]
-    public void ReceiveLatestFileCacheProperties(PATCH_105_PROTOCOL.MSG_LATEST_CACHE_PROPERTIES message) {
-        var rsp = new PATCH_105_PROTOCOL.MSG_LATEST_CACHE_PROPERTIES() {
-            Name = s_listFileName,
-            URL = s_listFileUrl,
-            URLPrefix = s_urlPrefix,
-            URLSuffix = s_urlSuffix,
-            Version = s_latestVersion,
-            CRC = s_listFileCrc,
-            Size = s_listFileSize,
+    private void ReceiveLatestFileCacheProperties(PATCH_105_PROTOCOL.MSG_LATEST_CACHE_PROPERTIES message) {
+        var cache = _patchCacheProperties;
+        var rsp = new PATCH_105_PROTOCOL.MSG_LATEST_CACHE_PROPERTIES {
+            Name = cache?.Name,
+            URL = cache?.Url,
+            URLPrefix = cache?.UrlPrefix,
+            URLSuffix = cache?.UrlSuffix,
+            Version = cache?.Version ?? 0,
+            CRC = cache?.Crc ?? 0,
+            Size = cache?.Size ?? 0,
         };
 
         Sender.Tell(rsp);
     }
 
-    [MessageHandler(typeof(PATCH_105_PROTOCOL.MSG_LATESTFILELIST))]
-    public void ReceiveLatestFileList(PATCH_105_PROTOCOL.MSG_LATESTFILELIST message) {
-        var rsp = new PATCH_105_PROTOCOL.MSG_LATESTFILELIST() { LatestFileList = this._latestFileList };
-        Sender.Tell(rsp);
-    }
-
     private async Task<MemoryStream> DownloadWadStream(string wadName) {
         if (!EndpointReached) {
-            throw new Exception("By this point, the patch server endpoint has not yet been reached!");
+            throw new InvalidOperationException("Patch server endpoint is not available.");
         }
 
         // Remove the `.wad` extension if one exists.
@@ -163,7 +172,10 @@ public class PatchServer : Server {
 
         var url = $"{_patchServerWorkingUrl}/{PatchServerWadUrlPrefix}/{wadName}.wad";
 
-        return await DownloadFileStream(url);
+        var stream = await DownloadFileStream(url)
+            ?? throw new InvalidOperationException($"Failed to download WAD '{wadName}' from patch server.");
+
+        return stream;
     }
 
     private async Task<MemoryStream> DownloadStream(string fileName) {
@@ -242,13 +254,14 @@ public class PatchServer : Server {
         try {
             using var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Head, url));
 
+            // Any response (2xx, 3xx, 4xx) means the server is reachable —
+            // we only care that the endpoint exists, not that the path is valid.
             return true;
         }
-        catch (HttpRequestException ex) when (ex.StatusCode >= HttpStatusCode.InternalServerError) {
-            return ex.StatusCode < HttpStatusCode.InternalServerError;
-        }
-        catch (Exception ex) {
-            Logger.Error("Error while checking patch server at URL {Url}. Exception: {Ex}",
+        catch (HttpRequestException ex) {
+            // Network-level failure (DNS, connection refused, TLS error) or
+            // 5xx server error — the endpoint is not reachable.
+            Logger.Warning("Patch server at URL {Url} is not reachable: {Reason}",
                 Logger.Args(url, ex.Message));
 
             return false;
@@ -285,29 +298,34 @@ public class PatchServer : Server {
         }
 
         // Process the actual revision from the revision string. It is right after the 'r' and before the '.'.
-        var revisionStart = _revision.IndexOf('r') + 1;
-        var revisionEnd = _revision.IndexOf('.');
-        if (revisionStart == -1 || revisionEnd == -1) {
+        var revisionStartIdx = _revision.IndexOf('r');
+        var revisionEndIdx = _revision.IndexOf('.');
+        if (revisionStartIdx == -1 || revisionEndIdx == -1) {
             Logger.Error("Could not parse the revision from the revision string.");
 
             return false;
         }
-        var actualRevision = _revision[revisionStart..revisionEnd];
+        var actualRevision = _revision[(revisionStartIdx + 1)..revisionEndIdx];
 
-        // Cache the `.bin` file properties.
-        s_latestVersion = Convert.ToUInt32(actualRevision);
-        s_listFileName = LatestFileListNameBin;
-        s_listFileUrl = $"{_patchServerWorkingUrl}/{LatestFileListNameBin}";
-        s_listFileSize = Convert.ToUInt32(latestBin.Length);
-        s_urlPrefix = _patchServerWorkingUrl;
-        s_urlSuffix = "";
-
-        // Convert the stream to a byte array to compute the crc32 hash.
-        var ms = new MemoryStream();
+        // Compute CRC32 of the binary list.
         latestBin.Seek(0, SeekOrigin.Begin);
-        latestBin.CopyTo(ms);
-        ms.Seek(0, SeekOrigin.Begin);
-        s_listFileCrc = Crc32.Calculate(uint.MaxValue, ms.ToArray()) ^ uint.MaxValue;
+        uint crc;
+        using (var ms = new MemoryStream()) {
+            latestBin.CopyTo(ms);
+            ms.Seek(0, SeekOrigin.Begin);
+            crc = Crc32.Calculate(uint.MaxValue, ms.ToArray()) ^ uint.MaxValue;
+        }
+
+        // Cache the `.bin` file properties into the instance record.
+        _patchCacheProperties = new PatchCacheProperties {
+            Version = Convert.ToUInt32(actualRevision),
+            Name = LatestFileListNameBin,
+            Url = $"{_patchServerWorkingUrl}/{LatestFileListNameBin}",
+            Size = Convert.ToUInt32(latestBin.Length),
+            UrlPrefix = _patchServerWorkingUrl,
+            UrlSuffix = "",
+            Crc = crc
+        };
 
         return true;
     }
@@ -315,6 +333,9 @@ public class PatchServer : Server {
     private static bool ParseLatestFileList(Stream content, out LatestFileList latestFileList) {
         latestFileList = null;
         var xml = StreamToXmlDoc(content);
+        if (xml is null) {
+            return false;
+        }
 
         var rootNode = xml
             .GetElementsByTagName("LatestFileList")
@@ -327,24 +348,24 @@ public class PatchServer : Server {
         }
 
         latestFileList = new LatestFileList { Files = new List<LatestFile>() };
-        if (!ParseChildNodes(rootNode, latestFileList)) {
-            return false;
-        }
+        ParseChildNodes(rootNode, latestFileList);
 
         var baseNode = xml
             .GetElementsByTagName("Base")
             .Cast<XmlElement>()
             .FirstOrDefault();
-        if (baseNode != null) {
-            return ParseChildNodes(baseNode, latestFileList);
+        if (baseNode == null) {
+            Logger.Error("XmlDocument does not contain a Base node.");
+
+            return false;
         }
 
-        Logger.Error("XmlDocument does not contain a Base node.");
+        ParseChildNodes(baseNode, latestFileList);
 
-        return false;
+        return true;
     }
 
-    private static bool ParseChildNodes(XmlNode parentNode, LatestFileList latestFileList) {
+    private static void ParseChildNodes(XmlNode parentNode, LatestFileList latestFileList) {
         foreach (var latestFileNode in parentNode.ChildNodes.Cast<XmlElement>()) {
             if (latestFileNode.Name is "_TableList" or "About") {
                 continue;
@@ -352,10 +373,10 @@ public class PatchServer : Server {
 
             var isRecord = latestFileNode.Name == "RECORD";
             var def = ParseLatestFileXmlNode(latestFileNode, isRecord);
-            latestFileList.Files.Add(def);
+            if (def is not null) {
+                latestFileList.Files.Add(def);
+            }
         }
-
-        return true;
     }
 
     private static LatestFile ParseLatestFileXmlNode(XmlNode latestFileNode, bool isRecord = false) {
@@ -389,8 +410,9 @@ public class PatchServer : Server {
     }
 
     private static XmlDocument StreamToXmlDoc(Stream content) {
-        // XmlDocument will not break on exception, for whatever god forsaken reason. Fuck you, Microsoft.
-        // This is our own catch to continue willingly even on exception.
+        // XmlDocument.Load does not throw on all malformed XML — it can return
+        // a partially-loaded document. We wrap in a try/catch to handle the cases
+        // it does throw, and let callers validate the resulting document.
         try {
             var xmlDoc = new XmlDocument();
             xmlDoc.Load(content);
@@ -405,7 +427,7 @@ public class PatchServer : Server {
     }
 
     private static uint TryParseUInt(string value) {
-        uint.TryParse(value, out var result);
+        _ = uint.TryParse(value, out var result);
 
         return result;
     }

--- a/src/Imlight.CoreLib/Patch/PatchServer.cs
+++ b/src/Imlight.CoreLib/Patch/PatchServer.cs
@@ -150,6 +150,7 @@ public class PatchServer : Server {
             Version = cache?.Version ?? 0,
             CRC = cache?.Crc ?? 0,
             Size = cache?.Size ?? 0,
+            FileTime = cache?.FileTime ?? 0,
         };
 
         Sender.Tell(rsp);
@@ -310,7 +311,8 @@ public class PatchServer : Server {
             Size = Convert.ToUInt32(latestBin.Length),
             UrlPrefix = _patchServerWorkingUrl,
             UrlSuffix = "",
-            Crc = crc
+            Crc = crc,
+            FileTime = (uint) DateTimeOffset.UtcNow.ToUnixTimeSeconds()
         };
 
         return true;

--- a/src/Imlight.CoreLib/Patch/PatchServer.cs
+++ b/src/Imlight.CoreLib/Patch/PatchServer.cs
@@ -63,12 +63,7 @@ public class PatchServer : Server {
     public static IActorRef Instance { get; private set; }
     public static bool EndpointReached { get; set; }
 
-    /// <summary>
-    /// Cached properties of the LatestFileList.bin — populated during initialization
-    /// and served to clients via <see cref="ReceiveLatestFileCacheProperties"/>.
-    /// </summary>
     private PatchCacheProperties _patchCacheProperties;
-
     private LatestFileList _latestFileList;
     private Stopwatch _diagnosticStopwatch;
     private string _patchServerWorkingUrl;
@@ -297,28 +292,19 @@ public class PatchServer : Server {
             return false;
         }
 
-        // Process the actual revision from the revision string. It is right after the 'r' and before the '.'.
-        var revisionStartIdx = _revision.IndexOf('r');
-        var revisionEndIdx = _revision.IndexOf('.');
-        if (revisionStartIdx == -1 || revisionEndIdx == -1) {
-            Logger.Error("Could not parse the revision from the revision string.");
-
-            return false;
-        }
-        var actualRevision = _revision[(revisionStartIdx + 1)..revisionEndIdx];
-
         // Compute CRC32 of the binary list.
+        // Algorithm: CRC-32 with init=0, reflected polynomial 0xEDB88320, no final XOR.
         latestBin.Seek(0, SeekOrigin.Begin);
         uint crc;
         using (var ms = new MemoryStream()) {
             latestBin.CopyTo(ms);
             ms.Seek(0, SeekOrigin.Begin);
-            crc = Crc32.Calculate(uint.MaxValue, ms.ToArray()) ^ uint.MaxValue;
+            crc = Crc32.Calculate(0, ms.ToArray());
         }
 
         // Cache the `.bin` file properties into the instance record.
         _patchCacheProperties = new PatchCacheProperties {
-            Version = Convert.ToUInt32(actualRevision),
+            Version = 1,
             Name = LatestFileListNameBin,
             Url = $"{_patchServerWorkingUrl}/{LatestFileListNameBin}",
             Size = Convert.ToUInt32(latestBin.Length),

--- a/src/Imlight.CoreLib/Patch/Services/PatchService.cs
+++ b/src/Imlight.CoreLib/Patch/Services/PatchService.cs
@@ -42,8 +42,10 @@ internal class PatchService(SessionActor sessionActor) : MessageService(sessionA
             ListFileCRC = rsp.CRC,
             ListFileURL = rsp.URL,
             ListFileType = 1, // This causes the client to fail parsing the file if it is not 1. Do not change !
+            ListFileTime = rsp.FileTime,
             URLPrefix = rsp.URLPrefix,
             URLSuffix = rsp.URLSuffix,
+            Locale = message.Locale,
         };
 
         SendToSocket(socketRsp);

--- a/src/Imlight.CoreLib/Shared/Behaviors/ServerQuestBehavior.cs
+++ b/src/Imlight.CoreLib/Shared/Behaviors/ServerQuestBehavior.cs
@@ -270,7 +270,7 @@ public class ServerQuestBehavior : IClientBehaviorProvider<ServerQuestBehavior> 
             return 0;
         }
 
-        var fullEntryName = $"{questName}.{entryName}";
+        var fullEntryName = $"{questName}_{entryName}";
         
         return GetRegistryValue(fullEntryName);
     }

--- a/src/Imlight.CoreLib/Shared/Behaviors/ServerWizSpellbookBehavior.cs
+++ b/src/Imlight.CoreLib/Shared/Behaviors/ServerWizSpellbookBehavior.cs
@@ -38,6 +38,8 @@ public class ServerWizSpellbookBehavior : ServerSpellbookBehavior {
     [JsonIgnore] public int MaxSpells { get; set; }
     [JsonIgnore] public int MaxTreasureCards { get; set; }
 
+    public Dictionary<ulong, HashSet<uint>> ExcludedItemSpellIds { get; set; } = [];
+
     public void InitializeProperties(DeckBehaviorTemplate deckTemplate) {
         SetPropertiesFromDeckTemplate(deckTemplate);
     }
@@ -135,6 +137,37 @@ public class ServerWizSpellbookBehavior : ServerSpellbookBehavior {
 
         return true;
     }
+
+    /// <summary>
+    /// Adds or removes a spell template ID from a deck item's exclusion list.
+    /// </summary>
+    /// <param name="deckId">The global ID of the deck item.</param>
+    /// <param name="spellTemplateId">The spell template ID to exclude/include.</param>
+    /// <param name="exclude">True to exclude, false to include (un-exclude).</param>
+    public void SetItemSpellExclusion(ulong deckId, uint spellTemplateId, bool exclude) {
+        if (exclude) {
+            if (!ExcludedItemSpellIds.TryGetValue(deckId, out var set)) {
+                set = [];
+                ExcludedItemSpellIds[deckId] = set;
+            }
+            set.Add(spellTemplateId);
+        }
+        else {
+            if (ExcludedItemSpellIds.TryGetValue(deckId, out var set)) {
+                set.Remove(spellTemplateId);
+                if (set.Count == 0) {
+                    ExcludedItemSpellIds.Remove(deckId);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns true if the given spell template ID is excluded for the given deck item.
+    /// </summary>
+    public bool IsItemSpellExcluded(ulong deckId, uint spellTemplateId) 
+        => ExcludedItemSpellIds.TryGetValue(deckId, out var set)
+            && set.Contains(spellTemplateId);
 
     public new ClientSpellbookBehavior GetClientBehaviorInstance() {
         var spellIdList = new List<SpellIDTracker>();

--- a/src/Imlight.CoreLib/Shared/Networking/MessageService.cs
+++ b/src/Imlight.CoreLib/Shared/Networking/MessageService.cs
@@ -57,7 +57,9 @@ using Imlight.CoreLib.WizardData.Models.Player;
 
 namespace Imlight.CoreLib.Shared.Networking;
 
-internal abstract class MessageService(SessionActor sessionActor) : ReceiveProtocolDispatcher {
+internal abstract class MessageService(SessionActor sessionActor) : ReceiveProtocolDispatcher, IWithTimers {
+
+    public ITimerScheduler Timers { get; set; }
 
     protected SessionActor SessionActor { get; init; } = sessionActor;
 
@@ -269,22 +271,45 @@ internal abstract class MessageService(SessionActor sessionActor) : ReceiveProto
                             bool makePrivate = false,
                             ulong ownerCharId = 0,
                             string destinationLocation = "") {
-        // Broadcast teleport effects to the zone, if applicable.
+        // If the destination location is nothing, default it to "Start."
+        var location = destinationLocation == "" ? "Start" : destinationLocation;
+        var ownerId = ownerCharId == 0 ? GetActiveWizard().CharId : ownerCharId;
+
         if (doTeleportEffects) {
             var teleportEffectsMsg = new CHARACTER_103_PROTOCOL.MSG_DOTELEPORTEFFECTS();
             TellOtherServices(teleportEffectsMsg);
 
-            // Wait 2 seconds for the effects to finish.
-            Task.Delay(2000).Wait();
+            // Defer the actual zone transfer by 2s so the client can play
+            // teleport effects.  Uses an Akka timer instead of blocking the
+            // actor thread.
+            var delayMsg = new SERVICE_101_PROTOCOL.MSG_TELEPORT_DELAY {
+                DestinationZone = destinationZone,
+                DestinationLocation = location,
+                MakePrivate = makePrivate,
+                OwnerCharId = ownerId
+            };
+            Timers.StartSingleTimer("teleport-delay", delayMsg, TimeSpan.FromSeconds(2));
+
+            return;
         }
 
-        // If the destination location is nothing, default it to "Start."
+        // No effects — transfer immediately.
+        DoTeleport(destinationZone, location, makePrivate, ownerId);
+    }
+
+    [MessageHandler(typeof(SERVICE_101_PROTOCOL.MSG_TELEPORT_DELAY))]
+    private void OnTeleportDelay(SERVICE_101_PROTOCOL.MSG_TELEPORT_DELAY msg) {
+        DoTeleport(msg.DestinationZone, msg.DestinationLocation, msg.MakePrivate, msg.OwnerCharId);
+    }
+
+    private void DoTeleport(string destinationZone, string destinationLocation,
+                            bool makePrivate, ulong ownerCharId) {
         var zoneTransfer = new ZONE_102_PROTOCOL.MSG_ZONETRANSFER {
-            DestinationLocation = destinationLocation == "" ? "Start" : destinationLocation,
+            DestinationLocation = destinationLocation,
             DestinationZone = destinationZone,
             SendToClient = true,
             IsPrivate = makePrivate,
-            OwnerCharId = ownerCharId == 0 ? GetActiveWizard().CharId : ownerCharId
+            OwnerCharId = ownerCharId
         };
         TellOtherServices(zoneTransfer);
     }

--- a/src/Imlight.CoreLib/Shared/Networking/MessageService.cs
+++ b/src/Imlight.CoreLib/Shared/Networking/MessageService.cs
@@ -107,12 +107,12 @@ internal abstract class MessageService(SessionActor sessionActor) : ReceiveProto
     }
 
     /// <summary>
-    /// Broadcasts a message to the entire zone.
+    /// Broadcasts a client-visible message to the zone, optionally restricted to
+    /// specific supervisor targets.
     /// </summary>
-    /// <param name="originalMessage"></param>
-    /// <param name="isSelfless"></param>
-    /// <exception cref="ActorKilledException"></exception>
-    protected void ZoneBroadcast(IMessage originalMessage, bool isSelfless = true) {
+    protected void ZoneBroadcast(IMessage originalMessage,
+                                 bool isSelfless = true,
+                                 ZoneBroadcastTarget targets = ZoneBroadcastTarget.All) {
         if (SessionActor is null) {
             throw new ActorKilledException($"{GetType()} attempted to send message to undefined SessionActor.");
         }
@@ -120,25 +120,26 @@ internal abstract class MessageService(SessionActor sessionActor) : ReceiveProto
         var message = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
             Message = originalMessage,
             Selfless = isSelfless,
-            Sender = SessionActor.ActorRef
+            Sender = SessionActor.ActorRef,
+            Targets = targets,
         };
 
         SessionActor.ActorRef.Tell(message, Self);
     }
 
     /// <summary>
-    /// Broadcasts a message to the entire zone, excluding all players.
+    /// Broadcasts a server-protocol message to zone supervisors, excluding players
+    /// (e.g. trigger post events, spawn commands).
     /// </summary>
-    /// <param name="originalMessage"></param>
-    /// <exception cref="ActorKilledException"></exception>
     protected void ZoneBroadcastNoPlayers(IServerMessage originalMessage) {
         if (SessionActor is null) {
             throw new ActorKilledException($"{GetType()} attempted to send message to undefined SessionActor.");
         }
 
-        var message = new ZONE_102_PROTOCOL.MSG_ZONESUPERVISORBROADCAST {
+        var message = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
             Messages = [originalMessage],
-            Sender = SessionActor.ActorRef
+            Sender = SessionActor.ActorRef,
+            Targets = ZoneBroadcastTarget.AllNoPlayers,
         };
 
         SessionActor.ActorRef.Tell(message, Self);

--- a/src/Imlight.CoreLib/Shared/Networking/ReceiveProtocolDispatcher.cs
+++ b/src/Imlight.CoreLib/Shared/Networking/ReceiveProtocolDispatcher.cs
@@ -37,12 +37,13 @@
  * 
  * Created by: Jooty
  * Version: KALI 1.0
- * Last Updated: 3/18/2025
+ * Last Updated: 06/28/2026
  */
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using Akka.Actor;
 
@@ -65,7 +66,7 @@ public class ReceiveProtocolDispatcher : ReceiveActor {
 
     public Dictionary<Type, MethodInfo> MessageHandlers { get; private set; }
 
-    private readonly Dictionary<Type, MethodInfo[]> _handlerCache = [];
+    private readonly Dictionary<Type, Action<object>> _handlerCache = [];
 
     protected ReceiveProtocolDispatcher() {
         SetMessageHandlers();
@@ -73,33 +74,56 @@ public class ReceiveProtocolDispatcher : ReceiveActor {
     }
 
     protected virtual void ConfigureReceivers() => Receive<object>(message => {
-        // Find the method that handles this message type
         var messageType = message.GetType();
 
-        if (!_handlerCache.TryGetValue(messageType, out var handlers)) {
-            handlers = MessageHandlers
-                .Where(kvp => kvp.Key.IsAssignableFrom(messageType))
-                .Select(kvp => kvp.Value)
-                .ToArray();
-            _handlerCache[messageType] = handlers;
+        if (!_handlerCache.TryGetValue(messageType, out var handler)) {
+            handler = BuildCompiledHandler(messageType);
+            _handlerCache[messageType] = handler; // null is a valid sentinel — means "no handler"
         }
 
-        if (handlers.Length == 0) {
+        if (handler is null) {
             Unhandled(message);
-
             return;
         }
 
-        // Invoke all methods that handle this message type
-        foreach (var method in handlers) {
+        handler(message);
+    });
+
+    private Action<object> BuildCompiledHandler(Type messageType) {
+        var matching = MessageHandlers
+            .Where(kvp => kvp.Key.IsAssignableFrom(messageType))
+            .Select(kvp => kvp.Value)
+            .ToList();
+
+        if (matching.Count == 0) {
+            return null;
+        }
+
+        // Chain multiple handlers (rare, but supported) via delegate combination.
+        Action<object> combined = null;
+
+        foreach (var method in matching) {
+            var instance = Expression.Constant(this);
             var parameters = method.GetParameters();
+
             if (parameters.Length == 0) {
-                method.Invoke(this, null);
+                // Parameterless handler (just ignore the incoming message)
+                var call = Expression.Call(instance, method);
+                var lambda = Expression.Lambda<Action<object>>(
+                    call, Expression.Parameter(typeof(object), "_"));
+                combined += lambda.Compile();
             } else {
-                method.Invoke(this, [message]);
+                // Single-parameter handler: cast object -> concrete type.
+                var param = Expression.Parameter(typeof(object));
+                var cast = Expression.Convert(param, parameters[0].ParameterType);
+                var call = Expression.Call(instance, method, cast);
+                var lambda = Expression.Lambda<Action<object>>(call, param);
+                combined += lambda.Compile();
             }
         }
-    });
+
+        return combined;
+    }
 
     private void SetMessageHandlers() {
         MessageHandlers = [];

--- a/src/Imlight.CoreLib/Shared/Networking/Server.cs
+++ b/src/Imlight.CoreLib/Shared/Networking/Server.cs
@@ -78,7 +78,18 @@ public abstract class Server : ReceiveProtocolDispatcher {
         }
         else {
 #if !DEBUG
-            this.Ip = new HttpClient().GetStringAsync("https://api.ipify.org/").Result;
+            try {
+                this.Ip = new HttpClient()
+                    .GetStringAsync("https://api.ipify.org/")
+                    .GetAwaiter()
+                    .GetResult();
+            }
+            catch {
+                // If the ipify call fails (offline, timeout, blocked), fall back
+                // to loopback so the server can still start.
+                Logger.Warning("Failed to resolve public IP from ipify.org — falling back to 127.0.0.1.");
+                this.Ip = "127.0.0.1";
+            }
 #else
             this.Ip = "127.0.0.1";
 #endif
@@ -92,7 +103,7 @@ public abstract class Server : ReceiveProtocolDispatcher {
     protected virtual void ReceiveAllocateSocket(SERVER_100_PROTOCOL.MSG_ALLOCATESOCKET message) {
         // Create a new child actor, which represents the active socket connection.
         var id = GetNewUniqueId();
-        var sessionProps = SessionActor.Props(message.Socket, id, Context.Self);
+        var sessionProps = SessionActor.Props(message.Socket, id, Context.Self, _actorFactoryRef);
         Context.ActorOf(sessionProps, $"SessionActor.{id}");
 
         // Logger

--- a/src/Imlight.CoreLib/Shared/Networking/SessionActor.cs
+++ b/src/Imlight.CoreLib/Shared/Networking/SessionActor.cs
@@ -78,6 +78,7 @@ public sealed class SessionActor : ReceiveActor, IDisposable {
 
     private readonly IActorRef _actorFactoryRef;
     private readonly Dictionary<IActorRef, MessageService> _services;
+    private readonly Dictionary<Type, List<IActorRef>> _dispatchTable = [];
     private readonly Socket _socket;
     private readonly List<IMessage> _preInitMessages = new();
     private IActorRef _socketListenerRef;
@@ -167,25 +168,23 @@ public sealed class SessionActor : ReceiveActor, IDisposable {
     /// </summary>
     /// <param name="msg"></param>
     private void HandleInternalTell(IServerMessage msg) {
-        // Iterate through services and forward the message to any service that can handle the message.
-        var wasDispatched = false;
-        foreach (var (actorRef, type) in _services) {
-            if (type.MessageHandlers.All(x => x.Key != msg.GetType())) {
-                continue;
+        if (_dispatchTable.TryGetValue(msg.GetType(), out var handlers)) {
+            var wasDispatched = false;
+            foreach (var handler in handlers) {
+                if (handler == Sender) {
+                    continue;
+                }
+                handler.Forward(msg);
+                wasDispatched = true;
             }
 
-            // If the handler is the sender, skip.
-            if (actorRef == Sender) {
-                continue;
+            if (!wasDispatched) {
+                Unhandled(msg);
             }
-
-            actorRef.Forward(msg);
-            wasDispatched = true;
+            return;
         }
 
-        if (!wasDispatched) {
-            Unhandled(msg);
-        }
+        Unhandled(msg);
     }
 
     /// <summary>
@@ -197,25 +196,19 @@ public sealed class SessionActor : ReceiveActor, IDisposable {
     /// <returns></returns>
     public T HandleInternalAsk<T>(IServerMessage msg)
         where T : IServerMessage {
-        // Iterate our services and see if any of them can handle this message.
-        foreach (var (actorRef, type) in _services) {
-            if (type.MessageHandlers.All(x => x.Key != msg.GetType())) {
-                continue;
-            }
+        if (_dispatchTable.TryGetValue(msg.GetType(), out var handlers)) {
+            foreach (var handler in handlers) {
+                if (handler == Sender) {
+                    continue;
+                }
 
-            // If the handler is the sender, skip.
-            if (actorRef == Sender) {
-                continue;
-            }
-
-            try {
-                var result = actorRef.Ask<T>(msg, timeout: TimeSpan.FromSeconds(20)).Result;
-
-                return result;
-            }
-            catch (Exception ex) {
-                Logger.Error("SessionActor service attempted to ask another service with {0}, but the timeout " +
-                          "was exceeded. {1}", Logger.Args(msg.GetType(), ex.Message));
+                try {
+                    return handler.Ask<T>(msg, timeout: TimeSpan.FromSeconds(20)).Result;
+                }
+                catch (Exception ex) {
+                    Logger.Error("SessionActor service attempted to ask another service with {0}, but the timeout " +
+                              "was exceeded. {1}", Logger.Args(msg.GetType(), ex.Message));
+                }
             }
         }
 
@@ -399,6 +392,15 @@ public sealed class SessionActor : ReceiveActor, IDisposable {
                 .Result
                 .Service;
             _services.Add(childRef, identity);
+
+            // Populate the dispatch table.
+            foreach (var msgType in identity.MessageHandlers.Keys) {
+                if (!_dispatchTable.TryGetValue(msgType, out var list)) {
+                    list = [];
+                    _dispatchTable[msgType] = list;
+                }
+                list.Add(childRef);
+            }
         }
     }
 
@@ -418,20 +420,14 @@ public sealed class SessionActor : ReceiveActor, IDisposable {
             return;
         }
 
-        // Iterate through services and forward the message to any service that can handle the message.
-        var wasDispatched = false;
-        foreach (var (actorRef, type) in _services) {
-            if (type.MessageHandlers.All(x => x.Key != packet.GetType())) {
-                continue;
+        if (_dispatchTable.TryGetValue(packet.GetType(), out var handlers)) {
+            foreach (var handler in handlers) {
+                handler.Forward(packet);
             }
-
-            actorRef.Forward(packet);
-            wasDispatched = true;
+            return;
         }
 
-        if (!wasDispatched) {
-            Unhandled(packet);
-        }
+        Unhandled(packet);
     }
 
     private void SendPreDisposeToServices() {

--- a/src/Imlight.CoreLib/Shared/Networking/SessionActor.cs
+++ b/src/Imlight.CoreLib/Shared/Networking/SessionActor.cs
@@ -37,7 +37,7 @@
  * 
  * Created by: Jooty
  * Version: KALI 1.0
- * Last Updated: 3/18/2025
+ * Last Updated: 06/27/2026
  */
 
 using System;
@@ -85,7 +85,7 @@ public sealed class SessionActor : ReceiveActor, IDisposable {
     private bool _isDisposed;
 
     // ctor
-    public SessionActor(Socket socket, ushort sessionId, IActorRef server) {
+    public SessionActor(Socket socket, ushort sessionId, IActorRef server, IActorRef actorFactoryRef = null) {
         this._socket = socket;
         this.Ip = socket.RemoteEndPoint.ToString();
         this.RemoteIp = socket.RemoteEndPoint.ToString().Split(':')[0];
@@ -93,11 +93,16 @@ public sealed class SessionActor : ReceiveActor, IDisposable {
         this._services = new Dictionary<IActorRef, MessageService>();
         this.ServerRef = server;
 
-        // To get the actor factory reference, we'll ask the server.
-        var query = new SERVER_100_PROTOCOL.MSG_QUERYACTORFACTORY();
-        this._actorFactoryRef = server.Ask<SERVER_100_PROTOCOL.MSG_ACTORFACTORYINFO>(query)
-            .Result
-            .Reference;
+        if (actorFactoryRef != null) {
+            this._actorFactoryRef = actorFactoryRef;
+        }
+        else {
+            // Fallback for callers that don't provide the ref.
+            var query = new SERVER_100_PROTOCOL.MSG_QUERYACTORFACTORY();
+            this._actorFactoryRef = server.Ask<SERVER_100_PROTOCOL.MSG_ACTORFACTORYINFO>(query)
+                .Result
+                .Reference;
+        }
 
         ActorRef = Context.Self;
 
@@ -106,8 +111,8 @@ public sealed class SessionActor : ReceiveActor, IDisposable {
     }
 
     // Akka.NET ctor
-    public static Props Props(Socket socket, ushort sessionId, IActorRef server)
-        => Akka.Actor.Props.Create(() => new SessionActor(socket, sessionId, server));
+    public static Props Props(Socket socket, ushort sessionId, IActorRef server, IActorRef actorFactoryRef = null)
+        => Akka.Actor.Props.Create(() => new SessionActor(socket, sessionId, server, actorFactoryRef));
 
     /// <summary>
     /// Places the session in the queue.

--- a/src/Imlight.CoreLib/Shared/Networking/SocketListener.cs
+++ b/src/Imlight.CoreLib/Shared/Networking/SocketListener.cs
@@ -35,7 +35,7 @@
  * 
  * Created by: Jooty
  * Version: KALI 1.0
- * Last Updated: 3/18/2025
+ * Last Updated: 06/28/2026
  */
 
 using System;
@@ -74,6 +74,15 @@ internal sealed class SocketListener : ReceiveActor, IDisposable {
         ];
     private bool _isDisposed;
 
+    private sealed class SocketReadCompleted {
+        public byte[] Buffer;
+        public int ByteCount;
+    }
+
+    private sealed class SocketReadFailed {
+        public Exception Error;
+    }
+
     // ctor
     public SocketListener(IActorRef sessionActor, Socket socket, ushort sessionid) {
         this._sessionActorRef = sessionActor;
@@ -82,6 +91,8 @@ internal sealed class SocketListener : ReceiveActor, IDisposable {
         this._tokenBucket = new TokenBucket(_tokenBucketMax, _tokenBucketPerSecond);
 
         Receive<string>(x => x == "Close", x => Dispose());
+        Receive<SocketReadCompleted>(OnSocketReadCompleted);
+        Receive<SocketReadFailed>(OnSocketReadFailed);
 
         StartReceive();
     }
@@ -103,19 +114,37 @@ internal sealed class SocketListener : ReceiveActor, IDisposable {
             return;
         }
 
-        _socket.ReceiveTimeout = 0; // No timeout for synchronous receives
         var buffer = new byte[_bufferSize];
+        _socket.ReceiveAsync(new ArraySegment<byte>(buffer), SocketFlags.None)
+            .ContinueWith(t => {
+                if (t.IsFaulted) {
+                    return (object) new SocketReadFailed {
+                        Error = t.Exception?.InnerException ?? t.Exception!
+                    };
+                }
+                return new SocketReadCompleted {
+                    Buffer = buffer,
+                    ByteCount = t.Result
+                };
+            })
+            .PipeTo(Self);
+    }
 
-        try {
-            int bytesReceived = _socket.Receive(buffer);
-            ProcessReceivedData(buffer, bytesReceived);
+    private void OnSocketReadCompleted(SocketReadCompleted result) {
+        ProcessReceivedData(result.Buffer, result.ByteCount);
+    }
+
+    private void OnSocketReadFailed(SocketReadFailed result) {
+        if (_closeOnSocketException) {
+            Logger.Error("SessionActor {Id} receive operation failed: {Message}",
+                Logger.Args(_sessionid, result.Error.Message));
+            Dispose();
+            return;
         }
-        catch (SocketException ex) {
-            if (_closeOnSocketException) {
-                Logger.Error("SessionActor {Id} receive operation failed: {Message}", Logger.Args(_sessionid, ex.Message));
-                this.Dispose();
-            }
-        }
+
+        // Schedule the next read — the socket stays open when
+        // _closeOnSocketException is false.
+        StartReceive();
     }
 
     private void ProcessReceivedData(byte[] buffer, int bytesReceived) {

--- a/src/Imlight.CoreLib/Shared/Networking/ZonePriorityMailbox.cs
+++ b/src/Imlight.CoreLib/Shared/Networking/ZonePriorityMailbox.cs
@@ -1,0 +1,22 @@
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Dispatch;
+using Imlight.CoreLib.Shared.Packets;
+
+namespace Imlight.CoreLib.Shared.Networking;
+
+public class ZonePriorityMailbox : UnboundedPriorityMailbox {
+
+    public ZonePriorityMailbox(Settings settings, Config config)
+        : base(settings, config) { }
+
+    protected override int PriorityGenerator(object message) {
+        return message switch {
+            ZONE_102_PROTOCOL.MSG_PLAYERMOVE    => 0,
+            ZONE_102_PROTOCOL.MSG_CREATUREMOVE  => 1,
+            ZONE_102_PROTOCOL.MSG_ZONEBROADCAST => 2,
+            _ => 10,
+        };
+    }
+
+}

--- a/src/Imlight.CoreLib/Shared/Packets/PATCH_105_PROTOCOL.cs
+++ b/src/Imlight.CoreLib/Shared/Packets/PATCH_105_PROTOCOL.cs
@@ -41,7 +41,8 @@ public sealed class PATCH_105_PROTOCOL : IServerProtocol {
         public uint Version;
         public uint CRC;
         public uint Size;
-        
+        public uint FileTime;
+
     }
 
     public class MSG_DOWNLOAD_WAD_REQUEST : IServerMessage {

--- a/src/Imlight.CoreLib/Shared/Packets/SERVER_100_PROTOCOL.cs
+++ b/src/Imlight.CoreLib/Shared/Packets/SERVER_100_PROTOCOL.cs
@@ -315,5 +315,50 @@ public sealed class SERVER_100_PROTOCOL : IServerProtocol {
         public ushort[] PlayerLimits;
 
     }
+
+    /// <summary>
+    /// Internal aggregate carrying concurrent game-server query results back to
+    /// GameServerPool for final "best server" selection.  Carries the original
+    /// requester so the follow-up handler can reply to the correct session.
+    /// </summary>
+    public class MSG_QUERYGAMESERVER_AGGREGATE : IServerMessage {
+
+        public byte MessageOrder { get; } = 28;
+        public byte ServiceID { get; } = 100;
+
+        public IActorRef OriginalSender;
+        public MSG_SERVERINFO[] ServerInfos;
+
+    }
+
+    /// <summary>
+    /// Internal aggregate carrying concurrent find-player query results back to
+    /// GameServerPool so it can check whether the target IP is connected.
+    /// </summary>
+    public class MSG_FINDPLAYER_AGGREGATE : IServerMessage {
+
+        public byte MessageOrder { get; } = 29;
+        public byte ServiceID { get; } = 100;
+
+        public IActorRef OriginalSender;
+        public string TargetIp;
+        public MSG_SERVERINFO[] ServerInfos;
+
+    }
+
+    /// <summary>
+    /// Internal aggregate carrying concurrent realm-list query results back to
+    /// GameServerPool for final assembly of the MSG_REALMLIST response.
+    /// </summary>
+    public class MSG_REALMLIST_AGGREGATE : IServerMessage {
+
+        public byte MessageOrder { get; } = 30;
+        public byte ServiceID { get; } = 100;
+
+        public IActorRef OriginalSender;
+        public string[] RealmNames;
+        public ushort[] PlayerCounts;
+
+    }
     
 }

--- a/src/Imlight.CoreLib/Shared/Packets/SERVICE_101_PROTOCOL.cs
+++ b/src/Imlight.CoreLib/Shared/Packets/SERVICE_101_PROTOCOL.cs
@@ -109,4 +109,39 @@ internal sealed class SERVICE_101_PROTOCOL : IServerProtocol {
 
     }
 
+    /// <summary>
+    /// Timer callback carrying deferred teleport parameters through a 2s delay.
+    /// </summary>
+    public class MSG_TELEPORT_DELAY : IServerMessage {
+
+        public byte MessageOrder { get; } = 12;
+        public byte ServiceID { get; } = 101;
+
+        public string DestinationZone;
+        public string DestinationLocation;
+        public bool MakePrivate;
+        public ulong OwnerCharId;
+
+    }
+
+    /// <summary>
+    /// Timer signal indicating the 2s recall delay has elapsed.
+    /// </summary>
+    public class MSG_RECALL_DELAY : IServerMessage {
+
+        public byte MessageOrder { get; } = 13;
+        public byte ServiceID { get; } = 101;
+
+    }
+
+    /// <summary>
+    /// Timer signal indicating the zone-transfer cleanup delay has elapsed.
+    /// </summary>
+    public class MSG_ZONETRANSFER_DELAY : IServerMessage {
+
+        public byte MessageOrder { get; } = 14;
+        public byte ServiceID { get; } = 101;
+
+    }
+
 }

--- a/src/Imlight.CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
+++ b/src/Imlight.CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
@@ -752,4 +752,17 @@ public class ZONE_102_PROTOCOL : IServerProtocol {
 
     }
 
+    /// <summary>
+    /// PipeTo aggregate carrying concurrent wizard-query results for a wizbang update tick.
+    /// </summary>
+    public sealed class MSG_WIZBANG_UPDATE_RESULT : IServerMessage {
+
+        public byte MessageOrder { get; } = 52;
+        public byte ServiceID { get; } = 102;
+
+        public IActorRef[] PlayerActors;
+        public Wizard[] Wizards;
+
+    }
+
 }

--- a/src/Imlight.CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
+++ b/src/Imlight.CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
@@ -17,6 +17,7 @@
  */
 
 using System.Collections.Generic;
+using System;
 using Akka.Actor;
 using Imcodec.Math;
 using Imcodec.IO;
@@ -30,6 +31,22 @@ using Imcodec.MessageLayer.Generated;
 using Imcodec.Types;
 
 namespace Imlight.CoreLib.Shared.Packets;
+
+/// <summary>
+/// Bitmask selecting which zone supervisors receive a broadcast.
+/// </summary>
+[Flags]
+public enum ZoneBroadcastTarget : byte {
+    None    = 0,
+    Players = 1 << 0,
+    Objects = 1 << 1,
+    Volumes = 1 << 2,
+    Triggers = 1 << 3,
+    Paths   = 1 << 4,
+    Sigils  = 1 << 5,
+    All         = Players | Objects | Volumes | Triggers | Paths | Sigils,
+    AllNoPlayers = All & ~Players,
+}
 
 public class ZONE_102_PROTOCOL : IServerProtocol {
 
@@ -352,8 +369,9 @@ public class ZONE_102_PROTOCOL : IServerProtocol {
     }
 
     /// <summary>
-    /// Called and sent to a <see cref="Zone"/> to broadcast a particular message
-    /// to other <see cref="SessionActor"/>s within that zone.
+    /// Called and sent to a <see cref="Zone"/> to broadcast a message
+    /// to the zone.  Carries an optional client-visible <see cref="IMessage"/>
+    /// and/or optional server-internal <see cref="IServerMessage"/> array.
     /// </summary>
     public class MSG_ZONEBROADCAST : IServerMessage {
 
@@ -366,35 +384,26 @@ public class ZONE_102_PROTOCOL : IServerProtocol {
         public IActorRef Sender;
 
         /// <summary>
-        /// The message to broadcast.
+        /// Client-visible message (e.g. movement, state change, wizbang).
+        /// May be null when only server messages are present.
         /// </summary>
         public IMessage Message;
+
+        /// <summary>
+        /// Server-internal messages to forward to zone entities.
+        /// May be null when only a client message is present.
+        /// </summary>
+        public IServerMessage[] Messages;
 
         /// <summary>
         /// True, if the message should not be sent to the sender.
         /// </summary>
         public bool Selfless;
 
-    }
-
-    /// <summary>
-    /// Called and sent to a <see cref="Zone"/> to broadcast a particular message
-    /// to all <see cref="ZoneEntity"/>s within that zone.
-    /// </summary>
-    public class MSG_ZONESUPERVISORBROADCAST : IServerMessage {
-
-        public byte MessageOrder { get; } = 21;
-        public byte ServiceID { get; } = 102;
-
         /// <summary>
-        /// The actor that sent the message.
+        /// Which supervisors the zone should forward this message to.
         /// </summary>
-        public IActorRef Sender;
-
-        /// <summary>
-        /// The messages to broadcast.
-        /// </summary>
-        public IServerMessage[] Messages;
+        public ZoneBroadcastTarget Targets = ZoneBroadcastTarget.All;
 
     }
 

--- a/src/Imlight.CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
+++ b/src/Imlight.CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
@@ -737,4 +737,19 @@ public class ZONE_102_PROTOCOL : IServerProtocol {
 
     }
 
+    /// <summary>
+    /// PipeTo aggregate carrying the result of an instance-container zone-exists query
+    /// back to GameWorld for final processing.
+    /// </summary>
+    public sealed class MSG_INSTANCECONTAINER_QUERY_RESULT : IServerMessage {
+
+        public byte MessageOrder { get; } = 51;
+        public byte ServiceID { get; } = 102;
+
+        public IActorRef OriginalSender;
+        public MSG_INSTANCECONTAINERHASZONERSP Response;
+        public MSG_ZONETRANSFER OriginalTransfer;
+
+    }
+
 }

--- a/src/Imlight.CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
+++ b/src/Imlight.CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
@@ -774,4 +774,14 @@ public class ZONE_102_PROTOCOL : IServerProtocol {
 
     }
 
+    /// <summary>
+    /// Periodic timer tick that flushes batched player/creature moves to supervisors.
+    /// </summary>
+    public sealed class MSG_FLUSHMOVES : IServerMessage {
+
+        public byte MessageOrder { get; } = 53;
+        public byte ServiceID { get; } = 102;
+
+    }
+
 }

--- a/src/Imlight.CoreLib/Shared/Resources/CoreObjectFactory.cs
+++ b/src/Imlight.CoreLib/Shared/Resources/CoreObjectFactory.cs
@@ -37,10 +37,11 @@
  * 
  * Created by: Jooty
  * Version: KALI 1.0
- * Last Updated: 3/18/2025
+ * Last Updated: 06/27/2026
  */
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Imcodec.Cryptography;
@@ -61,8 +62,7 @@ public class CoreObjectFactory : RootSingleResourceSingleton<CoreObjectFactory>,
 
     public static TemplateManifest TemplateManifest;
 
-    private static readonly Dictionary<ulong, CoreTemplate> s_templateCache = [];
-    private static readonly object s_templateCacheLock = new();
+    private static readonly ConcurrentDictionary<ulong, CoreTemplate> s_templateCache = new();
 
     protected override void AfterLoad() {
         var serializer = new BindSerializer();
@@ -161,35 +161,28 @@ public class CoreObjectFactory : RootSingleResourceSingleton<CoreObjectFactory>,
     /// <param name="id">The ID of the CoreTemplate.</param>
     /// <returns>The CoreTemplate object if found; otherwise, null.</returns>
     public static CoreTemplate GetCoreTemplate(ulong id) {
-        // Check if the template is already cached.
-        lock (s_templateCacheLock) {
-            if (s_templateCache.TryGetValue(id, out var cachedTemplate)) {
-                return cachedTemplate;
+        if (s_templateCache.TryGetValue(id, out var cachedTemplate)) {
+            return cachedTemplate;
+        }
+
+        // Slow path: load from disk.
+        return s_templateCache.GetOrAdd(id, _ => {
+            var templateLocation = TemplateManifest.m_serializedTemplates
+                .FirstOrDefault(x => x.m_id == id);
+            if (templateLocation is null) {
+                Logger.Error("Could not find CoreTemplate by ID {Tid}. Finding the template failed.", 
+                    Logger.Args(id));
+                return null;
             }
-        }
 
-        // If not cached, load the template from the manifest.
-        var templateLocation = TemplateManifest.m_serializedTemplates.FirstOrDefault(x => x.m_id == id);
-        if (templateLocation is null) {
-            Logger.Error("Could not find CoreTemplate by ID {Tid}. Finding the template failed.", 
-                Logger.Args(id));
-
-            return null;
-        }
-
-        var templateObj = RootArchiveLoader.GetFile<CoreTemplate>(templateLocation.m_filename);
-        if (templateObj is null) {
-            Logger.Error("Could not load CoreTemplate from {Loc}. Could not get file from root archive.",
-                Logger.Args(templateLocation.m_filename));
-        }
-        else {
-            // Cache the template for future use.
-            lock (s_templateCacheLock) {
-                s_templateCache[id] = templateObj;
+            var templateObj = RootArchiveLoader.GetFile<CoreTemplate>(templateLocation.m_filename);
+            if (templateObj is null) {
+                Logger.Error("Could not load CoreTemplate from {Loc}. Could not get file from root archive.",
+                    Logger.Args(templateLocation.m_filename));
             }
-        }
 
-        return templateObj ?? null;
+            return templateObj;
+        });
     }
 
     /// <summary>

--- a/src/Imlight.CoreLib/Shared/Services/ControlService.cs
+++ b/src/Imlight.CoreLib/Shared/Services/ControlService.cs
@@ -26,9 +26,7 @@ using Imlight.CoreLib.Shared.Packets;
 
 namespace Imlight.CoreLib.Shared.Services;
 
-internal class ControlService : MessageService, IWithTimers {
-
-    public ITimerScheduler Timers { get; set; }
+internal class ControlService : MessageService {
 
     private readonly byte _keepAliveInterval = ConfigurationManager.Settings["Advanced.KeepAliveInterval"].AsByte();
     private readonly byte _keepAliveRspWaitTime = ConfigurationManager.Settings["Advanced.KeepAliveRspWaitTime"].AsByte();

--- a/src/Imlight.CoreLib/WizardData/Collections/OnlinePlayerCollection.cs
+++ b/src/Imlight.CoreLib/WizardData/Collections/OnlinePlayerCollection.cs
@@ -41,7 +41,7 @@
 using Imlight.CoreLib.WizardData.Databases;
 using Imlight.CoreLib.WizardData.Models.Misc;
 using Raven.Client.Documents;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 
 namespace Imlight.CoreLib.WizardData.Collections;
@@ -51,7 +51,7 @@ public static class OnlinePlayerCollection {
     public const string CollectionName = "OnlinePlayers";
     private static readonly IDocumentStore s_store;
 
-    private static readonly List<OnlinePlayer> s_onlinePlayerCache = [];
+    private static readonly ConcurrentDictionary<ulong, OnlinePlayer> s_onlinePlayerCache = new();
 
     static OnlinePlayerCollection() 
         => s_store = PlayerDatabase.Instance.Store;
@@ -61,13 +61,11 @@ public static class OnlinePlayerCollection {
     /// </summary>
     /// <param name="onlinePlayer">The online player to add.</param>
     public static void AddOnlinePlayer(OnlinePlayer onlinePlayer) {
-        // If the ID is already present in the cache, replace it with the new one.
-        var existingPlayer = s_onlinePlayerCache
-            .FirstOrDefault(x => x is not null && x.AccountId == onlinePlayer.AccountId);
-        if (existingPlayer != null) {
-            s_onlinePlayerCache.Remove(existingPlayer);
-        }
-        s_onlinePlayerCache.Add(onlinePlayer);
+        s_onlinePlayerCache.AddOrUpdate(
+            onlinePlayer.AccountId,
+            onlinePlayer,
+            (_, _) => onlinePlayer
+        );
 
         // Store the online player in the database.
         using var session = s_store.OpenSession();
@@ -85,7 +83,7 @@ public static class OnlinePlayerCollection {
     /// <param name="accountId">The character ID of the online player to remove.</param>
     public static void RemoveOnlinePlayer(ulong accountId) {
         // Remove from the cache.
-        s_onlinePlayerCache.RemoveAll(x => x.AccountId == accountId);
+        s_onlinePlayerCache.TryRemove(accountId, out _);
 
         using var session = s_store.OpenSession();
 
@@ -103,8 +101,12 @@ public static class OnlinePlayerCollection {
     /// </summary>
     /// <param name="sessionId">The session ID of the online player to remove.</param>
     public static void RemoveOnlinePlayer(ushort sessionId) {
-        // Remove from the cache.
-        s_onlinePlayerCache.RemoveAll(x => x.SessionId == sessionId);
+        // Scan the snapshot and remove every entry with a matching SessionId.
+        foreach (var kvp in s_onlinePlayerCache) {
+            if (kvp.Value.SessionId == sessionId) {
+                s_onlinePlayerCache.TryRemove(kvp.Key, out _);
+            }
+        }
 
         using var session = s_store.OpenSession();
 
@@ -123,24 +125,24 @@ public static class OnlinePlayerCollection {
     /// <returns>An array of online players.</returns>
     public static OnlinePlayer[] GetOnlinePlayers() {
         // If the cache is not empty, return the cached players.
-        if (s_onlinePlayerCache.Count > 0) {
-            return [.. s_onlinePlayerCache];
+        if (!s_onlinePlayerCache.IsEmpty) {
+            return s_onlinePlayerCache.Values.ToArray();
         }
 
         // Otherwise, query the database for online players.
         using var session = s_store.OpenSession();
 
-        return [.. session.Query<OnlinePlayer>(collectionName: CollectionName)];
+        return session.Query<OnlinePlayer>(collectionName: CollectionName).ToArray();
     }
 
     /// <summary>
-    /// Retrieves the online player with the specified account ID from the collection.
+    /// Retrieves the online player with the specified character ID from the collection.
     /// </summary>
     /// <param name="characterId">The character ID of the online player to retrieve.</param>
-    /// <returns>The online player with the specified account ID, or null if not found.</returns>
+    /// <returns>The online player with the specified character ID, or null if not found.</returns>
     public static OnlinePlayer GetOnlinePlayer(ulong characterId) {
-        // Check the cache first.
-        var cachedPlayer = s_onlinePlayerCache
+        // Check the cache first.  Values snapshot is safe for concurrent reads.
+        var cachedPlayer = s_onlinePlayerCache.Values
             .FirstOrDefault(x => x.CharacterId == characterId);
         if (cachedPlayer != null) {
             return cachedPlayer;
@@ -161,7 +163,7 @@ public static class OnlinePlayerCollection {
     /// <returns>An array of online players in the specified zone.</returns>
     public static OnlinePlayer[] GetPlayersInZone(string zone) {
         // Check the cache first.
-        var cachedPlayers = s_onlinePlayerCache
+        var cachedPlayers = s_onlinePlayerCache.Values
             .Where(x => x.CurrentZone == zone)
             .ToArray();
         if (cachedPlayers.Length > 0) {
@@ -171,9 +173,10 @@ public static class OnlinePlayerCollection {
         // If not found in the cache, query the database.
         using var session = s_store.OpenSession();
 
-        return [.. session
+        return session
             .Query<OnlinePlayer>(collectionName: CollectionName)
-            .Where(x => x.CurrentZone == zone)];
+            .Where(x => x.CurrentZone == zone)
+            .ToArray();
     }
 
     /// <summary>
@@ -183,7 +186,7 @@ public static class OnlinePlayerCollection {
     /// <returns>An array of online players in the specified realm.</returns>
     public static OnlinePlayer[] GetPlayersInRealm(string realm) {
         // Check the cache first.
-        var cachedPlayers = s_onlinePlayerCache
+        var cachedPlayers = s_onlinePlayerCache.Values
             .Where(x => x.CurrentRealm == realm)
             .ToArray();
         if (cachedPlayers.Length > 0) {
@@ -193,9 +196,10 @@ public static class OnlinePlayerCollection {
         // If not found in the cache, query the database.
         using var session = s_store.OpenSession();
 
-        return [.. session
+        return session
             .Query<OnlinePlayer>(collectionName: CollectionName)
-            .Where(x => x.CurrentRealm == realm)];
+            .Where(x => x.CurrentRealm == realm)
+            .ToArray();
     }
 
     public static void Clear() {

--- a/src/Imlight.CoreLib/WizardData/Collections/WizardCollection.cs
+++ b/src/Imlight.CoreLib/WizardData/Collections/WizardCollection.cs
@@ -312,6 +312,24 @@ public static class WizardCollection {
     }
 
     /// <summary>
+    /// Updates the character spellbook behavior for a wizard — persists the
+    /// excluded item spell list and other spellbook state to the database.
+    /// </summary>
+    /// <param name="wizard">The wizard whose spellbook behavior should be persisted.</param>
+    public static void UpdateCharacterSpellbookBehavior(Wizard wizard) {
+        using var session = s_store.OpenSession();
+
+        var existingCharacter = session.Query<Wizard>(collectionName: CollectionName)
+            .FirstOrDefault(x => x.CharId == wizard.CharId);
+        if (existingCharacter is null) {
+            return;
+        }
+
+        existingCharacter.SpellbookBehavior = wizard.SpellbookBehavior;
+        session.SaveChanges();
+    }
+
+    /// <summary>
     /// Updates the character game stats for a wizard.
     /// </summary>
     /// <param name="wizard">The wizard object containing the updated game stats</param>

--- a/src/Imlight.Director/Config/Imlight.ini
+++ b/src/Imlight.Director/Config/Imlight.ini
@@ -69,7 +69,7 @@ PatchServerName = Imlight.Patch
 ; The port used by the patch server.
 PatchServerPort = 12500
 ; The URL to the patch server.
-PatchServerInternalUrl = https://patcher.phill030.de
+PatchServerInternalUrl = https://127.0.0.1
 ; The time in seconds that the patch server will wait to reach the endpoint before timing out.
 PatchServerInternalTimeout = 10
 ; The time in seconds that any given download will wait before timing out.
@@ -121,7 +121,7 @@ CharacterUploadIntervalInMinutes = 6
 ; The salt used to hash the session key.
 SessionKeyHashInput = MAGIC_HATTER
 PatchServerBufferSize = 4096
-PatchServerUserAgent = KingsIsle Patcher
+PatchServerUserAgent = Imlight Patcher
 ; The size of the buffer used by the session actor.
 SessionActorBufferSize = 4096
 ; The thread pool size used by the session actor to send messages.

--- a/src/Imlight.Director/Config/Imlight.ini
+++ b/src/Imlight.Director/Config/Imlight.ini
@@ -1,5 +1,5 @@
 [Global Settings]
-GameRevision = r800683.Wizard_1_610
+GameRevision = r801440.Wizard_1_610
 ; If true, the servers will refuse connections if the game revision does not match.
 EnforceRevision = false
 
@@ -72,7 +72,7 @@ PatchServerName = Imlight.Patch
 ; The port used by the patch server.
 PatchServerPort = 12500
 ; The URL to the patch server.
-PatchServerInternalUrl = https://127.0.0.1
+PatchServerInternalUrl = http://127.0.0.1:12369
 ; The time in seconds that the patch server will wait to reach the endpoint before timing out.
 PatchServerInternalTimeout = 10
 ; The time in seconds that any given download will wait before timing out.

--- a/src/Imlight.Director/Config/akka.conf
+++ b/src/Imlight.Director/Config/akka.conf
@@ -4,6 +4,15 @@
 
   actor {
       provider = remote
+
+      mailbox {
+        requirements {
+          "akka.dispatch.unbounded-priority-mailbox" = zone-priority
+        }
+        zone-priority {
+          mailbox-type = "Imlight.CoreLib.Shared.Networking.ZonePriorityMailbox, Imlight.CoreLib"
+        }
+      }
   }
 
   remote {

--- a/src/Imlight.Director/Imlight.Director.csproj
+++ b/src/Imlight.Director/Imlight.Director.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changelog
* Fixed the latest file list binary crc calculation
* Fixed the quest behavior using the wrong delimiter (`.` to `_`)
* Fixed the `ResHasEntryHandler` using a bad conditional for quest registry
* Fixed some duel sigils clipping with the ground or not visible at all
* Fixed the `QuestMadlibs` to gracefully fail when a template ID isn't present for a persona
* Fixed mobs passing every turn
* Fixed health/mana/energy updating the client on level up but not actually saving to the database
* Fixed the patch server
* Fixed #126
* Fixed #127
* Fixed #128
* Fixed #130
* Fixed #132
* Fixed #133
* Fixed #134
* Fixed #135
* Fixed `OnlinePlayerCollection` thread safety
* Added new fields to the latest file list network messages
* Added `ReqHasGoalHandler`
* Added `ResModifyEntryHandler`
* Updated entire suite to dotnet 10
* Updated the RavenDB version `6.2.2` -> `7.2.4`
* Removed the default `PatchServerInternalUrl` and replaced it with `http://127.0.0.1:12369`
* Changed the `GameServerPool` to aggregate queries instead of blocking the entire queue when one game server was slow to respond
* Changed the `SessionActor` to be directly passed the actor factory 
* Changed all places where `Task.Delay` was used and replaced it with proper timer conventions
* Changed the `InteractServiceMementoComponent` to guard against queries if no players are in range
* Changed the `InteractServiceMementoComponent` to query all players in range concurrently instead of at once
* Changed result handlers to self destruct after execution
* Changed creature zone move to only be routed to the combat sigil supervisor
* Changed the player movement zone broadcast to only route to the player supervisor
* Changed the player fish interval broadcast to the zone supervisors that actually use it
* Changed zones to no longer broadcast creature moves if no players are present in the zone
* Changed combat to used `Random.Shared` rather than instantiation each time
* Changed `CoreObjectFactory.GetCoreTemplate()` to fetch from a concurrent dictionary cache
* Changed the `SocketReceiver` to use `ReceiveAsync()`
* Changed the `ReceiveProtocolDispatcher` to no longer invoke dynamic methods, but create concrete actions
* Changed the `SessionActor` to appropriately map out message paths on start rather than invoking dynamic methods

### Zone Broadcasts
Zone broadcasting ended up with a lot of tech debt. `MSG_ZONESUPERVISORBROADCAST` has been removed. 

Instead, there is now a bitflag class `ZoneBroadcastTarget` which lets `MSG_ZONEBROADCAST` aim broadcasts to zone elements that actually care about them.

For example, creatures publicly broadcast their movement state to *all* zone elements. This means that zone elements like zone triggers are seeing creatures move, which is a wasted message. Instead:
```csharp
var movementMsgBroadcast = new ZONE_102_PROTOCOL.MSG_ZONEBROADCAST {
    Message = movementMsg
    Targets = ZoneBroadcastTarget.Players, // New target.
};
```

A zone broadcast can now be aimed at a zone element, reducing a huge amount of wasted messages.