### PR TITLE
docs: fix broken link in playerarchitecture documentation

### DIFF
--- a/docs/docs/modules/imlight/concepts/playerarchitecture.md
+++ b/docs/docs/modules/imlight/concepts/playerarchitecture.md
@@ -36,7 +36,7 @@ The behavior must be agnostic to the source of its data. It simply represents th
 
 The **Session Actor** is a transient object that represents a player's connection to the server. It is created when a player connects and destroyed when they disconnect. The Session Actor is responsible for managing the player's network connection, handling incoming messages, and sending outgoing messages.
 
-See the [Session Actor article](/imlight/concepts/sessionactor) for more information.
+See the [Session Actor article](./sessionactor.md) for more information.
 
 ### Game Object
 


### PR DESCRIPTION
## Summary
Fixes a broken link found in the playerarchitecture documentation.

## Changes
Updated the broken URL.

---

Hey! I was reading the documentation because I found this project interesting, and I noticed that this link was broken, so I fixed it.

Also, I’d like to take this opportunity to ask about the ":::<text>" syntax. What Markdown viewer or extension are you using? On GitHub, it looks a bit cut off.

Finally, is the tool Imview no longer available? I noticed the link in the Quick Start documentation, but it currently returns a 404.

Either way, impressive project, keep up the great work! :)