### PR TITLE
Fix texture flicker in Unicorn Way (WC_Unicorn) 

### DIFF
--- a/docs/docs/modules/imlight/commands.md
+++ b/docs/docs/modules/imlight/commands.md
@@ -80,6 +80,19 @@ Your command context will not drop. If you select a player, that player will sti
 | cantriplevel | Quality Assurance | `mod cantriplevel $level` | Changes your cantrip level. |
 | badge | Quality Assurance | `mod badge $locale_id` | Changes your badge. This must be a locale id to function. |
 
+## DynaMod Commands
+
+| Command | Security | Syntax | Description |
+| ------- | -------- | ------ | ----------- |
+| list | Quality Assurance | `.dynamod list` | Lists the dynamods on your character. |
+| set | Quality Assurance | `.dynamod set $state $clientTag` | Sets a dynamod to `on` or `off`. Creates it if it does not exist. |
+| toggle | Quality Assurance | `.dynamod toggle $clientTag` | Toggles a dynamod between `on` and `off`. Creates it as `off` if it does not exist. |
+| remove | Quality Assurance | `.dynamod remove $clientTag` | Removes a dynamod from your character. |
+
+:::tip
+The `$clientTag` may contain spaces (e.g. `WC_Rattlebones_ButterFlyZone instance`), so it must always be the last argument. The tag must match the object's `m_zoneTag` exactly to affect it.
+:::
+
 
 ## Spellbook Commands
 | Command | Security | Syntax | Description |

--- a/src/Imlight.CoreLib/Game/Commands/Protocols/CommandDynaModProtocol.cs
+++ b/src/Imlight.CoreLib/Game/Commands/Protocols/CommandDynaModProtocol.cs
@@ -1,0 +1,106 @@
+/*
+ * Imlight
+ * Copyright (C) 2026 Revive101
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Linq;
+using Akka.Actor;
+using Imcodec.ObjectProperty.TypeCache;
+using Imlight.CoreLib.Shared.Packets;
+using Imlight.CoreLib.WizardData.Models.Player;
+
+namespace Imlight.CoreLib.Game.Commands.Protocols;
+
+internal class CommandDynaMod : CommandProtocol {
+
+    internal override string Group { get; set; } = "dynamod";
+
+    [Command("list")]
+    [AuthRequired(AuthLevel.QualityAssurance)]
+    private void ListDynaModsCommand() {
+        var dynamods = Context.Character.DynamodSet?.Dynamods ?? [];
+        if (dynamods.Count == 0) {
+            InformSenderClient("No dynamods on this character.");
+
+            return;
+        }
+
+        var summary = string.Join(", ", dynamods
+            .Where(d => d is not null)
+            .Select(d => $"{d.ClientTag} = {d.ModState}"));
+        InformSenderClient($"Dynamods: {summary}");
+    }
+
+    [Command("set")]
+    [AuthRequired(AuthLevel.QualityAssurance)]
+    private void SetDynaModCommand(string state, [Remainder] string clientTag) {
+        var normalizedState = state.ToLowerInvariant() switch {
+            "on" => "On",
+            "off" => "Off",
+            _ => null
+        };
+        if (normalizedState is null) {
+            InformSenderClient("Invalid state. Use 'on' or 'off'.");
+
+            return;
+        }
+
+        SendDynaModAdd(clientTag, normalizedState);
+        InformSenderClient($"Dynamod '{clientTag}' set to {normalizedState}.");
+    }
+
+    [Command("toggle")]
+    [AuthRequired(AuthLevel.QualityAssurance)]
+    private void ToggleDynaModCommand([Remainder] string clientTag) {
+        var currentState = Context.Character.DynamodSet?.Dynamods?
+            .FirstOrDefault(d => d is not null
+                && d.ClientTag.Equals(clientTag, StringComparison.OrdinalIgnoreCase))?
+            .ModState;
+
+        var newState = string.Equals(currentState, "Off", StringComparison.OrdinalIgnoreCase) ? "On" : "Off";
+
+        SendDynaModAdd(clientTag, newState);
+        InformSenderClient($"Dynamod '{clientTag}' toggled to {newState} (was {(currentState is null ? "not present" : currentState)}).");
+    }
+
+    [Command("remove")]
+    [AuthRequired(AuthLevel.QualityAssurance)]
+    private void RemoveDynaModCommand([Remainder] string clientTag) {
+        var msg = new CHARACTER_103_PROTOCOL.MSG_REMOVEDYNAMOD {
+            DynaMod = new ResRemoveDynaMod {
+                m_dynaModClientTag = clientTag
+            },
+            ContextActor = Context.SessionActor
+        };
+        Context.SessionActor.Tell(msg);
+
+        InformSenderClient($"Dynamod '{clientTag}' removed.");
+    }
+
+    private void SendDynaModAdd(string clientTag, string state) {
+        var msg = new CHARACTER_103_PROTOCOL.MSG_ADDDYNAMOD {
+            DynaMod = new ResAddDynaMod {
+                m_dynaModClientTag = clientTag,
+                m_dynaModState = state,
+                m_zoneName = ""
+            },
+            ContextActor = Context.SessionActor
+        };
+        Context.SessionActor.Tell(msg);
+    }
+
+}

--- a/src/Imlight.Director/Config/Imlight.ini
+++ b/src/Imlight.Director/Config/Imlight.ini
@@ -57,7 +57,7 @@ PacifyAggroDecrease = 50
 
 [Character]
 StartingLevel = 1
-StartingZone = WizardCity/WC_Streets/WC_Unicorn
+StartingZone = WizardCity/Interiors/WC_Headmistress_House
 StartingWorld = 1
 BaseGoldPouch = 1000000
 MaxLevel = 200


### PR DESCRIPTION

Fixes (partially): #140

Fixes the "extreme bugginess with textures" reported in Unicorn Way. The static wall foliage was flickering between a green and a withered state. Those two states come from two zone-wide ambient effects that overlap each other: `WC_Rattlebones_ButterFlyZone instance` (green ivy) and `WC_Rattlebones_FogZone instance` (withered ivy + fog).

Also adds the new `dynamod` debug commands (`list`, `set`, `toggle`, `remove`) used to diagnose and manage character dynamods at runtime.

## Root cause

Unicorn Way renders two overlapping zone-wide ambient effects, both spawned by the server as dynamic objects:

- `WC_Rattlebones_ButterFlyZone instance` renders the **green ivy** (butterflies).
- `WC_Rattlebones_FogZone instance` renders the **withered ivy + fog**.

When both flags are active the two textures overlap, which produces the z-fighting/flicker between green and withered as the player moves.

In addition, the missions did not manage these flags correctly:

- `WC-COMMONS-MAIN-001` turns `ButterFlyZone` to `off`.
- `WC-UNICORN-MAIN-007` turns `FogZone` (and `WC_Debris`) to `off`.
- **No mission ever turned `ButterFlyZone` back to `on`**, so after completing the zone both flags ended up `off` and the "revived" green state never appeared.

## Changes

1. **New characters** default the `WC_Rattlebones_ButterFlyZone instance` dynamod to `off` at creation (`Wizard.cs`), so the object is not spawned for them until it is turned on.
2. **Default spawn** moved to the Headmistress House (`WizardCity/Interiors/WC_Headmistress_House`), where the first quest is given, so new players pick it up immediately and the problem resolves itself. This also helps with the first mission not appearing for fresh characters.
3. Added `dynamod` debug commands (`list`, `set`, `toggle`, `remove`) for QA to manage dynamods at runtime and isolate similar zone effects.

## Dependencies

This fix also depends on **another [pull request](https://github.com/Revive101/spiraldb/pull/1) in spiraldb**. There, the corresponding mission was fixed so it flips the `WC_Rattlebones_ButterFlyZone instance` flag to `on` (before turning the fog off), so the green "revived" state actually appears after completing the zone. Without that quest-side change, `ButterFlyZone` stays `off` and no green shows.

## Verification

- The culprit was isolated by toggling the effects off with the new `dynamod` debug command.
- With `ButterFlyZone = on` and `FogZone = off`, the green ivy appears on its own (the intended revived look) and remains stable.

## Notes

- This PR resolves the **texture bugginess** in Unicorn Way.
- It does **not** yet address the **random white flashes** that occur when standing in certain spots; that remains an open issue.
