### PR TITLE
`Fix/patches` -> `quality-assurance`

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,63 @@
+# Sample workflow for building and deploying the Imlight VitePress docs to GitHub Pages
+name: Deploy docs to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [quality-assurance]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # Not needed if lastUpdated is not enabled
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Install dependencies
+        run: npm ci
+      - name: Build with VitePress
+        run: npm run docs:build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/docs/.vitepress/dist
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/docs/.vitepress/config.mts
+++ b/docs/docs/.vitepress/config.mts
@@ -1,22 +1,24 @@
 import { defineConfig } from 'vitepress'
 import taskLists from 'markdown-it-task-lists';
 
+const base = "/Imlight/";
+
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "Imlight",
   description: "Rewriting Magic",
   srcDir: "modules",
-  base: "/Imlight-docs/",
+  base,
   markdown: {
     config: async (md) => {
       md.use(taskLists);
     }
   },
   head: [
-    ['link', { rel: "apple-touch-icon", sizes: "180x180", href: "/apple-touch-icon.png" }],
-    ['link', { rel: "icon", type: "image/png", sizes: "32x32", href: "/favicon-32x32.png" }],
-    ['link', { rel: "icon", type: "image/png", sizes: "16x16", href: "/favicon-16x16.png" }],
-    ['link', { rel: "shortcut icon", href: "/favicon.ico" }],
+    ['link', { rel: "apple-touch-icon", sizes: "180x180", href: `${base}apple-touch-icon.png` }],
+    ['link', { rel: "icon", type: "image/png", sizes: "32x32", href: `${base}favicon-32x32.png` }],
+    ['link', { rel: "icon", type: "image/png", sizes: "16x16", href: `${base}favicon-16x16.png` }],
+    ['link', { rel: "shortcut icon", href: `${base}favicon.ico` }],
   ],
   themeConfig: {
     logo: '/logo-nobg.png',
@@ -132,7 +134,7 @@ export default defineConfig({
     },
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/Revive101/Imlight-docs' }
+      { icon: 'github', link: 'https://github.com/Revive101/Imlight' }
     ]
   }
 })

--- a/src/Imlight.CoreLib/Game/Combat/CombatDeck.cs
+++ b/src/Imlight.CoreLib/Game/Combat/CombatDeck.cs
@@ -168,8 +168,7 @@ internal class CombatDeck {
         else {
             _cardsDiscardedThisTurn.Add(spell);
 
-            // Free the slot now so a vault draw can be made this turn. GetHand removes the same card
-            // again next round, which is a harmless no-op.
+            // Free the slot now so a vault draw can be made this turn; GetHand's removal is a no-op.
             LastGivenHand.Remove(spell);
         }
     }

--- a/src/Imlight.CoreLib/Game/Combat/CombatDeck.cs
+++ b/src/Imlight.CoreLib/Game/Combat/CombatDeck.cs
@@ -167,6 +167,10 @@ internal class CombatDeck {
         }
         else {
             _cardsDiscardedThisTurn.Add(spell);
+
+            // Free the slot now so a vault draw can be made this turn. GetHand removes the same card
+            // again next round, which is a harmless no-op.
+            LastGivenHand.Remove(spell);
         }
     }
 
@@ -256,7 +260,7 @@ internal class CombatDeck {
             TreasureCardsInHand--;
         }
 
-        // Remove from the persistent vault list (not the used copy — this removes it permanently).
+        // Remove from the persistent vault list (not the used copy; this removes it permanently).
         var vaultEntry = _treasureVault.Find(v => v.TemplateId == spell.m_templateID);
         if (vaultEntry != null) {
             if (vaultEntry.Quantity - 1 <= 0) {

--- a/src/Imlight.CoreLib/Game/Combat/CombatDuelSubCircle.cs
+++ b/src/Imlight.CoreLib/Game/Combat/CombatDuelSubCircle.cs
@@ -194,12 +194,10 @@ public class CombatDuelSubCircle {
         return newHand;
     }
 
-    /// <summary>
-    /// The hand exactly as it stands now, with no draw or refill. After a discard frees a slot, this lets
-    /// the client see the open slot so it can offer the vault draw. DrawHand would refill the slot instead.
-    /// </summary>
-    internal Hand GetCurrentHand()
-        => new() { m_spellList = _combatDeck.LastGivenHand ?? [] };
+    internal Hand GetCurrentHand() {
+        // As-is, no draw or refill: a discard frees a slot this turn and the client must see it open.
+        return new() { m_spellList = _combatDeck.LastGivenHand ?? [] };
+    }
 
     internal void DiscardCard(Spell spell) {
         _combatDeck.Discard(spell);
@@ -442,10 +440,8 @@ public class CombatDuelSubCircle {
                 var isTreasureCard = template is SpellTemplate spellTemplate
                     && (spellTemplate.m_Treasure || spellTemplate.m_name.EndsWith(" TC"));
 
-                // A deck entry the player hasn't learned can only be a treasure card: the deck editor
-                // accepts learned spells and TCs, and item cards live in TemporarySpells. This catches
-                // TCs whose template m_Treasure flag isn't set. Guarded on a populated list so an empty
-                // list can't misclassify the whole deck.
+                // A deck entry the player hasn't learned can only be a treasure card (item cards live in
+                // TemporarySpells). Guarded on a populated list so an empty list can't misclassify the deck.
                 if (!isTreasureCard
                     && _wizard.SpellbookBehavior.LearnedSpellTemplateIds is { Count: > 0 }
                     && !_wizard.SpellbookBehavior.LearnedSpellTemplateIds.Contains(spell.m_templateID)) {

--- a/src/Imlight.CoreLib/Game/Combat/CombatDuelSubCircle.cs
+++ b/src/Imlight.CoreLib/Game/Combat/CombatDuelSubCircle.cs
@@ -194,6 +194,13 @@ public class CombatDuelSubCircle {
         return newHand;
     }
 
+    /// <summary>
+    /// The hand exactly as it stands now, with no draw or refill. After a discard frees a slot, this lets
+    /// the client see the open slot so it can offer the vault draw. DrawHand would refill the slot instead.
+    /// </summary>
+    internal Hand GetCurrentHand()
+        => new() { m_spellList = _combatDeck.LastGivenHand ?? [] };
+
     internal void DiscardCard(Spell spell) {
         _combatDeck.Discard(spell);
     }
@@ -434,6 +441,16 @@ public class CombatDuelSubCircle {
                 var template = CoreObjectFactory.GetCoreTemplate(spell.m_templateID);
                 var isTreasureCard = template is SpellTemplate spellTemplate
                     && (spellTemplate.m_Treasure || spellTemplate.m_name.EndsWith(" TC"));
+
+                // A deck entry the player hasn't learned can only be a treasure card: the deck editor
+                // accepts learned spells and TCs, and item cards live in TemporarySpells. This catches
+                // TCs whose template m_Treasure flag isn't set. Guarded on a populated list so an empty
+                // list can't misclassify the whole deck.
+                if (!isTreasureCard
+                    && _wizard.SpellbookBehavior.LearnedSpellTemplateIds is { Count: > 0 }
+                    && !_wizard.SpellbookBehavior.LearnedSpellTemplateIds.Contains(spell.m_templateID)) {
+                    isTreasureCard = true;
+                }
 
                 if (isTreasureCard) {
                     // Treasure cards go to the vault (separate pool, drawn on demand).

--- a/src/Imlight.CoreLib/Game/Results/Handlers/ResDropTableHandler.cs
+++ b/src/Imlight.CoreLib/Game/Results/Handlers/ResDropTableHandler.cs
@@ -166,7 +166,7 @@ internal sealed class ResDropTableHandler : BaseResultHandler<ResDropTable> {
 
     private static void SendLootInfoToClient(IActorRef playerActor, DropTableResult results, Wizard wizard) {
         // Inform the game client of the loot results.
-        if (results.Items.Count == 0) {
+        if (!DropTableConverter.HasRewards(results)) {
             return;
         }
 

--- a/src/Imlight.CoreLib/Game/Services/EquipmentService.cs
+++ b/src/Imlight.CoreLib/Game/Services/EquipmentService.cs
@@ -54,7 +54,9 @@ using Imlight.Common;
 using Imlight.CoreLib.Shared.Items;
 using Imlight.CoreLib.Shared.Networking;
 using Imlight.CoreLib.Shared.Packets;
+using Imlight.CoreLib.WizardData.Collections;
 using Imlight.CoreLib.WizardData.Models.Misc;
+using Imlight.CoreLib.WizardData.Models.Player;
 
 namespace Imlight.CoreLib.Game.Services;
 
@@ -142,6 +144,12 @@ internal class EquipmentService(SessionActor sessionActor) : MessageService(sess
         SendEquipItem(item, message.SlotName);
         SendAddEffects(effects);
 
+        // A mount equipped indoors is dismounted right away; the reconcile no-ops in the open world.
+        if (Enum.TryParse<EquipmentSlotType>(message.SlotName, true, out var equippedSlot)
+            && equippedSlot == EquipmentSlotType.Mount) {
+            SessionActor.ActorRef.Tell(new ZONE_102_PROTOCOL.MSG_ENFORCEINTERIORMOUNT());
+        }
+
         // If removedEffects is not null, the Wizard replaced an item with another item that has different effects.
         // We need to remove the old effects from the client.
         if (removedEffects is not null) {
@@ -183,6 +191,76 @@ internal class EquipmentService(SessionActor sessionActor) : MessageService(sess
 
         SendUnequipItem(message.SlotName, slot, itemId);
         SendRemoveEffects(removedEffects);
+
+        // A manual unequip abandons any pending auto-remount.
+        if (Enum.TryParse<EquipmentSlotType>(message.SlotName, true, out var unequippedSlot)
+            && unequippedSlot == EquipmentSlotType.Mount
+            && wizard.InteriorStowedMountId != 0) {
+            wizard.InteriorStowedMountId = 0;
+            WizardCollection.UpdateCharacterInteriorStowedMount(wizard);
+        }
+    }
+
+    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ENFORCEINTERIORMOUNT))]
+    private void ReceiveEnforceInteriorMount(ZONE_102_PROTOCOL.MSG_ENFORCEINTERIORMOUNT message) {
+        // Zone data flags disallow mounts (m_noMounts): really unequip on entry (model and speed effect) and
+        // re-equip on leaving. The stowed GID is persisted so it survives the zone transfer.
+        try {
+            var wizard = GetActiveWizard();
+            var equip = wizard.EquipmentBehavior;
+
+            if (ZoneDisallowsMounts()) {
+                var mount = equip.GetItemInSlot(EquipmentSlotType.Mount);
+                if (mount is null) {
+                    return; // not mounted, nothing to dismount
+                }
+
+                var slot = equip.GetSlotOfItem(mount.m_globalID);
+                if (!wizard.EquipmentToInventoryTransfer(mount.m_globalID, out var removedEffects)) {
+                    Logger.Warning("Interior dismount transfer failed for mount {0}", Logger.Args(mount.m_globalID));
+
+                    return;
+                }
+
+                wizard.InteriorStowedMountId = mount.m_globalID;
+                WizardCollection.UpdateCharacterInteriorStowedMount(wizard);
+                SendUnequipItem("Mount", slot, mount.m_globalID); // drops the model client-side
+                SendRemoveEffects(removedEffects);                // drops the mount speed effect
+            }
+            else if (wizard.InteriorStowedMountId != 0) {
+                var gid = wizard.InteriorStowedMountId;
+                wizard.InteriorStowedMountId = 0;
+                WizardCollection.UpdateCharacterInteriorStowedMount(wizard);
+
+                if (!wizard.InventoryToEquipmentTransfer(gid, out var addedEffects, out _)) {
+                    Logger.Warning("Outdoor remount transfer failed for mount {0}", Logger.Args(gid));
+
+                    return;
+                }
+
+                var item = equip.GetItemInSlot(EquipmentSlotType.Mount);
+                if (item is not null) {
+                    SendEquipItem(item, "Mount");
+                }
+                SendAddEffects(addedEffects); // restores the mount speed
+            }
+        }
+        catch (Exception ex) {
+            Logger.Error("Error while reconciling the mount for the zone: {0} {1}",
+                Logger.Args(ex.Message, ex.StackTrace));
+        }
+    }
+
+    private bool ZoneDisallowsMounts() {
+        var zoneActor = SessionActor.GetZoneActor();
+        if (zoneActor is null) {
+            return false;
+        }
+
+        var rsp = zoneActor.Ask<ZONE_102_PROTOCOL.MSG_QUERYZONEDATARSP>(
+            new ZONE_102_PROTOCOL.MSG_QUERYZONEDATA(), TimeSpan.FromSeconds(5)).Result;
+
+        return rsp?.ZoneData?.m_noMounts ?? false;
     }
 
     private void SendEquipItem(WizClientObjectItem item, string slotName) {

--- a/src/Imlight.CoreLib/Game/Services/ZoneService.cs
+++ b/src/Imlight.CoreLib/Game/Services/ZoneService.cs
@@ -289,6 +289,9 @@ internal class ZoneService(SessionActor sessionActor) : MessageService(sessionAc
         // I've just been added to a zone. I need to spawn myself for all the other players.
         SpawnMyself();
 
+        // Dismount in no-mount zones, re-equip on leaving (EquipmentService owns the reconcile).
+        SessionActor.ActorRef.Tell(new ZONE_102_PROTOCOL.MSG_ENFORCEINTERIORMOUNT());
+
         if (_randomBackflips) {
             var wizard = GetActiveWizard();
             Timers.StartPeriodicTimer("backflip", new ZONE_102_PROTOCOL.MSG_RANDOMFLIPS {
@@ -468,7 +471,7 @@ internal class ZoneService(SessionActor sessionActor) : MessageService(sessionAc
         catch { }
 
         // Serialize the realm list as a RealmInfoList PropertyClass blob.
-        // The client expects this exact type — we cannot fabricate the format.
+        // The client expects this exact type; we cannot fabricate the format.
         var realmInfoList = new RealmInfoList {
             m_infoList = []
         };
@@ -490,7 +493,7 @@ internal class ZoneService(SessionActor sessionActor) : MessageService(sessionAc
             return;
         }
 
-        // Serialize an empty instance list — the client requires a valid
+        // Serialize an empty instance list; the client requires a valid
         // InstanceInfoList PropertyClass blob, not an empty string.
         var instanceInfoList = new InstanceInfoList {
             m_instanceList = new List<InstanceInfo>()
@@ -537,7 +540,7 @@ internal class ZoneService(SessionActor sessionActor) : MessageService(sessionAc
         }
 
         if (!keyRsp.Success) {
-            Logger.Warning("Realm transfer to {Realm} failed — realm not found.",
+            Logger.Warning("Realm transfer to {Realm} failed; realm not found.",
                 Logger.Args(message.RealmName));
 
             return;

--- a/src/Imlight.CoreLib/Game/World/GameWorld.cs
+++ b/src/Imlight.CoreLib/Game/World/GameWorld.cs
@@ -218,7 +218,7 @@ public class GameWorld : ReceiveProtocolDispatcher, IWithTimers {
             return;
         }
 
-        // Capture sender before async work — Akka Sender is context-bound.
+        // Capture sender before async work; Akka Sender is context-bound.
         var originalSender = Sender;
 
         var hasZoneMsg = new ZONE_102_PROTOCOL.MSG_INSTANCECONTAINERHASZONE {
@@ -241,14 +241,21 @@ public class GameWorld : ReceiveProtocolDispatcher, IWithTimers {
         var message = result.OriginalTransfer;
 
         if (result.Response == null || !result.Response.HasZone) {
-            CreateZoneLoader(message.DestinationZone);
+            // A loader may already be in progress; a second player can enter the same instance zone while it
+            // is still loading. Only spin up one loader (and register its owner once); the extra transfer just
+            // queues and is handled when the zone finishes loading. These results arrive one at a time on the
+            // GameWorld actor thread, so even though the Asks ran concurrently, this guard still prevents a
+            // duplicate loader or a duplicate owner registration.
+            if (!_zoneLoaderActors.ContainsKey(message.DestinationZone)) {
+                CreateZoneLoader(message.DestinationZone);
+                _instanceCreationCalledByMap.Add(message.DestinationZone, message.OwnerCharId);
+            }
             _awaitingTransfers.Add(message, result.OriginalSender);
-            _instanceCreationCalledByMap.Add(message.DestinationZone, message.OwnerCharId);
 
             return;
         }
 
-        // Instance container has the zone — forward the transfer to it.
+        // Instance container has the zone; forward the transfer to it.
         _instanceContainers[message.OwnerCharId].Tell(message, result.OriginalSender);
     }
 
@@ -270,8 +277,22 @@ public class GameWorld : ReceiveProtocolDispatcher, IWithTimers {
     }
 
     private IActorRef CreateZoneLoader(string zonePath) {
-        // Create the loader actor and prepare the loading of this zone.
-        var loaderRef = Context.ActorOf(Akka.Actor.Props.Create(() => new ZoneLoader()));
+        // Run the loader on the dedicated zone-loading dispatcher (see akka.conf). Its work, a synchronous WAD
+        // open plus six deserializes, would otherwise run on the default dispatcher, where a burst of
+        // concurrent loads can starve session and handshake processing and drop entering players. Fail-safe:
+        // if the dispatcher cannot be resolved, fall back to the default rather than failing every zone load.
+        IActorRef loaderRef;
+        try {
+            loaderRef = Context.ActorOf(
+                Akka.Actor.Props.Create(() => new ZoneLoader()).WithDispatcher("zone-loading-dispatcher"));
+        }
+        catch (Exception ex) {
+            Logger.Warning("zone-loading-dispatcher unavailable ({Reason}); loading '{ZoneName}' on the default " +
+                "dispatcher instead.", Logger.Args(ex.Message, zonePath));
+            loaderRef = Context.ActorOf(Akka.Actor.Props.Create(() => new ZoneLoader()));
+        }
+
+        Logger.Information("Game world starting zone load: {ZoneName}", Logger.Args(zonePath));
 
         // Tell the loader to begin loading the zone and await the response.
         var msg = new ZONE_102_PROTOCOL.MSG_ZONELOADBEGIN { ZonePath = zonePath };

--- a/src/Imlight.CoreLib/Game/Zone/Components/CombatDuelComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/CombatDuelComponent.cs
@@ -332,8 +332,9 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
                 Logger.Args(Duel.m_duelID.Full, caster.SlotIndex, drawnSpell.m_templateID));
         }
 
-        // Send the updated hand to the participant.
-        SendCombatHand();
+        // Send the current hand so only the drawn treasure is added. A refilling SendCombatHand would
+        // also top every open slot up from the main deck; the refill happens at the next round.
+        SendCurrentCombatHand(caster);
     }
 
     [MessageHandler(typeof(COMBAT_106_PROTOCOL.MSG_ACTORCOMBATMOVE))]
@@ -640,8 +641,8 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
     }
 
     private void SendCombatPhase(byte phase) {
-        // Determine what sigil slot is up first.
-        var upFirstSigilSlot = GetUpFirstSigilSlot();
+        // Determine which participant the client should point its turn indicator at.
+        var upFirstListIndex = GetUpFirstListIndex();
 
         // Serialize the up first data and send it to all the combat participants.
         // This is the one instance where the client sends a versionable object to the client.
@@ -652,7 +653,7 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
 
         var upFirst = new UpFirstData {
             m_resultType = 122, // Always recorded as 122, per packet captures.
-            m_upFirst = upFirstSigilSlot,
+            m_upFirst = upFirstListIndex,
             m_roundNum = Duel.m_roundNum,
         };
         if (!versionableSerializer.Serialize(upFirst, _upFirstFlags, out var upFirstData)) {
@@ -673,13 +674,13 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
     }
 
     private void SendUpFirst(int roundNum) {
-        var upFirstSigilSlot = GetUpFirstSigilSlot();
+        var upFirstListIndex = GetUpFirstListIndex();
 
         var upFirstMsg = new DOODLEDOUG_MESSAGES_51_PROTOCOL.MSG_COMBATUPFIRST {
             DuelID = SigilId,
             RoundNum = (ushort) roundNum,
             FirstTeamToAct = (byte) Duel.m_firstTeamToAct,
-            UpFirst = upFirstSigilSlot,
+            UpFirst = upFirstListIndex,
         };
         ZoneBroadcast(upFirstMsg);
     }
@@ -752,6 +753,34 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
 
             participantActor.Tell(msg);
         });
+    }
+
+    /// <summary>
+    /// Re-sends one participant's hand exactly as it stands now, with no draw or refill. Used after a
+    /// discard (which frees a slot this turn) so the client sees the open slot and can enable the vault
+    /// draw. DrawHand would refill the freed slot from the deck.
+    /// </summary>
+    private void SendCurrentCombatHand(CombatDuelSubCircle circle) {
+        if (circle is null || circle.OccupiedTeam == CombatTeam.Monster) {
+            return;
+        }
+
+        var hand = circle.GetCurrentHand();
+        if (!_serializer.Serialize(hand, _combatParticipantHandFlags, out var buffer)) {
+            Logger.Error("Failed to serialize current combat hand for duel {0}", Logger.Args(SigilId));
+
+            return;
+        }
+
+        var msg = new DOODLEDOUG_MESSAGES_51_PROTOCOL.MSG_COMBATHAND {
+            DeckCount = (byte) circle.AvailableSpells,
+            TotalDeckCount = (ushort) circle.TotalSpells,
+            TreasureCardCount = (ushort) circle.VaultRemainingCount,
+            ParticipantID = circle.ParticipantObject.m_globalID,
+            HandData = buffer,
+        };
+
+        circle.ParticipantActor.Tell(msg);
     }
 
     private void SendCombatPips() {
@@ -848,13 +877,21 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
 
     private void HandleDiscardMove(CombatDuelSubCircle caster, int spellSelection) {
         var spell = caster.GetSpellFromLastHand((byte) spellSelection);
+        if (spell is null) {
+            Logger.Warning("Duel {0} | Slot {1} | Discard received for an empty hand slot ({2}).",
+                Logger.Args(Duel.m_duelID.Full, caster.SlotIndex, spellSelection));
+
+            return;
+        }
+
         caster.DiscardCard(spell);
 
         Logger.Debug("Duel {0} | Slot {1} | Discarded a card: {2}",
             Logger.Args(Duel.m_duelID.Full, caster.SlotIndex, spell.m_templateID.ToString() ?? "None"));
 
-        // Send the updated hand so the client sees the new vault count and replacement card.
-        SendCombatHand();
+        // Re-send the hand as-is so the client sees the freed slot and can offer the vault draw.
+        // SendCombatHand would refill the slot from the deck instead.
+        SendCurrentCombatHand(caster);
     }
 
     private void HandlePassMove(CombatDuelSubCircle caster) {
@@ -868,6 +905,15 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
 
     private void HandleAttackMove(CombatDuelSubCircle caster, int spellSelection, uint spellTarget) {
         var spell = caster.GetSpellFromLastHand((byte) spellSelection);
+        if (spell is null) {
+            Logger.Warning("Duel {0} | Slot {1} | Attack received for an empty hand slot ({2}).",
+                Logger.Args(Duel.m_duelID.Full, caster.SlotIndex, spellSelection));
+
+            CombatResolver.AddCombatMove(CombatMoveType.Pass, caster, null, null);
+
+            return;
+        }
+
         if (!caster.HasPipsForSpell(spell)) {
             Logger.Warning("Duel {0} | Slot {1} | Participant does not have enough pips for spell {2}",
                 Logger.Args(Duel.m_duelID.Full, caster.SlotIndex, spell.m_templateID));
@@ -879,7 +925,20 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
         // If the spell doesn't have a target like for AoE spells or self-heals,
         // the value will be the integer cap.
         var target = caster;
-        if (spellTarget >= 0 && spellTarget < SubCircles.Length) {
+        if (caster.OccupiedTeam == CombatTeam.Player) {
+            // The client's list is MSG_COMBATADD minus MSG_COMBATREMOVE. Dead creatures broadcast
+            // REMOVE on death and drop off it; dead players stay listed (they can be revived), so only
+            // creature corpses go uncounted.
+            var orderedParticipants = SubCircles
+                .Where(s => s is not null && s.AddedToDuel
+                    && (s.IsAlive || s.OccupiedTeam == CombatTeam.Player))
+                .OrderBy(s => s.SlotIndex)
+                .ToList();
+            if (spellTarget < orderedParticipants.Count) {
+                target = orderedParticipants[(int) spellTarget];
+            }
+        }
+        else if (spellTarget < SubCircles.Length) {
             target = SubCircles[spellTarget];
         }
 
@@ -927,22 +986,31 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
     private static CombatTeam DetermineFirstTeam()
         => (CombatTeam) new Random().Next(0, 2);
 
-    private byte GetUpFirstSigilSlot() {
-        var upFirstSigilSlot = 0;
+    private byte GetUpFirstListIndex() {
+        // Prefer the first living participant of the team that acts first, then fall back to any
+        // living participant so the client still has something to point at.
+        var upFirst = SubCircles.FirstOrDefault(s => s is not null && s.AddedToDuel && s.IsAlive
+            && s.SlotType == (Duel.m_firstTeamToAct == (int) CombatTeam.Player
+                ? CombatSlotType.Player
+                : CombatSlotType.Creature))
+            ?? SubCircles.FirstOrDefault(s => s is not null && s.AddedToDuel && s.IsAlive);
+        if (upFirst is null) {
+            return 0;
+        }
 
-        // Define the relevant CombatSlotType
-        var targetType = Duel.m_firstTeamToAct == (int) CombatTeam.Player
-                                     ? CombatSlotType.Player
-                                     : CombatSlotType.Creature;
-
-        for (int i = 0; i < SubCircles.Length; i++) {
-            if (SubCircles[i].SlotType == targetType && SubCircles[i].IsAlive) {
-                upFirstSigilSlot = SubCircles[i].SlotIndex;
-                break;
+        // The client points its indicator at its own participant list (MSG_COMBATADD minus
+        // MSG_COMBATREMOVE) in slot order. Dead creatures broadcast REMOVE on death and drop off that
+        // list, so they must not be counted; dead players stay listed (they can be revived), so they
+        // still count. Anything else shifts the indicator one slot off.
+        byte listIndex = 0;
+        for (var i = 0; i < upFirst.SlotIndex; i++) {
+            if (SubCircles[i] is not null && SubCircles[i].AddedToDuel
+                && (SubCircles[i].IsAlive || SubCircles[i].OccupiedTeam == CombatTeam.Player)) {
+                listIndex++;
             }
         }
 
-        return (byte) upFirstSigilSlot;
+        return listIndex;
     }
 
     private void AddWaitingCombatParticipants() => EnactActionOnSubCircles(circle => {

--- a/src/Imlight.CoreLib/Game/Zone/Components/CombatDuelComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/CombatDuelComponent.cs
@@ -332,8 +332,7 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
                 Logger.Args(Duel.m_duelID.Full, caster.SlotIndex, drawnSpell.m_templateID));
         }
 
-        // Send the current hand so only the drawn treasure is added. A refilling SendCombatHand would
-        // also top every open slot up from the main deck; the refill happens at the next round.
+        // Send the hand as-is: a refilling send would also pull real deck cards into the open slots.
         SendCurrentCombatHand(caster);
     }
 
@@ -755,12 +754,8 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
         });
     }
 
-    /// <summary>
-    /// Re-sends one participant's hand exactly as it stands now, with no draw or refill. Used after a
-    /// discard (which frees a slot this turn) so the client sees the open slot and can enable the vault
-    /// draw. DrawHand would refill the freed slot from the deck.
-    /// </summary>
     private void SendCurrentCombatHand(CombatDuelSubCircle circle) {
+        // As-is, no draw or refill, so a discarded slot stays visibly open for the vault draw.
         if (circle is null || circle.OccupiedTeam == CombatTeam.Monster) {
             return;
         }
@@ -889,8 +884,7 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
         Logger.Debug("Duel {0} | Slot {1} | Discarded a card: {2}",
             Logger.Args(Duel.m_duelID.Full, caster.SlotIndex, spell.m_templateID.ToString() ?? "None"));
 
-        // Re-send the hand as-is so the client sees the freed slot and can offer the vault draw.
-        // SendCombatHand would refill the slot from the deck instead.
+        // Re-send as-is so the freed slot stays open; SendCombatHand would refill it from the deck.
         SendCurrentCombatHand(caster);
     }
 
@@ -926,9 +920,8 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
         // the value will be the integer cap.
         var target = caster;
         if (caster.OccupiedTeam == CombatTeam.Player) {
-            // The client's list is MSG_COMBATADD minus MSG_COMBATREMOVE. Dead creatures broadcast
-            // REMOVE on death and drop off it; dead players stay listed (they can be revived), so only
-            // creature corpses go uncounted.
+            // The client's list is MSG_COMBATADD minus MSG_COMBATREMOVE: creature corpses drop off on
+            // death, dead players stay (they can be revived), so only creature corpses go uncounted.
             var orderedParticipants = SubCircles
                 .Where(s => s is not null && s.AddedToDuel
                     && (s.IsAlive || s.OccupiedTeam == CombatTeam.Player))
@@ -987,8 +980,7 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
         => (CombatTeam) new Random().Next(0, 2);
 
     private byte GetUpFirstListIndex() {
-        // Prefer the first living participant of the team that acts first, then fall back to any
-        // living participant so the client still has something to point at.
+        // Prefer the acting team's first living participant, else any living participant.
         var upFirst = SubCircles.FirstOrDefault(s => s is not null && s.AddedToDuel && s.IsAlive
             && s.SlotType == (Duel.m_firstTeamToAct == (int) CombatTeam.Player
                 ? CombatSlotType.Player
@@ -998,10 +990,8 @@ internal sealed class CombatDuelComponent(ZoneEntity entity)
             return 0;
         }
 
-        // The client points its indicator at its own participant list (MSG_COMBATADD minus
-        // MSG_COMBATREMOVE) in slot order. Dead creatures broadcast REMOVE on death and drop off that
-        // list, so they must not be counted; dead players stay listed (they can be revived), so they
-        // still count. Anything else shifts the indicator one slot off.
+        // The client counts its own list (COMBATADD minus COMBATREMOVE): creature corpses dropped off,
+        // dead players still listed. Counting anything else shifts the indicator one slot.
         byte listIndex = 0;
         for (var i = 0; i < upFirst.SlotIndex; i++) {
             if (SubCircles[i] is not null && SubCircles[i].AddedToDuel

--- a/src/Imlight.CoreLib/Game/Zone/Components/InteractReagentComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/InteractReagentComponent.cs
@@ -73,9 +73,15 @@ internal sealed class InteractReagentComponent(ZoneEntity entity)
     }
     public string NpcNameKey {
         get {
-            var goTemplate = Entity.Template as GameObjectTemplate;
+            if (Entity.Template is not GameObjectTemplate goTemplate) {
+                return "";
+            }
+
+            // An object name that doesn't resolve to a reagent template used to throw here, and the memento
+            // reads this key unguarded while building the press-X banner, suppressing the prompt for the
+            // whole node. Fall back to empty so the banner still appears.
             var reagentItemTemplate = ReagentFactory.GetReagentTemplate(goTemplate.m_objectName);
-            return reagentItemTemplate.m_displayName;
+            return reagentItemTemplate?.m_displayName ?? "";
         }
     }
     public string NpcTextKey => "GUI_CollectItem";
@@ -96,7 +102,8 @@ internal sealed class InteractReagentComponent(ZoneEntity entity)
     public static bool ShouldAttachToEntity(CoreTemplate template)
         => template is GameObjectTemplate goTemplate
         && goTemplate.m_adjectiveList is not null
-        && goTemplate.m_adjectiveList.Any(x => x == "Reagent");
+        && goTemplate.m_adjectiveList.Any(a => a is not null
+            && string.Equals(a.Trim(), "Reagent", StringComparison.OrdinalIgnoreCase));
 
     public IEnumerable<ServiceOptionBase> GetServiceOptions(Wizard _)
         => [ new InteractableOption { m_serviceName = ServiceName }];

--- a/src/Imlight.CoreLib/Game/Zone/Core/Zone.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Core/Zone.cs
@@ -351,6 +351,13 @@ public class Zone : ReceiveProtocolDispatcher, IWithTimers {
         Sender.Tell(rsp);
     }
 
+    [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_QUERYZONEDATA))]
+    private void ReceiveQueryZoneData() {
+        Sender.Tell(new ZONE_102_PROTOCOL.MSG_QUERYZONEDATARSP {
+            ZoneData = ZoneData
+        });
+    }
+
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_POSTEVENT))]
     private void ReceiveTriggerPost(ZONE_102_PROTOCOL.MSG_POSTEVENT message) {
         Logger.Verbose("Zone {ZoneName} received post event {EventName}.", Logger.Args(ZoneName, message.EventName));

--- a/src/Imlight.CoreLib/Shared/Networking/IHandshakeService.cs
+++ b/src/Imlight.CoreLib/Shared/Networking/IHandshakeService.cs
@@ -1,0 +1,53 @@
+/*
+ * Imlight
+ * Copyright (C) 2025 Revive101
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * ========================================================================
+ * HANDSHAKE SERVICE
+ * ========================================================================
+ * 
+ * PURPOSE:
+ * Marks a message service that must be created first when a session's
+ * services are loaded, because it drives the connection handshake.
+ * 
+ * USAGE EXAMPLE:
+ * internal class ControlService : MessageService, IHandshakeService { ... }
+ * 
+ * NOTE:
+ * ControlService is the only implementer. Its constructor sends the
+ * SessionOffer, the first thing the client waits for on connect, so it
+ * must not queue behind the other services' setup Asks. The service list
+ * comes from a HashSet (ServiceFactory.ServiceTypes), so its order cannot
+ * be relied upon; this marker makes the ordering explicit.
+ * See SessionActor.SetServices.
+ * 
+ * TODO:
+ * 
+ * Created by: Jooty
+ * Version: KALI 1.0
+ * Last Updated: 08/12/2026
+ */
+
+namespace Imlight.CoreLib.Shared.Networking;
+
+/// <summary>
+/// Marks a message service that must be created first when a session's services are loaded, because it drives
+/// the connection handshake. ControlService is the one; its constructor sends the SessionOffer, the first
+/// thing the client waits for on connect. SessionActor.SetServices creates services implementing this
+/// interface before all others, so the offer goes out immediately instead of queuing behind the other
+/// services' blocking identity Asks; a late offer outlives the client's patience at "enter world".
+/// </summary>
+internal interface IHandshakeService { }

--- a/src/Imlight.CoreLib/Shared/Networking/SessionActor.cs
+++ b/src/Imlight.CoreLib/Shared/Networking/SessionActor.cs
@@ -281,7 +281,7 @@ public sealed class SessionActor : ReceiveActor, IDisposable {
         };
         ServerRef.Tell(msg);
 
-        // Don't preemptively close the socket — the client disconnects itself
+        // Don't preemptively close the socket; the client disconnects itself
         // after receiving the final message (e.g. MSG_CHARACTERSELECTED).
         // Closing it here races with any pending SocketSender messages.
 
@@ -379,7 +379,10 @@ public sealed class SessionActor : ReceiveActor, IDisposable {
     }
 
     private void SetServices(List<Type> services) {
-        foreach (var service in services) {
+        // Create handshake services (ControlService) first. Their constructor sends the SessionOffer, the
+        // first thing the client waits for on connect, so they must not queue behind the other services'
+        // blocking identity Asks in this loop. See IHandshakeService.
+        foreach (var service in services.OrderByDescending(t => typeof(IHandshakeService).IsAssignableFrom(t))) {
             var serviceName = $"{service}";
             var props = Akka.Actor.Props.Create(service, this);
             var childRef = Context.ActorOf(props, serviceName);

--- a/src/Imlight.CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
+++ b/src/Imlight.CoreLib/Shared/Packets/ZONE_102_PROTOCOL.cs
@@ -408,6 +408,18 @@ public class ZONE_102_PROTOCOL : IServerProtocol {
     }
 
     /// <summary>
+    /// Server-internal nudge telling EquipmentService to reconcile the equipped mount with the current
+    /// zone: really unequip it on entering an interior and re-equip it on returning outdoors. Sent by
+    /// ZoneService on zone entry.
+    /// </summary>
+    public sealed class MSG_ENFORCEINTERIORMOUNT : IServerMessage {
+
+        public byte MessageOrder { get; } = 21;
+        public byte ServiceID { get; } = 102;
+
+    }
+
+    /// <summary>
     /// Called by a <see cref="ZonePath"/> to itself to indicate that it's time to spawn a creature,
     /// if possible.
     /// </summary>
@@ -794,6 +806,29 @@ public class ZONE_102_PROTOCOL : IServerProtocol {
         public byte ServiceID { get; } = 102;
 
         public ushort MobileId;
+
+    }
+
+    /// <summary>
+    /// Sent by a session service to a <see cref="Zone"/> to fetch its loaded <see cref="WizZoneData"/>,
+    /// e.g. to check zone flags like m_noMounts.
+    /// </summary>
+    public sealed class MSG_QUERYZONEDATA : IServerMessage {
+
+        public byte MessageOrder { get; } = 55;
+        public byte ServiceID { get; } = 102;
+
+    }
+
+    /// <summary>
+    /// Sent by a <see cref="Zone"/> in response to <see cref="MSG_QUERYZONEDATA"/>.
+    /// </summary>
+    public sealed class MSG_QUERYZONEDATARSP : IServerMessage {
+
+        public byte MessageOrder { get; } = 56;
+        public byte ServiceID { get; } = 102;
+
+        public WizZoneData ZoneData;
 
     }
 

--- a/src/Imlight.CoreLib/Shared/Services/ControlService.cs
+++ b/src/Imlight.CoreLib/Shared/Services/ControlService.cs
@@ -26,7 +26,7 @@ using Imlight.CoreLib.Shared.Packets;
 
 namespace Imlight.CoreLib.Shared.Services;
 
-internal class ControlService : MessageService {
+internal class ControlService : MessageService, IHandshakeService {
 
     private readonly byte _keepAliveInterval = ConfigurationManager.Settings["Advanced.KeepAliveInterval"].AsByte();
     private readonly byte _keepAliveRspWaitTime = ConfigurationManager.Settings["Advanced.KeepAliveRspWaitTime"].AsByte();
@@ -175,6 +175,10 @@ internal class ControlService : MessageService {
             return;
         }
 
+        // A heartbeat-response timeout is a real drop the player sees as "connection lost"; it needs to be
+        // visible in the log. It only fires outside the game server (_isInGameServer guards it above).
+        Logger.Warning("SessionActor {SessionID} heartbeat response timed out after {Wait}s; closing session.",
+            Logger.Args(SessionActor.SessionID, _keepAliveRspWaitTime));
         CloseSession();
     }
 
@@ -183,8 +187,11 @@ internal class ControlService : MessageService {
             return;
         }
 
-        Logger.Verbose("SessionActor {SessionID} " +
-                  "did not return a SessionAccept message in time", Logger.Args(SessionActor.SessionID));
+        // This is the initial-handshake timeout; the drop players see as "connection lost" on game-world
+        // entry / character switch. It needs to be visible in the log so it can be correlated with
+        // concurrent zone loads.
+        Logger.Warning("SessionActor {SessionID} did not return a SessionAccept within {Wait}s; closing session " +
+                  "(initial-handshake timeout).", Logger.Args(SessionActor.SessionID, _keepAliveRspWaitTime));
         CloseSession();
     }
 

--- a/src/Imlight.CoreLib/WizardData/Collections/WizardCollection.cs
+++ b/src/Imlight.CoreLib/WizardData/Collections/WizardCollection.cs
@@ -295,6 +295,23 @@ public static class WizardCollection {
     }
 
     /// <summary>
+    /// Persists <see cref="Wizard.InteriorStowedMountId"/>: the mount auto-stowed for an interior, to be
+    /// re-equipped outdoors. Written the moment it changes because a zone transfer is a disconnect.
+    /// </summary>
+    public static void UpdateCharacterInteriorStowedMount(Wizard wizard) {
+        using var session = s_store.OpenSession();
+
+        var existingCharacter = session.Query<Wizard>(collectionName: CollectionName)
+            .FirstOrDefault(x => x.CharId == wizard.CharId);
+        if (existingCharacter is null) {
+            return;
+        }
+
+        existingCharacter.InteriorStowedMountId = wizard.InteriorStowedMountId;
+        session.SaveChanges();
+    }
+
+    /// <summary>
     /// Updates the character badge override for a wizard.
     /// </summary>
     /// <param name="wizard">The wizard object containing the updated character badge override.</param>
@@ -312,7 +329,7 @@ public static class WizardCollection {
     }
 
     /// <summary>
-    /// Updates the character spellbook behavior for a wizard — persists the
+    /// Updates the character spellbook behavior for a wizard; persists the
     /// excluded item spell list and other spellbook state to the database.
     /// </summary>
     /// <param name="wizard">The wizard whose spellbook behavior should be persisted.</param>
@@ -398,7 +415,7 @@ public static class WizardCollection {
     }
 
     /// <summary>
-    /// Updates the friend behavior for a wizard — persists pending friend requests
+    /// Updates the friend behavior for a wizard; persists pending friend requests
     /// and other in-memory friend state to the database.
     /// </summary>
     /// <param name="wizard">The wizard whose friend behavior should be persisted.</param>

--- a/src/Imlight.CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/Imlight.CoreLib/WizardData/Models/Player/Wizard.cs
@@ -43,6 +43,8 @@ public class Wizard : IDisposable {
     public string Zone { get; set; }
     public string ZoneDisplayName { get; set; }
     public string PreviousZone { get; set; }
+
+    public ulong InteriorStowedMountId { get; set; }
     public string MarkedZone { get; set; }
     public string MarkedZoneDisplayName { get; set; }
     public long TimeHomeLastClicked { get; set; }
@@ -973,7 +975,7 @@ public class Wizard : IDisposable {
             return false;
         }
 
-        // Persistent save — use AddRelationship so the row is created when this
+        // Persistent save; use AddRelationship so the row is created when this
         // is the very first interaction between the two characters.
         BuddyRelationshipCollection.AddRelationship(relationship);
 

--- a/src/Imlight.Director/Config/Imlight.ini
+++ b/src/Imlight.Director/Config/Imlight.ini
@@ -140,7 +140,7 @@ SessionActorServiceRangeRetry = 30
 ; The time in seconds that the server will send a heartbeat to the client.
 KeepAliveInterval = 60
 ; The time in seconds the server will wait for a heartbeat response.
-KeepAliveRspWaitTime = 4
+KeepAliveRspWaitTime = 15
 ; How many requests are allowed within the token bucket of the session actor.
 SessionTokenBucketMax = 150
 ; How many new tokens are added to the token bucket per second.

--- a/src/Imlight.Director/Config/akka.conf
+++ b/src/Imlight.Director/Config/akka.conf
@@ -19,3 +19,18 @@
     }
   }
 }
+
+# Dedicated pool for ZoneLoader actors (see GameWorld.CreateZoneLoader). Zone loading is synchronous
+# WAD-parse + deserialize work; on the default dispatcher a burst of concurrent loads starves session and
+# handshake processing. Its own fork-join pool keeps that spike off the threads that answer keep-alives;
+# parallelism-max bounds how many zones load at once, and extra loads simply queue.
+zone-loading-dispatcher {
+  type = Dispatcher
+  executor = "fork-join-executor"
+  fork-join-executor {
+    parallelism-min = 2
+    parallelism-factor = 1.0
+    parallelism-max = 4
+  }
+  throughput = 1
+}


### PR DESCRIPTION
## Changelog
* Added `IHandshakeService.cs`
* Fixed docs deployment
* Fixed the zone loader to be an exclusive actor. Fixes the case where two players force a zone load the same time
* Fixed treasure card draws not always being set as a TC
* Fixed server-client sync of combat participants when a creature is defeated in battle
* Fixed some reagent pickups
* Fixed mounts being usable in zones they should not be able to