### PR TITLE
Serialize wizard updates to support optimistic concurrency

### DIFF
--- a/src/Imlight.CoreLib/WizardData/Collections/AccountCollection.cs
+++ b/src/Imlight.CoreLib/WizardData/Collections/AccountCollection.cs
@@ -21,9 +21,8 @@ using Raven.Client.Documents;
 using Imlight.CoreLib.WizardData.Databases;
 using Imlight.CoreLib.WizardData.Models.Misc;
 using Imlight.CoreLib.WizardData.Models.Player;
-using Imlight.CoreLib.Shared.Behaviors;
-using Imlight.CoreLib.WizardData.Implementations;
-using Imcodec.ObjectProperty.TypeCache;
+using Raven.Client.Documents.Session;
+using System;
 
 namespace Imlight.CoreLib.WizardData.Collections;
 
@@ -36,32 +35,118 @@ public static class AccountCollection {
         s_store = PlayerDatabase.Instance.Store;
     }
 
+    private const int WriteLaneCount = 1 << 6; // 64 lanes
+    private const ulong WriteLaneMask = WriteLaneCount - 1;
+    private static readonly object[] s_writeLanes =
+        Enumerable.Range(0, WriteLaneCount)
+            .Select(_ => new object())
+            .ToArray();
+
+    // Tracks the write lane held by the current thread.
+    // Enforces that an account lock is acquired before a character lock
+    // and prevents acquiring multiple Account lanes at the same time.
+    [ThreadStatic]
+    private static int? s_heldWriteLane;
+
+    private static T WithWriteLane<T>(ulong accountId, Func<T> write) {
+        if (WizardCollection.HoldsWriteLane)
+            throw new InvalidOperationException("Cannot acquire an account write lane while holding a wizard write lane.");
+
+        var laneIndex = (int) (accountId & WriteLaneMask);
+        if (s_heldWriteLane is { } heldLane && heldLane != laneIndex)
+            throw new InvalidOperationException($"Cannot acquire account lane {laneIndex} while holding account lane {heldLane}.");
+
+        var writeLane = s_writeLanes[laneIndex];
+
+        lock (writeLane) {
+            var previousLane = s_heldWriteLane;
+            s_heldWriteLane = laneIndex;
+
+            try {
+                return write();
+            }
+            finally {
+                s_heldWriteLane = previousLane;
+            }
+        }
+    }
+
+    private static bool UpdateAccount(ulong accountId, Action<Account> update) {
+        return WithWriteLane(accountId, () => {
+            using var session = s_store.OpenSession();
+
+            var existingAccount = session.Query<Account>(collectionName: CollectionName)
+                .FirstOrDefault(account => account.AccountId == accountId);
+
+            if (existingAccount is null)
+                return false;
+
+            update(existingAccount);
+
+            session.SaveChanges();
+
+            return true;
+        });
+    }
+
+    private static ulong? GetAccountId(string username) {
+        using var session = s_store.OpenSession();
+
+        return session.Query<Account>(collectionName: CollectionName)
+            .Where(account => account.Username == username)
+            .Select(account => (ulong?) account.AccountId)
+            .FirstOrDefault();
+    }
+
+    private static bool UpdateAccount(string username, Action<Account> update) {
+        var accountId = GetAccountId(username);
+
+        if (accountId is null)
+            return false;
+
+        return UpdateAccount(accountId.Value, update);
+    }
+
+    private static Account LoadAccountDetails(IDocumentSession session, Account account) {
+        WizardCollection.LoadWizardsOntoAccount(account.AccountId, ref account);
+
+        var infractions = session.Query<Infraction>(collectionName: InfractionCollection.CollectionName)
+            .Where(i => i.AccountId == account.AccountId)
+            .ToList();
+
+        account.InfractionHistory = new InfractionHistory(account.AccountId, infractions);
+
+        return account;
+    }
+
     /// <summary>
     /// Creates a new account in the database.
     /// </summary>
     /// <param name="account">The account to be created.</param>
     /// <returns>True if the account is successfully created, false if the account already exists.</returns>
     public static bool CreateAccount(Account account) {
-        using var session = s_store.OpenSession();
+        return WithWriteLane(account.AccountId, () => {
+            using var session = s_store.OpenSession();
 
-        // Return false if the account already exists.
-        if (session.Query<Account>(collectionName: CollectionName)
-                   .Any(c => c.Username == account.Username)) {
-            return false;
-        }
+            // Return false if the account already exists.
+            if (session.Query<Account>(collectionName: CollectionName)
+                       .Any(c => c.Username == account.Username)) {
+                return false;
+            }
 
-        // Foreach character in the account, add it to the database.
-        foreach (var character in account.Characters) {
-            WizardCollection.AddCharacter(character);
-        }
+            // Foreach character in the account, add it to the database.
+            foreach (var character in account.Characters) {
+                WizardCollection.AddCharacter(character);
+            }
 
-        session.Store(account);
-        var metadata = session.Advanced.GetMetadataFor(account);
-        metadata[Raven.Client.Constants.Documents.Metadata.Collection] = CollectionName;
+            session.Store(account);
+            var metadata = session.Advanced.GetMetadataFor(account);
+            metadata[Raven.Client.Constants.Documents.Metadata.Collection] = CollectionName;
 
-        session.SaveChanges();
-        
-        return true;
+            session.SaveChanges();
+
+            return true;
+        });
     }
 
     /// <summary>
@@ -70,26 +155,33 @@ public static class AccountCollection {
     /// <param name="username">The username of the account to delete.</param>
     /// <returns>True if the account was successfully deleted, false otherwise.</returns>
     public static bool DeleteAccount(string username) {
-        using var session = s_store.OpenSession();
+        var id = GetAccountId(username);
 
-        // Load the account with the characters included.
-        var account = session.Query<Account>(collectionName: CollectionName)
-            .Include(c => c.CharacterIds)
-            .FirstOrDefault(c => c.Username == username);
-        if (account is null) {
+        if (id is null)
             return false;
-        }
 
-        // Delete the characters.
-        foreach (var characterId in account.CharacterIds) {
-            WizardCollection.DeleteCharacter(characterId);
-        }
+        var accountId = id.Value;
 
-        // Delete the account.
-        session.Delete(account);
-        session.SaveChanges();
+        return WithWriteLane(accountId, () => {
+            using var session = s_store.OpenSession();
 
-        return true;
+            var account = session.Query<Account>(collectionName: CollectionName)
+                .FirstOrDefault(a => a.AccountId == accountId);
+
+            if (account is null)
+                return false;
+
+            // Delete the characters.
+            foreach (var characterId in account.CharacterIds) {
+                WizardCollection.DeleteCharacter(characterId);
+            }
+
+            // Delete the account.
+            session.Delete(account);
+            session.SaveChanges();
+
+            return true;
+        });
     }
 
     /// <summary>
@@ -100,25 +192,12 @@ public static class AccountCollection {
     public static Account GetAccount(ulong id) {
         using var session = s_store.OpenSession();
 
-        // Load the account with the characters included.
         var account = session.Query<Account>(collectionName: CollectionName)
-            .FirstOrDefault(c => c.AccountId == id);
-        if (account is null) {
-            return null;
-        }
+            .FirstOrDefault(a => a.AccountId == id);
 
-        // Load the characters.
-        var _ = WizardCollection.LoadWizardsOntoAccount(account.AccountId, ref account);
-
-        // Load infractions. The constructor will load the action history.
-        var infractions = session.Query<Infraction>(collectionName: InfractionCollection.CollectionName)
-            .Where(i => i.AccountId == account.AccountId)
-            .ToList();
-
-        // Rebuild the InfractionHistory object.
-        account.InfractionHistory = new InfractionHistory(account.AccountId, infractions);
-
-        return account;
+        return account is null
+            ? null
+            : LoadAccountDetails(session, account);
     }
 
     /// <summary>
@@ -129,25 +208,12 @@ public static class AccountCollection {
     public static Account GetAccount(string username) {
         using var session = s_store.OpenSession();
 
-        // Load the account with the characters included.
         var account = session.Query<Account>(collectionName: CollectionName)
-            .FirstOrDefault(c => c.Username == username);
-        if (account is null) {
-            return null;
-        }
+            .FirstOrDefault(a => a.Username == username);
 
-        // Load the characters if the account is not null.
-        var _ = WizardCollection.LoadWizardsOntoAccount(account.AccountId, ref account);
-
-        // Load infractions. The constructor will load the action history.
-        var infractions = session.Query<Infraction>(collectionName: InfractionCollection.CollectionName)
-            .Where(i => i.AccountId == account.AccountId)
-            .ToList();
-
-        // Rebuild the InfractionHistory object.
-        account.InfractionHistory = new InfractionHistory(account.AccountId, infractions);
-
-        return account;
+        return account is null
+            ? null
+            : LoadAccountDetails(session, account);
     }
 
     /// <summary>
@@ -156,20 +222,9 @@ public static class AccountCollection {
     /// <param name="account">The account to be locked.</param>
     /// <returns>True if the account was successfully locked, false otherwise.</returns>
     public static bool LockAccount(string username) {
-        using var session = s_store.OpenSession();
-
-        // Load the account with the characters included.
-        var existingAccount = session.Query<Account>(collectionName: CollectionName)
-            .Include(c => c.CharacterIds)
-            .FirstOrDefault(c => c.Username == username);
-        if (existingAccount is null) {
-            return false;
-        }
-
-        existingAccount.IsLocked = true;
-        session.SaveChanges();
-
-        return true;
+        return UpdateAccount(username, account => {
+            account.IsLocked = true;
+        });
     }
 
     /// <summary>
@@ -178,20 +233,9 @@ public static class AccountCollection {
     /// <param name="username">The username of the account to unlock.</param>
     /// <returns>True if the account was successfully unlocked, false otherwise.</returns>
     public static bool UnlockAccount(string username) {
-        using var session = s_store.OpenSession();
-
-        // Load the account with the characters included.
-        var existingAccount = session.Query<Account>(collectionName: CollectionName)
-            .Include(c => c.CharacterIds)
-            .FirstOrDefault(c => c.Username == username);
-        if (existingAccount is null) {
-            return false;
-        }
-
-        existingAccount.IsLocked = false;
-        session.SaveChanges();
-
-        return true;
+        return UpdateAccount(username, account => {
+            account.IsLocked = false;
+        });
     }
 
     /// <summary>
@@ -201,21 +245,10 @@ public static class AccountCollection {
     /// <param name="newPassword">The new password.</param>
     /// <returns>True if the password was successfully changed, false otherwise.</returns>
     public static bool ChangePassword(string username, string newPassword) {
-        using var session = s_store.OpenSession();
-
-        // Load the account with the characters included.
-        var existingAccount = session.Query<Account>(collectionName: CollectionName)
-            .Include(c => c.CharacterIds)
-            .FirstOrDefault(c => c.Username == username);
-        if (existingAccount is null) {
-            return false;
-        }
-
-        var passwordHash = DatabaseUtilities.CreateHashedPassword(newPassword);
-        existingAccount.PasswordHash = passwordHash;
-        session.SaveChanges();
-
-        return true;
+        return UpdateAccount(username, account => {
+            var passwordHash = DatabaseUtilities.CreateHashedPassword(newPassword);
+            account.PasswordHash = passwordHash;
+        });
     }
 
     /// <summary>
@@ -225,20 +258,9 @@ public static class AccountCollection {
     /// <param name="authLevel">The new authentication level.</param>
     /// <returns>True if the update was successful, false otherwise.</returns>
     public static bool UpdateAuthLevel(string username, AuthLevel authLevel) {
-        using var session = s_store.OpenSession();
-
-        // Load the account with the characters included.
-        var existingAccount = session.Query<Account>(collectionName: CollectionName)
-            .Include(c => c.CharacterIds)
-            .FirstOrDefault(c => c.Username == username);
-        if (existingAccount is null) {
-            return false;
-        }
-
-        existingAccount.AuthLevel = authLevel;
-        session.SaveChanges();
-
-        return true;
+        return UpdateAccount(username, account => {
+            account.AuthLevel = authLevel;
+        });
     }
 
     /// <summary>
@@ -248,19 +270,9 @@ public static class AccountCollection {
     /// <param name="characterId"></param>
     /// <returns></returns>
     public static bool AddCharacterToAccount(ulong accountId, ulong characterId) {
-        using var session = s_store.OpenSession();
-
-        // Start by loading an account, if one exists.
-        var existingAccount = session.Query<Account>(collectionName: CollectionName)
-            .FirstOrDefault(c => c.AccountId == accountId);
-        if (existingAccount is null) {
-            return false;
-        }
-
-        existingAccount.CharacterIds.Add(characterId);
-        session.SaveChanges();
-
-        return true;
+        return UpdateAccount(accountId, account => {
+            account.CharacterIds.Add(characterId);
+        });
     }
 
     /// <summary>
@@ -270,19 +282,9 @@ public static class AccountCollection {
     /// <param name="characterId"></param>
     /// <returns></returns>
     public static bool DeleteCharacterFromAccount(ulong accountId, ulong characterId) {
-        using var session = s_store.OpenSession();
-
-        // Start by loading an account, if one exists.
-        var existingAccount = session.Query<Account>(collectionName: CollectionName)
-            .FirstOrDefault(c => c.AccountId == accountId);
-        if (existingAccount is null) {
-            return false;
-        }
-
-        existingAccount.CharacterIds.Remove(characterId);
-        session.SaveChanges();
-
-        return true;
+        return UpdateAccount(accountId, account => {
+            account.CharacterIds.Remove(characterId);
+        });
     }
 
     /// <summary>
@@ -290,37 +292,23 @@ public static class AccountCollection {
     /// </summary>
     /// <param name="accountId">The ID of the account to add the infraction to.</param>
     /// <param name="infractionId">The ID of the infraction to add.</param>
-    public static void AddInfractionToAccount(ulong accountId, ulong infractionId) {
-        using var session = s_store.OpenSession();
-
-        // Start by loading an account, if one exists.
-        var existingAccount = session.Query<Account>(collectionName: CollectionName)
-            .FirstOrDefault(c => c.AccountId == accountId);
-        if (existingAccount is null) {
-            return;
-        }
-
-        existingAccount.InfractionIds.Add(infractionId);
-        session.SaveChanges();
+    /// <returns></returns>
+    public static bool AddInfractionToAccount(ulong accountId, ulong infractionId) {
+        return UpdateAccount(accountId, account => {
+            account.InfractionIds.Add(infractionId);
+        });
     }
 
     /// <summary>
     /// Removes an infraction from an account.
     /// </summary>
     /// <param name="accountId">The ID of the account.</param>
-    /// <param name="infractionIndex">The index of the infraction to remove.</param>
-    public static void RemoveInfractionFromAccount(ulong accountId, ulong infractionIndex) {
-        using var session = s_store.OpenSession();
-
-        // Start by loading an account, if one exists.
-        var existingAccount = session.Query<Account>(collectionName: CollectionName)
-            .FirstOrDefault(c => c.AccountId == accountId);
-        if (existingAccount is null) {
-            return;
-        }
-
-        existingAccount.InfractionIds.Remove(infractionIndex);
-        session.SaveChanges();
+    /// <param name="infractionId">The ID of the infraction to remove.</param>
+    /// <returns></returns>
+    public static bool RemoveInfractionFromAccount(ulong accountId, ulong infractionId) {
+        return UpdateAccount(accountId, account => {
+            account.InfractionIds.Remove(infractionId);
+        });
     }
 
 }

--- a/src/Imlight.CoreLib/WizardData/Collections/OnlinePlayerCollection.cs
+++ b/src/Imlight.CoreLib/WizardData/Collections/OnlinePlayerCollection.cs
@@ -41,6 +41,7 @@
 using Imlight.CoreLib.WizardData.Databases;
 using Imlight.CoreLib.WizardData.Models.Misc;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
 using System.Collections.Concurrent;
 using System.Linq;
 
@@ -55,6 +56,12 @@ public static class OnlinePlayerCollection {
 
     static OnlinePlayerCollection() 
         => s_store = PlayerDatabase.Instance.Store;
+
+    private static void DeleteOnlinePlayer(IDocumentSession session, OnlinePlayer onlinePlayer) {
+        var documentId = session.Advanced.GetDocumentId(onlinePlayer);
+        session.Advanced.Evict(onlinePlayer);
+        session.Delete(documentId);
+    }
 
     /// <summary>
     /// Adds an online player to the collection.
@@ -91,7 +98,7 @@ public static class OnlinePlayerCollection {
             .Query<OnlinePlayer>(collectionName: CollectionName)
             .FirstOrDefault(x => x.AccountId == accountId);
         if (onlinePlayer != null) {
-            session.Delete(onlinePlayer);
+            DeleteOnlinePlayer(session, onlinePlayer);
             session.SaveChanges();
         }
     }
@@ -114,7 +121,7 @@ public static class OnlinePlayerCollection {
             .Query<OnlinePlayer>(collectionName: CollectionName)
             .FirstOrDefault(x => x.SessionId == sessionId);
         if (onlinePlayer != null) {
-            session.Delete(onlinePlayer);
+            DeleteOnlinePlayer(session, onlinePlayer);
             session.SaveChanges();
         }
     }
@@ -212,7 +219,7 @@ public static class OnlinePlayerCollection {
             .Query<OnlinePlayer>(collectionName: CollectionName)
             .ToArray();
         foreach (var onlinePlayer in onlinePlayers) {
-            session.Delete(onlinePlayer);
+            DeleteOnlinePlayer(session, onlinePlayer);
         }
 
         session.SaveChanges();

--- a/src/Imlight.CoreLib/WizardData/Collections/WizardCollection.cs
+++ b/src/Imlight.CoreLib/WizardData/Collections/WizardCollection.cs
@@ -26,7 +26,6 @@ using Imlight.CoreLib.WizardData.Databases;
 using Imlight.CoreLib.WizardData.Models.Player;
 using Imcodec.ObjectProperty.TypeCache;
 using Imcodec.Math;
-using System.Collections.Generic;
 
 namespace Imlight.CoreLib.WizardData.Collections;
 
@@ -35,32 +34,63 @@ public static class WizardCollection {
     public const string CollectionName = "Wizards";
     private static readonly IDocumentStore s_store;
 
+    private const int WriteLaneCount = 1 << 8; // 256 lanes
+    private const ulong WriteLaneMask = WriteLaneCount - 1;
+    private static readonly object[] s_writeLanes =
+        Enumerable.Range(0, WriteLaneCount)
+            .Select(_ => new object())
+            .ToArray();
+
     private static readonly TimeSpan s_nonStaleWaitTimeout
         = TimeSpan.FromSeconds(ConfigurationManager.Settings["Database.DatabaseWaitForNonStaleResultsTimeout"].AsByte(5));
 
     static WizardCollection()
         => s_store = PlayerDatabase.Instance.Store;
 
+    private static T WithWriteLane<T>(ulong charId, Func<T> write) {
+        var writeLane = s_writeLanes[(int)(charId & WriteLaneMask)];
+
+        lock (writeLane) {
+            return write();
+        }
+    }
+
+    private static bool UpdateCharacter(ulong charId, Action<Wizard> update) {
+        return WithWriteLane(charId, () => {
+            using var session = s_store.OpenSession();
+            var existingCharacter = GetCharacterByCharId(session, charId);
+            if (existingCharacter is null) {
+                return false;
+            }
+
+            update(existingCharacter);
+            session.SaveChanges();
+            return true;
+        });
+    }
+
     /// <summary>
     /// Creates a character in the database.
     /// </summary>
     /// <param name="character"></param>
     public static bool AddCharacter(Wizard character) {
-        using var session = s_store.OpenSession();
+        return WithWriteLane(character.CharId, () => {
+            using var session = s_store.OpenSession();
 
-        // Return false if the character already exists in the database.
-        var existingCharacter = GetCharacterByCharId(session, character.CharId);
-        if (existingCharacter is not null) {
-            return false;
-        }
+            // Return false if the character already exists in the database.
+            var existingCharacter = GetCharacterByCharId(session, character.CharId);
+            if (existingCharacter is not null) {
+                return false;
+            }
 
-        session.Store(character);
-        var metadata = session.Advanced.GetMetadataFor(character);
-        metadata[Raven.Client.Constants.Documents.Metadata.Collection] = CollectionName;
+            session.Store(character);
+            var metadata = session.Advanced.GetMetadataFor(character);
+            metadata[Raven.Client.Constants.Documents.Metadata.Collection] = CollectionName;
 
-        session.SaveChanges();
+            session.SaveChanges();
 
-        return true;
+            return true;
+        });
     }
 
     /// <summary>
@@ -68,23 +98,25 @@ public static class WizardCollection {
     /// </summary>
     /// <param name="id"></param>
     public static bool DeleteCharacter(ulong id) {
-        using var session = s_store.OpenSession();
+        return WithWriteLane(id, () => {
+            using var session = s_store.OpenSession();
 
-        var character = GetCharacterByCharId(session, id);
-        if (character is null) {
-            return false;
-        }
+            var character = GetCharacterByCharId(session, id);
+            if (character is null) {
+                return false;
+            }
 
-        // Delete related items/dynamods/quests data/etc.
-        WizardItemCollection.DeleteInventory(id);
-        WizardPetSnackCollection.DeleteSnackBag(id);
-        DynamodCollection.DeleteAllDynamodSets(id);
-        WizardReagentCollection.DeleteReagentBag(id);
+            // Delete related items/dynamods/quests data/etc.
+            WizardItemCollection.DeleteInventory(id);
+            WizardPetSnackCollection.DeleteSnackBag(id);
+            DynamodCollection.DeleteAllDynamodSets(id);
+            WizardReagentCollection.DeleteReagentBag(id);
 
-        session.Delete(character);
-        session.SaveChanges();
+            session.Delete(character);
+            session.SaveChanges();
 
-        return true;
+            return true;
+        });
     }
 
     /// <summary>
@@ -165,17 +197,11 @@ public static class WizardCollection {
     /// <param name="zoneName">The name of the zone.</param>
     /// <param name="zoneDisplayName">The display name of the zone.</param>
     public static void UpdateCharacterZone(Wizard character, string zoneName, string zoneDisplayName) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, character.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.PreviousZone = existingCharacter.PreviousZone;
-        existingCharacter.Zone = zoneName;
-        existingCharacter.ZoneDisplayName = zoneDisplayName;
-        session.SaveChanges();
+        UpdateCharacter(character.CharId, existingCharacter => {
+            existingCharacter.PreviousZone = existingCharacter.PreviousZone;
+            existingCharacter.Zone = zoneName;
+            existingCharacter.ZoneDisplayName = zoneDisplayName;
+        });
     }
 
     /// <summary>
@@ -185,16 +211,10 @@ public static class WizardCollection {
     /// <param name="location">The new location of the character.</param>
     /// <param name="orientation">The new orientation of the character.</param>
     public static void UpdateCharacterLocation(Wizard character, Vector3 location, float orientation) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, character.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.Location = location;
-        existingCharacter.Orientation = new Vector3(0, 0, orientation);
-        session.SaveChanges();
+        UpdateCharacter(character.CharId, existingCharacter => {
+            existingCharacter.Location = location;
+            existingCharacter.Orientation = new Vector3(0, 0, orientation);
+        });
     }
 
     /// <summary>
@@ -209,18 +229,12 @@ public static class WizardCollection {
                                                      Vector3 orientation,
                                                      string ZoneName,
                                                      string zoneDisplayName) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, character.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.MarkedLocation = location;
-        existingCharacter.MarkedOrientation = orientation;
-        existingCharacter.MarkedZone = ZoneName;
-        existingCharacter.MarkedZoneDisplayName = zoneDisplayName;
-        session.SaveChanges();
+        UpdateCharacter(character.CharId, existingCharacter => {
+            existingCharacter.MarkedLocation = location;
+            existingCharacter.MarkedOrientation = orientation;
+            existingCharacter.MarkedZone = ZoneName;
+            existingCharacter.MarkedZoneDisplayName = zoneDisplayName;
+        });
     }
 
     /// <summary>
@@ -228,18 +242,12 @@ public static class WizardCollection {
     /// </summary>
     /// <param name="wizard">The wizard object containing the updated equipment.</param>
     public static void UpdateCharacterItems(Wizard wizard) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.InventoryBehavior = wizard.InventoryBehavior;
-        existingCharacter.EquipmentBehavior = wizard.EquipmentBehavior;
-        existingCharacter.PetSnackBehavior = wizard.PetSnackBehavior;
-        existingCharacter.AlchemyBehavior = wizard.AlchemyBehavior;
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter => {
+            existingCharacter.InventoryBehavior = wizard.InventoryBehavior;
+            existingCharacter.EquipmentBehavior = wizard.EquipmentBehavior;
+            existingCharacter.PetSnackBehavior = wizard.PetSnackBehavior;
+            existingCharacter.AlchemyBehavior = wizard.AlchemyBehavior;
+        });
     }
 
     /// <summary>
@@ -247,16 +255,10 @@ public static class WizardCollection {
     /// </summary>
     /// <param name="wizard">The wizard object containing the updated level.</param>
     public static void UpdateCharacterLevel(Wizard wizard) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.MagicSchoolBehavior.Level = wizard.MagicSchoolBehavior.Level;
-        existingCharacter.MagicSchoolBehavior.ExperiencePoints = wizard.MagicSchoolBehavior.ExperiencePoints;
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter => {
+            existingCharacter.MagicSchoolBehavior.Level = wizard.MagicSchoolBehavior.Level;
+            existingCharacter.MagicSchoolBehavior.ExperiencePoints = wizard.MagicSchoolBehavior.ExperiencePoints;
+        });
     }
 
     /// <summary>
@@ -264,15 +266,8 @@ public static class WizardCollection {
     /// </summary>
     /// <param name="wizard">The wizard whose character mount is being updated.</param>
     public static void UpdateCharacterMount(Wizard wizard) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.MountOwnerBehavior = wizard.MountOwnerBehavior;
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter =>
+            existingCharacter.MountOwnerBehavior = wizard.MountOwnerBehavior);
     }
 
     /// <summary>
@@ -280,15 +275,8 @@ public static class WizardCollection {
     /// </summary>
     /// <param name="wizard">The wizard object containing the updated character name override.</param>
     public static void UpdateCharacterNameOverride(Wizard wizard) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.PlayerNameBehavior.NameOverride = wizard.PlayerNameBehavior.NameOverride;
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter =>
+            existingCharacter.PlayerNameBehavior.NameOverride = wizard.PlayerNameBehavior.NameOverride);
     }
 
     /// <summary>
@@ -296,15 +284,8 @@ public static class WizardCollection {
     /// re-equipped outdoors. Written the moment it changes because a zone transfer is a disconnect.
     /// </summary>
     public static void UpdateCharacterInteriorStowedMount(Wizard wizard) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.InteriorStowedMountId = wizard.InteriorStowedMountId;
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter =>
+            existingCharacter.InteriorStowedMountId = wizard.InteriorStowedMountId);
     }
 
     /// <summary>
@@ -312,15 +293,8 @@ public static class WizardCollection {
     /// </summary>
     /// <param name="wizard">The wizard object containing the updated character badge override.</param>
     public static void UpdateCharacterBadgeOverride(Wizard wizard) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.PlayerNameBehavior.BadgeTitle = wizard.PlayerNameBehavior.BadgeTitle;
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter =>
+            existingCharacter.PlayerNameBehavior.BadgeTitle = wizard.PlayerNameBehavior.BadgeTitle);
     }
 
     /// <summary>
@@ -329,15 +303,8 @@ public static class WizardCollection {
     /// </summary>
     /// <param name="wizard">The wizard whose spellbook behavior should be persisted.</param>
     public static void UpdateCharacterSpellbookBehavior(Wizard wizard) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.SpellbookBehavior = wizard.SpellbookBehavior;
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter =>
+            existingCharacter.SpellbookBehavior = wizard.SpellbookBehavior);
     }
 
     /// <summary>
@@ -345,15 +312,8 @@ public static class WizardCollection {
     /// </summary>
     /// <param name="wizard">The wizard object containing the updated game stats</param>
     public static void UpdateCharacterGameStats(Wizard wizard) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.GameStats = wizard.GameStats;
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter =>
+            existingCharacter.GameStats = wizard.GameStats);
     }
 
     /// <summary>
@@ -361,15 +321,8 @@ public static class WizardCollection {
     /// </summary>
     /// <param name="wizard">The wizard object containing the updated pet owner behavior.</param>
     public static void UpdateCharacterPetOwnerBehavior(Wizard wizard) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.PetOwnerBehavior = wizard.PetOwnerBehavior;
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter =>
+            existingCharacter.PetOwnerBehavior = wizard.PetOwnerBehavior);
     }
 
     /// <summary>
@@ -377,15 +330,8 @@ public static class WizardCollection {
     /// </summary>
     /// <param name="wizard">The wizard to update the time for</param>
     public static void UpdateCharacterTimeWentHome(Wizard wizard, long time) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.TimeHomeLastClicked = time;
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter =>
+            existingCharacter.TimeHomeLastClicked = time);
     }
 
     /// <summary>
@@ -393,15 +339,8 @@ public static class WizardCollection {
     /// </summary>
     /// <param name="wizard">The wizard object containing the updated training points count.</param>
     public static void UpdateCharacterTrainingPoints(Wizard wizard) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.MagicSchoolBehavior.TrainingPoints = wizard.MagicSchoolBehavior.TrainingPoints;
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter =>
+            existingCharacter.MagicSchoolBehavior.TrainingPoints = wizard.MagicSchoolBehavior.TrainingPoints);
     }
 
     /// <summary>
@@ -410,15 +349,8 @@ public static class WizardCollection {
     /// </summary>
     /// <param name="wizard">The wizard whose friend behavior should be persisted.</param>
     public static void UpdateCharacterFriendBehavior(Wizard wizard) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.FriendsBehavior = wizard.FriendsBehavior;
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter =>
+            existingCharacter.FriendsBehavior = wizard.FriendsBehavior);
     }
 
     /// <summary>
@@ -427,15 +359,8 @@ public static class WizardCollection {
     /// <param name="wizard">The wizard to add the spell to.</param>
     /// <param name="spellTemplateId">The ID of the spell template to add.</param>
     public static void LearnSpell(Wizard wizard, uint spellTemplateId) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.SpellbookBehavior.LearnedSpellTemplateIds.Add(spellTemplateId);
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter =>
+            existingCharacter.SpellbookBehavior.LearnedSpellTemplateIds.Add(spellTemplateId));
     }
 
     /// <summary>
@@ -444,15 +369,8 @@ public static class WizardCollection {
     /// <param name="wizard">The wizard whose spellbook will be modified.</param>
     /// <param name="spellTemplateId">The ID of the spell template to be removed.</param>
     public static void UnlearnSpell(Wizard wizard, uint spellTemplateId) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.SpellbookBehavior.LearnedSpellTemplateIds.Remove(spellTemplateId);
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter =>
+            existingCharacter.SpellbookBehavior.LearnedSpellTemplateIds.Remove(spellTemplateId));
     }
 
     /// <summary>
@@ -461,15 +379,8 @@ public static class WizardCollection {
     /// <param name="wizard">The wizard to add the treasure card to.</param>
     /// <param name="spellTemplateId">The template ID of the spell to add as a treasure card.</param>
     public static void AddTreasureCard(Wizard wizard, uint spellTemplateId) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.SpellbookBehavior.AddTreasureCard(spellTemplateId);
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter =>
+            existingCharacter.SpellbookBehavior.AddTreasureCard(spellTemplateId));
     }
 
     /// <summary>
@@ -478,15 +389,8 @@ public static class WizardCollection {
     /// <param name="wizard">The wizard whose spellbook will be modified.</param>
     /// <param name="spellTemplateId">The template ID of the treasure card to remove.</param>
     public static void RemoveTreasureCard(Wizard wizard, uint spellTemplateId) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.SpellbookBehavior.RemoveTreasureCard(spellTemplateId);
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter =>
+            existingCharacter.SpellbookBehavior.RemoveTreasureCard(spellTemplateId));
     }
 
     /// <summary>
@@ -495,17 +399,10 @@ public static class WizardCollection {
     /// <param name="wizard">The wizard to add the relationship to.</param>
     /// <param name="relationship">The relationship to add.</param>
     public static void AddOrUpdateRelationship(Wizard wizard, Relationship relationship) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        existingCharacter.FriendsBehavior ??= new();
-        existingCharacter.FriendsBehavior.AddOrUpdateRelationship(relationship);
-
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter => {
+            existingCharacter.FriendsBehavior ??= new();
+            existingCharacter.FriendsBehavior.AddOrUpdateRelationship(relationship);
+        });
     }
 
     /// <summary>
@@ -514,20 +411,8 @@ public static class WizardCollection {
     /// <param name="wizard">The wizard to remove the relationship from.</param>
     /// <param name="friendId">The ID of the friend to remove.</param>
     public static void RemoveRelationship(Wizard wizard, ulong friendId) {
-        using var session = s_store.OpenSession();
-
-        var existingCharacter = GetCharacterByCharId(session, wizard.CharId);
-        if (existingCharacter is null) {
-            return;
-        }
-
-        if (existingCharacter.FriendsBehavior is null) {
-            return;
-        }
-
-        existingCharacter.FriendsBehavior.Breakup(friendId);
-
-        session.SaveChanges();
+        UpdateCharacter(wizard.CharId, existingCharacter =>
+            existingCharacter.FriendsBehavior?.Breakup(friendId));
     }
 
     /// <summary>
@@ -540,17 +425,8 @@ public static class WizardCollection {
             return false;
         }
 
-        using var session = s_store.OpenSession();
-        var dbWizard = GetCharacterByCharId(session, wizard.CharId);
-
-        if (dbWizard is null) {
-            return false;
-        }
-
-        dbWizard.QuestBehavior = wizard.QuestBehavior;
-        session.SaveChanges();
-
-        return true;
+        return UpdateCharacter(wizard.CharId, dbWizard =>
+            dbWizard.QuestBehavior = wizard.QuestBehavior);
     }
 
     private static Wizard LoadWizard(Wizard wizard) {

--- a/src/Imlight.CoreLib/WizardData/Collections/WizardCollection.cs
+++ b/src/Imlight.CoreLib/WizardData/Collections/WizardCollection.cs
@@ -41,6 +41,12 @@ public static class WizardCollection {
             .Select(_ => new object())
             .ToArray();
 
+    // Tracks the write lane held by the current thread.
+    // Prevents acquiring a different Wizard lane while one is already held.
+    [ThreadStatic]
+    private static int? s_heldWriteLane;
+    internal static bool HoldsWriteLane => s_heldWriteLane.HasValue;
+
     private static readonly TimeSpan s_nonStaleWaitTimeout
         = TimeSpan.FromSeconds(ConfigurationManager.Settings["Database.DatabaseWaitForNonStaleResultsTimeout"].AsByte(5));
 
@@ -48,10 +54,22 @@ public static class WizardCollection {
         => s_store = PlayerDatabase.Instance.Store;
 
     private static T WithWriteLane<T>(ulong charId, Func<T> write) {
-        var writeLane = s_writeLanes[(int)(charId & WriteLaneMask)];
+        var laneIndex = (int) (charId & WriteLaneMask);
+        if (s_heldWriteLane is { } heldLane && heldLane != laneIndex)
+            throw new InvalidOperationException($"Cannot acquire wizard lane {laneIndex} while holding wizard lane {heldLane}.");
+
+        var writeLane = s_writeLanes[laneIndex];
 
         lock (writeLane) {
-            return write();
+            var previousLane = s_heldWriteLane;
+            s_heldWriteLane = laneIndex;
+
+            try {
+                return write();
+            }
+            finally {
+                s_heldWriteLane = previousLane;
+            }
         }
     }
 

--- a/src/Imlight.CoreLib/WizardData/Collections/WizardCollection.cs
+++ b/src/Imlight.CoreLib/WizardData/Collections/WizardCollection.cs
@@ -198,7 +198,7 @@ public static class WizardCollection {
     /// <param name="zoneDisplayName">The display name of the zone.</param>
     public static void UpdateCharacterZone(Wizard character, string zoneName, string zoneDisplayName) {
         UpdateCharacter(character.CharId, existingCharacter => {
-            existingCharacter.PreviousZone = existingCharacter.PreviousZone;
+            existingCharacter.PreviousZone = existingCharacter.Zone;
             existingCharacter.Zone = zoneName;
             existingCharacter.ZoneDisplayName = zoneDisplayName;
         });


### PR DESCRIPTION
Many crashes were occurring if the server was connected to a RavenDB database with optimistic-concurrency enabled due to players receiving multiple updates database updates at the same time (always happened after your first combat with lost souls in Unicorn way). 

These changes make sure that all updates to the same wizard (hash) are serialized and are executed in the correct sequence