### PR TITLE
fix: save location and orientation on character disconnect

### DIFF
--- a/src/Imlight.CoreLib/Game/Services/CombatService.cs
+++ b/src/Imlight.CoreLib/Game/Services/CombatService.cs
@@ -389,7 +389,7 @@ internal class CombatService(SessionActor sessionActor) : MessageService(session
         // hasn't had enough time to set its Wizard reference yet.
         var wizardObj = GetActiveGameObject();
         if (wizardObj is null) {
-            wizardObj = GetActiveWizard().GameObject;
+            wizardObj = GetActiveWizard()?.GetInitializedGameObject();
 
             if (wizardObj is null) {
                 Logger.Error("Failed to get wizard object for adding effects.");

--- a/src/Imlight.CoreLib/Game/Services/EquipmentService.cs
+++ b/src/Imlight.CoreLib/Game/Services/EquipmentService.cs
@@ -312,7 +312,7 @@ internal class EquipmentService(SessionActor sessionActor) : MessageService(sess
         // hasn't had enough time to set its Wizard reference yet.
         var wizardObj = GetActiveGameObject();
         if (wizardObj is null) {
-            wizardObj = GetActiveWizard()?.GameObject;
+            wizardObj = GetActiveWizard()?.GetInitializedGameObject();
 
             if (wizardObj is null) {
                 throw new ServiceRetryException("Failed to get active game object for add effects broadcast.");

--- a/src/Imlight.CoreLib/Game/Services/WizardService.cs
+++ b/src/Imlight.CoreLib/Game/Services/WizardService.cs
@@ -28,7 +28,7 @@
  * the game server session.
  * 
  * NOTE:
- * - Supports wizard location and orientation caching
+ * - Updates wizard location and orientation
  * - Manages level-up mechanics and stat updates
  * - Provides internal wizard state management
  * 
@@ -50,6 +50,8 @@ using Imcodec.MessageLayer.Generated;
 using Imcodec.ObjectProperty.TypeCache;
 using Imcodec.Math;
 using Microsoft.Extensions.ObjectPool;
+using System;
+using Imlight.Common;
 
 namespace Imlight.CoreLib.Game.Services;
 
@@ -63,9 +65,17 @@ internal class WizardService(SessionActor sessionActor) : MessageService(session
     protected static Props Props(SessionActor parentActor)
         => Akka.Actor.Props.Create(() => new WizardService(parentActor));
 
-    protected override void OnDispose() {
-        ((System.IDisposable) _activeWizard)?.Dispose();
-        base.OnDispose();
+    protected override void OnPreDispose() {
+        try {
+            _activeWizard?.SaveLocation();
+        }
+        catch (Exception ex) {
+            Logger.Error("Failed to save wizard location during disconnect: {0}",
+                Logger.Args(ex));
+        }
+        finally {
+            base.OnPreDispose();
+        }
     }
 
     #region Internal Handlers
@@ -211,13 +221,13 @@ internal class WizardService(SessionActor sessionActor) : MessageService(session
             unchecked((short) message.LocationX * 4),
             unchecked((short) message.LocationY * 4),
             unchecked((short) message.LocationZ * 4));
-        _activeWizard.SetCachedLocation(position);
+        _activeWizard.Location = position;
 
         // Direction is a byte and it's packed. Unpack it and convert it to radians.
         var initDir = message.Direction;
         var degrees = initDir * (360f / byte.MaxValue) * ORIENTATION_TOLERANCE;
-        var radians = degrees * (System.Math.PI / 180f);
-        _activeWizard.SetCachedOrientation((byte) radians);
+        var radians = degrees * (System.MathF.PI / 180f);
+        _activeWizard.Orientation = new Vector3(0, 0, radians);
     }
 
     #endregion

--- a/src/Imlight.CoreLib/Game/Services/ZoneService.cs
+++ b/src/Imlight.CoreLib/Game/Services/ZoneService.cs
@@ -92,6 +92,7 @@ internal class ZoneService(SessionActor sessionActor) : MessageService(sessionAc
     protected override void OnPreDispose() {
         var gameObj = GetActiveGameObject();
         if (gameObj is null) {
+            base.OnPreDispose();
             return;
         }
 

--- a/src/Imlight.CoreLib/WizardData/Models/Player/Wizard.cs
+++ b/src/Imlight.CoreLib/WizardData/Models/Player/Wizard.cs
@@ -36,10 +36,17 @@ using Imcodec.Types;
 namespace Imlight.CoreLib.WizardData.Models.Player;
 
 [Serializable]
-public class Wizard : IDisposable {
+public class Wizard {
 
     public ulong AccountId { get; set; }
-    public ulong CharId { get; set; }
+    public ulong CharId {
+        get;
+        set {
+            field = value;
+            GameObject.m_characterId = (GID) value;
+            GameObject.m_globalID = value;
+        }
+    }
     public string Zone { get; set; }
     public string ZoneDisplayName { get; set; }
     public string PreviousZone { get; set; }
@@ -50,25 +57,17 @@ public class Wizard : IDisposable {
     public long TimeHomeLastClicked { get; set; }
     public byte World { get; set; }
     public Vector3 Location {
-        get => GameObject?.m_location ?? _location;
+        get => GameObject.m_location;
         set {
-            if (GameObject is not null) {
-                GameObject.m_location = value;
-            }
-            else {
-                _location = value;
-            }
+            GameObject.m_location = value;
+            _hasLocation = true;
         }
     }
     public Vector3 Orientation {
-        get => GameObject?.m_orientation ?? _orientation;
+        get => GameObject.m_orientation;
         set {
-            if (GameObject is not null) {
-                GameObject.m_orientation = value;
-            }
-            else {
-                _orientation = value;
-            }
+            GameObject.m_orientation = value;
+            _hasOrientation = true;
         }
     }
 
@@ -91,7 +90,25 @@ public class Wizard : IDisposable {
     public ServerQuestBehavior QuestBehavior { get; set; }
 
     [JsonIgnore] public Account Account;
-    [JsonIgnore] public WizClientObject GameObject;
+    // Holds character data before attachment and is replaced by the initialized player object.
+    [JsonIgnore] public WizClientObject GameObject {
+        get;
+        set {
+            ArgumentNullException.ThrowIfNull(value);
+            value.m_characterId = (GID) CharId;
+            value.m_globalID = CharId;
+            if (_hasLocation) {
+                value.m_location = field.m_location;
+            }
+            if (_hasOrientation) {
+                value.m_orientation = field.m_orientation;
+            }
+            field = value;
+            HasInitializedGameObject = true;
+        }
+    } = new();
+    // Set when attachment replaces the offline data object; does not imply zone entry.
+    [JsonIgnore] public bool HasInitializedGameObject { get; private set; }
     [JsonIgnore] public List<GameEffectBase> GameEffects = [];
     [JsonIgnore] public string GameServerIp;
     [JsonIgnore] public ushort GameServerPort;
@@ -107,8 +124,8 @@ public class Wizard : IDisposable {
     /// </summary>
     [JsonIgnore] public readonly Dictionary<ulong, uint> OwnedPets = [];
 
-    [JsonIgnore] private Vector3 _location;
-    [JsonIgnore] private Vector3 _orientation;
+    [JsonIgnore] private bool _hasLocation;
+    [JsonIgnore] private bool _hasOrientation;
     private const string TutorialStartingZone = "WizardCity/Tutorial_Exterior";
 
     // Constructor: Used for deserialization. If this is not present, the default constructor will be used.
@@ -143,11 +160,11 @@ public class Wizard : IDisposable {
         DynamodCollection.AddDynamodSet(DynamodSet);
     }
 
-    public void SetCachedLocation(Vector3 loc)
-        => Location = loc;
+    public WizClientObject GetInitializedGameObject()
+        => HasInitializedGameObject ? GameObject : null;
 
-    public void SetCachedOrientation(float direction)
-        => Orientation = new Vector3(0, 0, direction);
+    public void SaveLocation()
+        => WizardCollection.UpdateCharacterLocation(this, Location, Orientation.Z);
 
     public void SetPersistentLocation(Vector3 loc) {
         Location = loc;
@@ -1509,10 +1526,5 @@ public class Wizard : IDisposable {
         QuestBehavior.CurrentQuestIDs.AddRange(uniqueQuests.Select(q => q.ID));
         WizardCollection.UpdateCharacterQuestBehavior(this);
     }
-
-    public void Dispose() =>
-        // If this object is being disposed, the player probably left the server.
-        // Save the character's location to the database.
-        WizardCollection.UpdateCharacterLocation(this, Location, Orientation.Z);
 
 }


### PR DESCRIPTION
When a player would disconnect, the service would not save the player's last location to the db in time since the GameObject would be destroyed, and the cached location and rotation were stale. This was happening because RavenDB was accessing these properties more than once, including after the GameObject was destroyed.

I removed the IDisposable interface from Wizard's data model as I felt that it didn't really need to be one since it didn't own any resources, it was just using the dispose function as a save location function.

### Changes:
- Keep the cached Location and Orientation values synchronized with the active GameObject.
- When the properties are read while a GameObject exists, refresh the cached value from the live game object so it remains valid after teardown.
- Update both the cache and GameObject when setting location or orientation.
- Save the wizard's final location explicitly from WizardService.OnPreDispose(), before session teardown completes.
- Remove IDisposable from Wizard and replace the implicit persistence side effect with an explicit SaveLocation() method.
- Preserve orientation as a float in radians instead of truncating it to a byte.
- Ensure ZoneService.OnPreDispose() still calls its base implementation when no active game object exists.