### PR TITLE
fix: allow players to enter Unicorn Way through Commons gate

### DIFF
--- a/src/Imlight.CoreLib/Game/Requirements/Handlers/ReqHasQuestHandler.cs
+++ b/src/Imlight.CoreLib/Game/Requirements/Handlers/ReqHasQuestHandler.cs
@@ -27,6 +27,8 @@ namespace Imlight.CoreLib.Game.Requirements.Handlers;
 /// </summary>
 internal sealed class ReqHasQuestHandler : BaseRequirementHandler<ReqHasQuest> {
 
+    private const string QUEST_COMPLETED_ENTRY = "Complete";
+
     public override bool Evaluate(IRequirementContext context) {
         var wizard = context.GetWizard();
         if (wizard == null) {
@@ -38,12 +40,17 @@ internal sealed class ReqHasQuestHandler : BaseRequirementHandler<ReqHasQuest> {
             return false;
         }
 
-        return HasQuestActive(wizard, questName);
+        return HasQuestActiveOrCompleted(wizard, questName);
     }
 
-    private static bool HasQuestActive(Wizard wizard, string questName) {
+    private static bool HasQuestActiveOrCompleted(Wizard wizard, string questName) {
+        // Completion drops the instance from the journal, so a completed quest is only visible
+        // through the entry CompleteQuest stamps. Client data pairs this with a
+        // ReqHasEntry on that same entry, which no player could satisfy if this were
+        // limited to active quests.
         return wizard.QuestBehavior.CurrentQuestInstances
-            .Any(q => q.QuestName == questName);
+            .Any(q => q.QuestName == questName)
+            || wizard.HasQuestRegistryValue(questName, QUEST_COMPLETED_ENTRY);
     }
 
 

--- a/src/Imlight.CoreLib/Game/Zone/Components/RenderComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/RenderComponent.cs
@@ -108,12 +108,17 @@ internal sealed class RenderComponent(ZoneEntity entity) : ZoneEntityComponent(e
             .Where(d => string.IsNullOrEmpty(d.ZoneName) 
                      || d.ZoneName.Equals(Entity.Zone.ZoneData.m_zoneName, System.StringComparison.OrdinalIgnoreCase))
             .ToList() ?? [];
+        string persistedState = null;
         foreach (var mod in relevantDynaMods) {
             // If the player has a dynamod that disables this object, do not spawn it for them.
             if (mod.ModState.Equals(DESPAWN_STATE_NAME, System.StringComparison.OrdinalIgnoreCase)) {
                 _playerIgnoreBecauseDynamod[suspect] = wizard;
 
                 return;
+            }
+
+            if (!mod.ModState.Equals(SPAWN_STATE_NAME, System.StringComparison.OrdinalIgnoreCase)) {
+                persistedState = mod.ModState;
             }
         }
 
@@ -136,6 +141,12 @@ internal sealed class RenderComponent(ZoneEntity entity) : ZoneEntityComponent(e
             // See: "You cannot send MSG_ADDOBJECT in regards to an object if
             // the client has not been told about it with MSG_NEWOBJECT."
             CreateObjectForPlayer(suspect);
+
+            // A dynamod state such as "IdleOpen" is only ever sent as a state change, so a player
+            // arriving in the zone has to be told again or the object reverts to its default.
+            if (persistedState is not null) {
+                Entity.ChangeStateExclusiveSender(persistedState, suspect);
+            }
 
             // Always add the player to the in-range list so the next
             // OnPlayerMove tick can correctly evaluate distance and send
@@ -208,18 +219,22 @@ internal sealed class RenderComponent(ZoneEntity entity) : ZoneEntityComponent(e
 
     [MessageHandler(typeof(ZONE_102_PROTOCOL.MSG_ENTERSTATE))]
     public void ReceiveEnterState(ZONE_102_PROTOCOL.MSG_ENTERSTATE msg) {
-        // In the context of the RenderComponent, we only care if "On" or "Off" is the state.
         var isDespawn = msg.StateName.Equals(DESPAWN_STATE_NAME, System.StringComparison.OrdinalIgnoreCase);
         var isSpawn = msg.StateName.Equals(SPAWN_STATE_NAME, System.StringComparison.OrdinalIgnoreCase);
-        if (!isDespawn && !isSpawn) {
-            return;
-        }
 
-        // If so, despawn the object for the sender if the tag matches.
+        // If the tag matches, spawn or despawn the object for the sender.
         var zoneTag = msg.ObjectName;
         if (Entity.Info is not null && Entity.Info.m_zoneTag.Equals(zoneTag, System.StringComparison.OrdinalIgnoreCase)) {
             var player = msg.Sender;
             if (player is null) {
+                return;
+            }
+
+            // Any other state names an object state such as "IdleOpen". Only the client can act
+            // on it, and it never affects whether the object is spawned.
+            if (!isDespawn && !isSpawn) {
+                Entity.ChangeStateExclusiveSender(msg.StateName, player);
+
                 return;
             }
 


### PR DESCRIPTION
The gate from commons to unicorn way never opens, and when forced open it still doesn't teleport you. If a player is defeated in unicorn way they get sent back to commons and are stuck there for good and same if they just leave Unicorn Way through the gate.

From investigating I can conclude these two has most def been the cause of it.

Dynamod states other than On/Off are stored but never applied. OnPlayerJoin only acts on the despawn case and ReceiveEnterState returns early for anything else so IdleOpen is dropped... The quest sets it fine since when I did dynamod list it shows WC_GateCommons_ToUnicornWay = IdleOpen, it just never reaches the object.

Trigger TelepotToUW requires ReqHasQuest(WC-COMMONS-MAIN-001) AND ReqHasEntry(WC-COMMONS-MAIN-001_Complete). ReqHasQuest only matched active quests, but the _Complete entry is written by CompleteQuest at the same moment the quest leaves the journal. Both halves can never be true at once so that trigger can never fire for anyone resulting in our bug where they can't get back to unicorn way through commons.

Reproduction steps

1. Create a character and accept the first quest from Merle Ambrose which teleports you into
   Unicorn Way
2. Lose a duel against a Lost Soul or just walk back to commons
4. Try to enter unicorn way through the commons. gate is shut and cannot be entered no matter what you do leaving the character stuck for ever