### PR TITLE
fix: bone cage interact prompt not showing up

### DIFF
--- a/src/Imlight.CoreLib/Game/Zone/Components/InteractQuestSelectComponent.cs
+++ b/src/Imlight.CoreLib/Game/Zone/Components/InteractQuestSelectComponent.cs
@@ -18,19 +18,19 @@
  * ========================================================================
  * INTERACT QUEST SELECT COMPONENT
  * ========================================================================
- * 
+ *
  * PURPOSE:
  * Handles a quest goal where the player's goal is to interact with a
  * specific object in the game world.
- * 
+ *
  * USAGE EXAMPLE:
- * 
+ *
  * NOTE:
  * Collection goals (tally count > 1) consume the object on use; single-use goals
  * leave the object in place and drive post-use state via completeResults.
- * 
+ *
  * TODO:
- * 
+ *
  * Created by: Jooty
  * Version: KALI 1.0
  * Last Updated: 08/22/2026
@@ -195,7 +195,14 @@ internal sealed class InteractQuestSelectComponent(ZoneEntity entity)
                && goalProgress.CurrentProgress != int.MaxValue
                && (goalName == null || goalProgress.GoalName == goalName);
 
-    private static bool DoesGoalMatchObject(GameObjectTemplate gameObjectTemplate, GoalTemplate goal)
-        => goal.m_clientTags?.Contains(gameObjectTemplate.m_objectName) == true;
+    private static bool DoesGoalMatchObject(GameObjectTemplate gameObjectTemplate, GoalTemplate goal) {
+        if (goal.m_clientTags?.Contains(gameObjectTemplate.m_objectName) == true) {
+            return true;
+        }
+
+        return goal is ScavengeGoalTemplate scavengeGoal
+            && gameObjectTemplate.m_adjectiveList is not null
+            && scavengeGoal.m_itemAdjectives?.Any(gameObjectTemplate.m_adjectiveList.Contains) == true;
+    }
 
 }


### PR DESCRIPTION
Im slowly going through the game and seeing what works and what doesn't and I got stuck on this bone cage quest while I was testing the dynamod for the gate prior to this fix. After further testing I come to realize that scavenge goals ship an empty m_clientTags and name their object by adjective instead. So, this fixes that very thing and may also fix other scavenge quests down the line just like the gate fix.

Reproduction steps

1. Create new character
2. Follow the quest line till you reached the one to open bone cages
3. Try to interact with it