### PR TITLE
fix: open chat permission bubble not properly showing.

### DIFF
--- a/src/Imlight.CoreLib/Game/WizardObjectLoader.cs
+++ b/src/Imlight.CoreLib/Game/WizardObjectLoader.cs
@@ -114,6 +114,10 @@ public static class WizardObjectLoader {
 
     public static void SetPlayerNameBehavior(WizClientObject clientObject, ref Wizard character) {
         if (CoreObjectFactory.FindBehaviorInstance<ClientWizPlayerNameBehavior>(clientObject, out var nameBehavior)) {
+            if (character.Account is not null) {
+                character.PlayerNameBehavior.ChatPermissions = character.Account.GetChatPermissions();
+            }
+
             var idx = clientObject.m_inactiveBehaviors.IndexOf(nameBehavior);
             clientObject.m_inactiveBehaviors[idx] = character.PlayerNameBehavior.GetClientBehaviorInstance();
         }

--- a/src/Imlight.CoreLib/WizardData/Models/Player/Account.cs
+++ b/src/Imlight.CoreLib/WizardData/Models/Player/Account.cs
@@ -68,6 +68,15 @@ public enum ChatMode {
 
 }
 
+[Flags]
+public enum ChatPermissions {
+
+    None = 0,
+    ChatEnabled = 1 << 0,
+    OpenChatLegacy = 1 << 4
+
+}
+
 [Serializable]
 public class Account {
 
@@ -305,6 +314,15 @@ public class Account {
 
         return flags;
     }
+
+    private const AccountFlags NonChatFlags =
+        AccountFlags.CanHaveCustomNames | AccountFlags.CanReportBugs;
+
+    public uint GetChatPermissions()
+        => ChatMode == ChatMode.Closed && AuthLevel < AuthLevel.HallMonitor
+            ? (uint) ChatPermissions.None
+            : (uint) (GetAccountFlags() & ~NonChatFlags)
+              | (uint) (ChatPermissions.ChatEnabled | ChatPermissions.OpenChatLegacy);
 
     /// <summary>
     /// Retrieves the highest level wizard on the account.


### PR DESCRIPTION
Players with open chat show the no open chat icon over their head and their messages never
reach anyone else. Both directions of chat are broken for every account.
ServerWizPlayerNameBehavior.ChatPermissions is set to 0 when a character is created and is
never updated. This fix targets that issue.

Here is a visual on the fix

<img width="1506" height="438" alt="{1F9B0EC4-A902-4BFB-8F19-6A29DAFEEDBC}" src="https://github.com/user-attachments/assets/3eb0749c-5ead-4b6f-b587-6be199b24e68" />
