### PR TITLE
ci: add Dependabot to check for submodule updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Adds Dependabot configuration to automatically detect updates (to the Imcodec submodule) and open a pull request when a new commit is available.

(Perhaps you need to enable Dependabot in `Insights` $\to$ `Dependency graph` $\to$ `Dependabot` as well)